### PR TITLE
Feature | Basic Settings Skeleton

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmApp.kt
@@ -1,9 +1,25 @@
 package com.example.alarmscratch.ui.alarmlist.composable
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.alarmscratch.ui.navigation.Destination
 import com.example.alarmscratch.ui.navigation.NavigableScreen
+import com.example.alarmscratch.ui.settings.AlarmDefaultsScreen
 
 @Composable
 fun AlarmApp() {
-    NavigableScreen()
+    val navHostController = rememberNavController()
+    NavHost(
+        navController = navHostController,
+        startDestination = Destination.NavigableScreen.route
+    ) {
+        composable(route = Destination.NavigableScreen.route) {
+            NavigableScreen(rootNavHostController = navHostController)
+        }
+        composable(route = Destination.AlarmDefaultSettings.route) {
+            AlarmDefaultsScreen()
+        }
+    }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmCard.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmCard.kt
@@ -62,9 +62,7 @@ fun AlarmCard(
     val cardColor = if (alarm.enabled) MaterialTheme.colorScheme.surfaceVariant else MediumVolcanicRock
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 10.dp),
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = cardColor,
             contentColor = cardTextAndIconColor
@@ -188,9 +186,7 @@ fun AlarmCard(
 @Composable
 fun NoAlarmsCard(modifier: Modifier = Modifier) {
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 10.dp),
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
             contentColor = BoatSails
@@ -234,7 +230,20 @@ private fun AlarmCardRepeatingPreview() {
             alarm = repeatingAlarm,
             onAlarmToggled = {},
             onAlarmDeleted = {},
-            modifier = Modifier.padding(5.dp)
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF0066CC
+)
+@Composable
+private fun NoAlarmsCardPreview() {
+    AlarmScratchTheme {
+        NoAlarmsCard(
+            modifier = Modifier.padding(20.dp)
         )
     }
 }
@@ -250,7 +259,7 @@ private fun AlarmCardTodayPreview() {
             alarm = todayAlarm,
             onAlarmToggled = {},
             onAlarmDeleted = {},
-            modifier = Modifier.padding(5.dp)
+            modifier = Modifier.padding(20.dp)
         )
     }
 }
@@ -266,7 +275,7 @@ private fun AlarmCardTomorrowPreview() {
             alarm = tomorrowAlarm,
             onAlarmToggled = {},
             onAlarmDeleted = {},
-            modifier = Modifier.padding(5.dp)
+            modifier = Modifier.padding(20.dp)
         )
     }
 }
@@ -282,18 +291,7 @@ private fun AlarmCardCalendarPreview() {
             alarm = calendarAlarm,
             onAlarmToggled = {},
             onAlarmDeleted = {},
-            modifier = Modifier.padding(5.dp)
+            modifier = Modifier.padding(20.dp)
         )
-    }
-}
-
-@Preview(
-    showBackground = true,
-    backgroundColor = 0xFF0066CC
-)
-@Composable
-private fun NoAlarmsCardPreview() {
-    AlarmScratchTheme {
-        NoAlarmsCard(modifier = Modifier.padding(5.dp))
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/AlarmListScreen.kt
@@ -1,6 +1,7 @@
 package com.example.alarmscratch.ui.alarmlist.composable
 
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -9,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.alarmscratch.data.model.Alarm
 import com.example.alarmscratch.data.repository.AlarmListState
@@ -19,9 +21,13 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmListScreen(
+    modifier: Modifier = Modifier,
     alarmListViewModel: AlarmListViewModel = viewModel(factory = AlarmListViewModel.Factory)
 ) {
+    // State
     val alarmListState by alarmListViewModel.alarmList.collectAsState()
+
+    // Actions
     val coroutineScope = rememberCoroutineScope()
     val onAlarmToggled: (Alarm) -> Unit = { alarm ->
         coroutineScope.launch { alarmListViewModel.updateAlarm(alarm) }
@@ -35,7 +41,7 @@ fun AlarmListScreen(
         alarmListState = alarmListState,
         onAlarmToggled = onAlarmToggled,
         onAlarmDeleted = onAlarmDeleted,
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier
     )
 }
 
@@ -48,6 +54,7 @@ fun AlarmListScreenContent(
 ) {
     // Alarm List
     LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(20.dp),
         modifier = modifier
     ) {
         when (alarmListState) {
@@ -92,7 +99,8 @@ private fun AlarmListScreenPreview() {
         AlarmListScreenContent(
             alarmListState = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds),
             onAlarmToggled = {},
-            onAlarmDeleted = {}
+            onAlarmDeleted = {},
+            modifier = Modifier.padding(20.dp)
         )
     }
 }
@@ -107,7 +115,8 @@ private fun AlarmListScreenNoAlarmsPreview() {
         AlarmListScreenContent(
             alarmListState = AlarmListState.Success(emptyList()),
             onAlarmToggled = {},
-            onAlarmDeleted = {}
+            onAlarmDeleted = {},
+            modifier = Modifier.padding(20.dp)
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/SkylineHeader.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/alarmlist/composable/SkylineHeader.kt
@@ -104,6 +104,7 @@ fun SkylineHeader(
                     modifier = Modifier.align(Alignment.Center)
                 ) {
                     if (currentScreen == Destination.AlarmList && alarmListState is AlarmListState.Success) {
+                        // TODO: Change Icon to Icons.Default.AlarmOff if there's no Active Alarms
                         // Alarm Icon
                         Icon(
                             imageVector = Icons.Default.Alarm,

--- a/app/src/main/java/com/example/alarmscratch/ui/navigation/AlarmNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/navigation/AlarmNavHost.kt
@@ -6,19 +6,28 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.alarmscratch.ui.alarmlist.composable.AlarmListScreen
+import com.example.alarmscratch.ui.settings.SettingsScreen
 
 @Composable
 fun AlarmNavHost(
-    navController: NavHostController,
+    navHostController: NavHostController,
     modifier: Modifier = Modifier
 ) {
     NavHost(
-        navController = navController,
+        navController = navHostController,
         startDestination = Destination.AlarmList.route,
         modifier = modifier
     ) {
         composable(route = Destination.AlarmList.route) {
             AlarmListScreen()
         }
+        composable(route = Destination.Settings.route) {
+            SettingsScreen()
+        }
     }
 }
+
+fun NavHostController.navigateSingleTop(route: String) =
+    navigate(route) {
+        launchSingleTop = true
+    }

--- a/app/src/main/java/com/example/alarmscratch/ui/navigation/AlarmNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/navigation/AlarmNavHost.kt
@@ -10,11 +10,12 @@ import com.example.alarmscratch.ui.settings.SettingsScreen
 
 @Composable
 fun AlarmNavHost(
-    navHostController: NavHostController,
+    localNavHostController: NavHostController,
+    rootNavHostController: NavHostController,
     modifier: Modifier = Modifier
 ) {
     NavHost(
-        navController = navHostController,
+        navController = localNavHostController,
         startDestination = Destination.AlarmList.route,
         modifier = modifier
     ) {
@@ -22,7 +23,7 @@ fun AlarmNavHost(
             AlarmListScreen()
         }
         composable(route = Destination.Settings.route) {
-            SettingsScreen()
+            SettingsScreen(navHostController = rootNavHostController)
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/navigation/Destination.kt
@@ -10,6 +10,11 @@ sealed class Destination(
     val route: String,
     val navComponent: AlarmNavComponent?
 ) {
+    object NavigableScreen : Destination(
+        route = "navigable_screen",
+        navComponent = null
+    )
+
     object AlarmList : Destination(
         route = "alarm_list",
         navComponent = AlarmNavComponent(
@@ -51,6 +56,7 @@ sealed class Destination(
             AlarmCreation
         )
 
+        // TODO: Might remove this. Doesn't seem needed anymore, but not removing yet.
         val Saver = run {
             val routeKey = "route"
             mapSaver(

--- a/app/src/main/java/com/example/alarmscratch/ui/navigation/NavigableScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/navigation/NavigableScreen.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun NavigableScreen(
+    rootNavHostController: NavHostController,
     navigableScreenViewModel: NavigableScreenViewModel = viewModel(factory = NavigableScreenViewModel.Factory)
 ) {
     // State
@@ -50,17 +51,18 @@ fun NavigableScreen(
     }
 
     // Navigation
-    val navHostController = rememberNavController()
+    val localNavHostController = rememberNavController()
 
     // Navigable Screen wrapping an Internal Screen
     NavigableScreenContent(
-        navHostController = navHostController,
+        localNavHostController = localNavHostController,
         alarmListState = alarmListState,
         onFabClicked = tempOnFabClicked
     ) {
         // Nested Internal Screen
         AlarmNavHost(
-            navHostController = navHostController,
+            localNavHostController = localNavHostController,
+            rootNavHostController = rootNavHostController,
             modifier = Modifier.padding(20.dp)
         )
     }
@@ -68,13 +70,13 @@ fun NavigableScreen(
 
 @Composable
 fun NavigableScreenContent(
-    navHostController: NavHostController,
+    localNavHostController: NavHostController,
     alarmListState: AlarmListState,
     onFabClicked: (Alarm) -> Unit,
     internalScreen: @Composable () -> Unit
 ) {
     // Navigation
-    val currentBackStackEntry by navHostController.currentBackStackEntryAsState()
+    val currentBackStackEntry by localNavHostController.currentBackStackEntryAsState()
     val selectedDestination = Destination.ALL_DESTINATIONS.find { destination ->
         destination.route == currentBackStackEntry?.destination?.route
     } ?: Destination.AlarmList
@@ -118,7 +120,7 @@ fun NavigableScreenContent(
             // Navigation Bar
             VolcanoNavigationBar(
                 selectedDestination = selectedDestination.route,
-                onDestinationChange = { navHostController.navigateSingleTop(it.route) },
+                onDestinationChange = { localNavHostController.navigateSingleTop(it.route) },
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -132,7 +134,7 @@ private fun NavigableScreenAlarmListPreview() {
         val alarmList = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds)
 
         NavigableScreenContent(
-            navHostController = rememberNavController(),
+            localNavHostController = rememberNavController(),
             alarmListState = alarmList,
             onFabClicked = {}
         ) {
@@ -153,7 +155,7 @@ private fun NavigableScreenAlarmListNoAlarmsPreview() {
         val alarmList = AlarmListState.Success(alarmList = emptyList())
 
         NavigableScreenContent(
-            navHostController = rememberNavController(),
+            localNavHostController = rememberNavController(),
             alarmListState = alarmList,
             onFabClicked = {}
         ) {
@@ -171,12 +173,17 @@ private fun NavigableScreenAlarmListNoAlarmsPreview() {
 @Composable
 private fun NavigableScreenSettingsPreview() {
     AlarmScratchTheme {
+        val navHostController = rememberNavController()
+
         NavigableScreenContent(
-            navHostController = rememberNavController(),
+            localNavHostController = navHostController,
             alarmListState = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds),
             onFabClicked = {}
         ) {
-            SettingsScreen(modifier = Modifier.padding(20.dp))
+            SettingsScreen(
+                navHostController = navHostController,
+                modifier = Modifier.padding(20.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/navigation/NavigableScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/navigation/NavigableScreen.kt
@@ -11,10 +11,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -22,7 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.data.model.Alarm
@@ -32,6 +29,7 @@ import com.example.alarmscratch.ui.alarmlist.composable.LavaFloatingActionButton
 import com.example.alarmscratch.ui.alarmlist.composable.SkylineHeader
 import com.example.alarmscratch.ui.alarmlist.composable.VolcanoNavigationBar
 import com.example.alarmscratch.ui.alarmlist.preview.alarmSampleDataHardCodedIds
+import com.example.alarmscratch.ui.settings.SettingsScreen
 import com.example.alarmscratch.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.ui.theme.BottomOceanBlue
 import com.example.alarmscratch.ui.theme.TopOceanBlue
@@ -41,8 +39,10 @@ import kotlinx.coroutines.launch
 fun NavigableScreen(
     navigableScreenViewModel: NavigableScreenViewModel = viewModel(factory = NavigableScreenViewModel.Factory)
 ) {
-    // Alarms
+    // State
     val alarmListState by navigableScreenViewModel.alarmList.collectAsState()
+
+    // Actions
     val coroutineScope = rememberCoroutineScope()
     // TODO: Temp inserting alarm here for now just for quick testing before the actual alarm creation screen is implemented
     val tempOnFabClicked: (Alarm) -> Unit = { alarm ->
@@ -50,38 +50,34 @@ fun NavigableScreen(
     }
 
     // Navigation
-    val navController = rememberNavController()
+    val navHostController = rememberNavController()
 
     // Navigable Screen wrapping an Internal Screen
     NavigableScreenContent(
-        navController = navController,
+        navHostController = navHostController,
         alarmListState = alarmListState,
         onFabClicked = tempOnFabClicked
     ) {
         // Nested Internal Screen
         AlarmNavHost(
-            navController = navController,
-            modifier = Modifier.fillMaxSize()
+            navHostController = navHostController,
+            modifier = Modifier.padding(20.dp)
         )
     }
 }
 
 @Composable
 fun NavigableScreenContent(
-    navController: NavController,
+    navHostController: NavHostController,
     alarmListState: AlarmListState,
     onFabClicked: (Alarm) -> Unit,
     internalScreen: @Composable () -> Unit
 ) {
     // Navigation
-    val currentBackStackEntry by navController.currentBackStackEntryAsState()
-    var selectedDestination by rememberSaveable(stateSaver = Destination.Saver) {
-        mutableStateOf(
-            value = Destination.ALL_DESTINATIONS.find { destination ->
-                destination.route == currentBackStackEntry?.destination?.route
-            } ?: Destination.AlarmList
-        )
-    }
+    val currentBackStackEntry by navHostController.currentBackStackEntryAsState()
+    val selectedDestination = Destination.ALL_DESTINATIONS.find { destination ->
+        destination.route == currentBackStackEntry?.destination?.route
+    } ?: Destination.AlarmList
 
     Surface(
         color = Color.Transparent,
@@ -108,11 +104,7 @@ fun NavigableScreenContent(
             )
 
             // Internal Screen
-            Box(
-                modifier = Modifier
-                    .padding(top = 20.dp)
-                    .weight(1f)
-            ) {
+            Box(modifier = Modifier.weight(1f)) {
                 // Extracted this for Previews since they don't work with ViewModels
                 internalScreen()
             }
@@ -126,29 +118,65 @@ fun NavigableScreenContent(
             // Navigation Bar
             VolcanoNavigationBar(
                 selectedDestination = selectedDestination.route,
-                onDestinationChange = { newDestination: Destination -> selectedDestination = newDestination },
+                onDestinationChange = { navHostController.navigateSingleTop(it.route) },
                 modifier = Modifier.fillMaxWidth()
             )
         }
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 private fun NavigableScreenAlarmListPreview() {
     AlarmScratchTheme {
         val alarmList = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds)
 
         NavigableScreenContent(
-            navController = rememberNavController(),
+            navHostController = rememberNavController(),
             alarmListState = alarmList,
             onFabClicked = {}
         ) {
             AlarmListScreenContent(
                 alarmListState = alarmList,
                 onAlarmToggled = {},
-                onAlarmDeleted = {}
+                onAlarmDeleted = {},
+                modifier = Modifier.padding(20.dp)
             )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NavigableScreenAlarmListNoAlarmsPreview() {
+    AlarmScratchTheme {
+        val alarmList = AlarmListState.Success(alarmList = emptyList())
+
+        NavigableScreenContent(
+            navHostController = rememberNavController(),
+            alarmListState = alarmList,
+            onFabClicked = {}
+        ) {
+            AlarmListScreenContent(
+                alarmListState = alarmList,
+                onAlarmToggled = {},
+                onAlarmDeleted = {},
+                modifier = Modifier.padding(20.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NavigableScreenSettingsPreview() {
+    AlarmScratchTheme {
+        NavigableScreenContent(
+            navHostController = rememberNavController(),
+            alarmListState = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds),
+            onFabClicked = {}
+        ) {
+            SettingsScreen(modifier = Modifier.padding(20.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/ui/settings/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/settings/AlarmDefaultsScreen.kt
@@ -1,0 +1,40 @@
+package com.example.alarmscratch.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Anchor
+import androidx.compose.material.icons.filled.SportsMartialArts
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.alarmscratch.R
+import com.example.alarmscratch.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.ui.theme.MediumVolcanicRock
+
+@Composable
+fun AlarmDefaultsScreen(modifier: Modifier = Modifier) {
+    // TODO: Temporary code
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column {
+            Text(text = "Alarm Defaults", fontSize = 38.sp, modifier = Modifier.padding(start = 15.dp, top = 15.dp))
+            SettingsComponent(icon = Icons.Default.SportsMartialArts, nameRes = R.string.settings_general, onClick = {})
+            HorizontalDivider(thickness = 2.dp, color = MediumVolcanicRock, modifier = Modifier.padding(horizontal = 15.dp))
+            SettingsComponent(icon = Icons.Default.Anchor, nameRes = R.string.settings_alarm_defaults, onClick = {})
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AlarmDefaultScreenPreview() {
+    AlarmScratchTheme {
+        AlarmDefaultsScreen()
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/settings/SettingsScreen.kt
@@ -1,0 +1,113 @@
+package com.example.alarmscratch.ui.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Alarm
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.alarmscratch.R
+import com.example.alarmscratch.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.ui.theme.MediumVolcanicRock
+
+@Composable
+fun SettingsScreen(
+    modifier: Modifier = Modifier
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        modifier = modifier
+    ) {
+        LazyColumn {
+            item {
+                SettingsComponent(icon = Icons.Default.Settings, nameRes = R.string.settings_general)
+            }
+            item {
+                HorizontalDivider(
+                    thickness = 2.dp,
+                    color = MediumVolcanicRock,
+                    modifier = Modifier.padding(horizontal = 15.dp)
+                )
+            }
+            item {
+                SettingsComponent(icon = Icons.Default.Alarm, nameRes = R.string.settings_alarm_defaults)
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsComponent(
+    icon: ImageVector,
+    @StringRes
+    nameRes: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { }
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(start = 15.dp, top = 35.dp, bottom = 35.dp)
+        ) {
+            Icon(imageVector = icon, contentDescription = null)
+            Text(
+                text = stringResource(id = nameRes),
+                fontSize = 24.sp,
+                modifier = Modifier.padding(start = 15.dp)
+            )
+        }
+        Icon(
+            imageVector = Icons.Default.ChevronRight,
+            contentDescription = null,
+            modifier = Modifier.padding(end = 15.dp)
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF0066CC
+)
+@Composable
+private fun SettingsScreenPreview() {
+    AlarmScratchTheme {
+        SettingsScreen(modifier = Modifier.padding(10.dp))
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF373736
+)
+@Composable
+private fun SettingsComponentPreview() {
+    AlarmScratchTheme {
+        SettingsComponent(icon = Icons.Default.Alarm, nameRes = R.string.settings_alarm_defaults)
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/ui/settings/SettingsScreen.kt
@@ -25,12 +25,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.R
+import com.example.alarmscratch.ui.navigation.Destination
+import com.example.alarmscratch.ui.navigation.navigateSingleTop
 import com.example.alarmscratch.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.ui.theme.MediumVolcanicRock
 
 @Composable
 fun SettingsScreen(
+    navHostController: NavHostController,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -41,7 +46,7 @@ fun SettingsScreen(
     ) {
         LazyColumn {
             item {
-                SettingsComponent(icon = Icons.Default.Settings, nameRes = R.string.settings_general)
+                SettingsComponent(icon = Icons.Default.Settings, nameRes = R.string.settings_general, onClick = {})
             }
             item {
                 HorizontalDivider(
@@ -51,7 +56,11 @@ fun SettingsScreen(
                 )
             }
             item {
-                SettingsComponent(icon = Icons.Default.Alarm, nameRes = R.string.settings_alarm_defaults)
+                SettingsComponent(
+                    icon = Icons.Default.Alarm,
+                    nameRes = R.string.settings_alarm_defaults,
+                    onClick = { navHostController.navigateSingleTop(route = Destination.AlarmDefaultSettings.route) }
+                )
             }
         }
     }
@@ -62,6 +71,7 @@ fun SettingsComponent(
     icon: ImageVector,
     @StringRes
     nameRes: Int,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -69,7 +79,7 @@ fun SettingsComponent(
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = modifier
             .fillMaxWidth()
-            .clickable { }
+            .clickable { onClick() }
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -90,6 +100,10 @@ fun SettingsComponent(
     }
 }
 
+/*
+ * Previews
+ */
+
 @Preview(
     showBackground = true,
     backgroundColor = 0xFF0066CC
@@ -97,7 +111,10 @@ fun SettingsComponent(
 @Composable
 private fun SettingsScreenPreview() {
     AlarmScratchTheme {
-        SettingsScreen(modifier = Modifier.padding(10.dp))
+        SettingsScreen(
+            navHostController = rememberNavController(),
+            modifier = Modifier.padding(20.dp)
+        )
     }
 }
 
@@ -108,6 +125,6 @@ private fun SettingsScreenPreview() {
 @Composable
 private fun SettingsComponentPreview() {
     AlarmScratchTheme {
-        SettingsComponent(icon = Icons.Default.Alarm, nameRes = R.string.settings_alarm_defaults)
+        SettingsComponent(icon = Icons.Default.Alarm, nameRes = R.string.settings_alarm_defaults, onClick = {})
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,28 +1,42 @@
 <resources>
-    <string name="app_name">AlarmScratch</string>
-
     <!-- General -->
+    <string name="app_name">AlarmScratch</string>
     <string name="error">Error</string>
 
-    <!-- Navigation -->
-    <string name="nav_alarm">Alarm</string>
-    <string name="nav_settings">Settings</string>
-
+    <!--
+        *********************
+        ** NavigableScreen **
+        *********************
+    -->
     <!-- SkylineHeader -->
     <string name="day_abbreviation">d</string>
     <string name="hour_abbreviation">h</string>
     <string name="minute_abbreviation">m</string>
     <string name="no_active_alarms">No Active Alarms</string>
+    <!-- VolcanoNavigationBar -->
+    <string name="nav_alarm">Alarm</string>
+    <string name="nav_settings">Settings</string>
 
+    <!--
+        *********************
+        ** AlarmListScreen **
+        *********************
+    -->
     <!-- AlarmCard -->
     <string name="date_today">Today</string>
     <string name="date_tomorrow">Tomorrow</string>
     <string name="time_am">AM</string>
     <string name="time_pm">PM</string>
-
     <!-- AlarmCardMenu -->
     <string name="menu_delete">Delete</string>
-
     <!-- NoAlarmsCard -->
     <string name="no_alarms">No Alarms</string>
+
+    <!--
+        ********************
+        ** SettingsScreen **
+        ********************
+    -->
+    <string name="settings_general">General Settings</string>
+    <string name="settings_alarm_defaults">Alarm Defaults</string>
 </resources>


### PR DESCRIPTION
### Description
- Add placeholder Settings Screen
- Add placeholder Alarm Defaults screen, which is a child of Settings Screen
- Add higher level navigation that allows child screens (Alarm Defaults, future Alarm Creation) to be displayed full screen, without the Skyline Header and Volcano Navigation Bar
- Remove old padding from individual Alarm Cards and replace with proper padding in the Alarm List's LazyColumn
- Tweak modifiers related to the size/padding of NavigableScreen's "internal screen"