### PR TITLE
Feature | Prelim Alarm Execution Code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.alarmscratch"
-        minSdk = 26
+        minSdk = 27
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Required for setting exact alarms -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <!-- Required for setting alarms on device boot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -23,6 +28,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Receive alarm execution events -->
+        <receiver android:name=".alarm.alarmexecution.AlarmReceiver" />
+        <!-- Reschedule alarms on device boot -->
+        <receiver
+            android:name=".alarm.alarmexecution.BootCompletedReceiver"
+            android:directBootAware="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,10 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- Required for setting alarms on device boot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".core.AlarmApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <!-- Required for setting alarms on device boot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Used to show an Alarm when it goes off while the User's screen is off -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".core.AlarmApplication"
@@ -19,6 +22,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AlarmScratch"
         tools:targetApi="31">
+        <!-- Main Activity. Lands on the Alarm List Screen. -->
         <activity
             android:name=".core.ui.MainActivity"
             android:exported="true"
@@ -30,6 +34,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Used to show an Alarm when it goes off while the User's screen is off -->
+        <activity
+            android:name=".alarm.ui.fullscreenalert.FullScreenAlarmActivity"
+            android:directBootAware="true"
+            android:showOnLockScreen="true"
+            android:showWhenLocked="true" />
         <!-- Receive alarm execution events -->
         <receiver android:name=".alarm.alarmexecution.AlarmReceiver" />
         <!-- Reschedule alarms on device boot -->

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
@@ -1,0 +1,17 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class AlarmReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val EXTRA_TEST_MESSAGE = "EXTRA_TEST_MESSAGE"
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val message = intent?.getStringExtra(EXTRA_TEST_MESSAGE) ?: return
+        println(message)
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
@@ -3,6 +3,8 @@ package com.example.alarmscratch.alarm.alarmexecution
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.view.Display
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.ui.notification.AlarmNotificationService
 
@@ -15,10 +17,26 @@ class AlarmReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
-            val alarmName = intent.getStringExtra(EXTRA_ALARM_NAME) ?: context.getString(R.string.default_alarm_name)
-            val alarmTime = intent.getStringExtra(EXTRA_ALARM_TIME) ?: ""
             val service = AlarmNotificationService(context)
-            service.showNotification(alarmName, alarmTime)
+            val alarmName = intent.getStringExtra(EXTRA_ALARM_NAME) ?: context.getString(R.string.default_alarm_name)
+            val alarmTime = intent.getStringExtra(EXTRA_ALARM_TIME) ?: context.getString(R.string.default_alarm_time)
+
+            // TODO: Check for lock status here. If screen is on, but it's locked, we want to show the full screen notification.
+            if (isDisplayOn(context)) {
+                service.showNotification(alarmName, alarmTime)
+            } else {
+                service.showFullScreenNotification(alarmName, alarmTime)
+            }
         }
+    }
+
+    private fun isDisplayOn(context: Context): Boolean {
+        val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        displayManager.displays.forEach {
+            if (it.state == Display.STATE_ON) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmReceiver.kt
@@ -3,15 +3,22 @@ package com.example.alarmscratch.alarm.alarmexecution
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.ui.notification.AlarmNotificationService
 
 class AlarmReceiver : BroadcastReceiver() {
 
     companion object {
-        const val EXTRA_TEST_MESSAGE = "EXTRA_TEST_MESSAGE"
+        const val EXTRA_ALARM_NAME = "EXTRA_ALARM_NAME"
+        const val EXTRA_ALARM_TIME = "EXTRA_ALARM_TIME"
     }
 
     override fun onReceive(context: Context?, intent: Intent?) {
-        val message = intent?.getStringExtra(EXTRA_TEST_MESSAGE) ?: return
-        println(message)
+        if (context != null && intent != null) {
+            val alarmName = intent.getStringExtra(EXTRA_ALARM_NAME) ?: context.getString(R.string.default_alarm_name)
+            val alarmTime = intent.getStringExtra(EXTRA_ALARM_TIME) ?: ""
+            val service = AlarmNotificationService(context)
+            service.showNotification(alarmName, alarmTime)
+        }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
@@ -1,0 +1,8 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import com.example.alarmscratch.alarm.data.model.Alarm
+
+interface AlarmScheduler {
+    fun scheduleAlarm(alarm: Alarm)
+    fun cancelAlarm(alarm: Alarm)
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import com.example.alarmscratch.alarm.data.model.Alarm
+import com.example.alarmscratch.core.extension.toNotificationDateTimeString
 import java.time.ZoneId
 
 class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
@@ -12,17 +13,13 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
     private val alarmManager = context.getSystemService(AlarmManager::class.java)
 
     override fun scheduleAlarm(alarm: Alarm) {
-        val intent = Intent(context, AlarmReceiver::class.java).apply {
-            putExtra(AlarmReceiver.EXTRA_TEST_MESSAGE, "${alarm.name} alarm executed")
-        }
-
         alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.RTC_WAKEUP,
             alarm.dateTime.atZone(ZoneId.systemDefault()).toEpochSecond() * 1000,
             PendingIntent.getBroadcast(
                 context,
                 alarm.id,
-                intent,
+                buildAlarmIntent(alarm),
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         )
@@ -38,4 +35,10 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
             )
         )
     }
+
+    private fun buildAlarmIntent(alarm: Alarm): Intent =
+        Intent(context, AlarmReceiver::class.java).apply {
+            putExtra(AlarmReceiver.EXTRA_ALARM_NAME, alarm.name)
+            putExtra(AlarmReceiver.EXTRA_ALARM_TIME, alarm.dateTime.toNotificationDateTimeString(context))
+        }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
@@ -1,0 +1,41 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.example.alarmscratch.alarm.data.model.Alarm
+import java.time.ZoneId
+
+class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
+
+    private val alarmManager = context.getSystemService(AlarmManager::class.java)
+
+    override fun scheduleAlarm(alarm: Alarm) {
+        val intent = Intent(context, AlarmReceiver::class.java).apply {
+            putExtra(AlarmReceiver.EXTRA_TEST_MESSAGE, "${alarm.name} alarm executed")
+        }
+
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            alarm.dateTime.atZone(ZoneId.systemDefault()).toEpochSecond() * 1000,
+            PendingIntent.getBroadcast(
+                context,
+                alarm.id,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+    }
+
+    override fun cancelAlarm(alarm: Alarm) {
+        alarmManager.cancel(
+            PendingIntent.getBroadcast(
+                context,
+                alarm.id,
+                Intent(context, AlarmReceiver::class.java),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -1,0 +1,32 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
+import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class BootCompletedReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context != null && intent?.action == Intent.ACTION_LOCKED_BOOT_COMPLETED) {
+            val alarmScheduler = AlarmSchedulerImpl(context)
+            val alarmRepo = AlarmRepository(
+                AlarmDatabase
+                    .getDatabase(context.createDeviceProtectedStorageContext())
+                    .alarmDao()
+            )
+
+            CoroutineScope(Dispatchers.IO).launch {
+                alarmRepo.getAllAlarmsFlow().collect { alarmList ->
+                    alarmList.forEach { alarm ->
+                        alarmScheduler.scheduleAlarm(alarm)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmDatabase.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmDatabase.kt
@@ -25,7 +25,11 @@ abstract class AlarmDatabase : RoomDatabase() {
 
         fun getDatabase(context: Context): AlarmDatabase =
             Instance ?: synchronized(this) {
-                Room.databaseBuilder(context, AlarmDatabase::class.java, "alarm_database")
+                Room.databaseBuilder(
+                    context.createDeviceProtectedStorageContext(),
+                    AlarmDatabase::class.java,
+                    "alarm_database"
+                )
                     // TODO: Remove destructive fallback. Just doing this for now.
                     .fallbackToDestructiveMigration()
                     .build()

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -33,6 +33,7 @@ fun AlarmCreationScreen(
         titleRes = R.string.alarm_creation_screen_title,
         alarm = alarmState,
         saveAlarm = { coroutineScope.launch { alarmCreationViewModel.saveAlarm() } },
+        scheduleAlarm = alarmCreationViewModel::scheduleAlarm,
         updateName = alarmCreationViewModel::updateName,
         updateDate = alarmCreationViewModel::updateDate,
         updateTime = alarmCreationViewModel::updateTime,
@@ -58,6 +59,7 @@ private fun AlarmCreationScreenPreview() {
                 weeklyRepeater = WeeklyRepeater(tueWedThu)
             ),
             saveAlarm = {},
+            scheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -1,8 +1,10 @@
 package com.example.alarmscratch.alarm.ui.alarmcreate
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.example.alarmscratch.alarm.alarmexecution.AlarmSchedulerImpl
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
@@ -42,6 +44,11 @@ class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : Vie
         } else {
             alarmRepository.insertAlarm(_newAlarm.value)
         }
+    }
+
+    fun scheduleAlarm(context: Context) {
+        val alarmScheduler = AlarmSchedulerImpl(context)
+        alarmScheduler.scheduleAlarm(_newAlarm.value)
     }
 
     fun updateName(name: String) {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -47,9 +47,9 @@ import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.AlarmDays
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.DateSelectionDialog
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.TimeSelectionDialog
-import com.example.alarmscratch.alarm.ui.alarmlist.component.amPm
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.get12HrTime
+import com.example.alarmscratch.core.extension.getAmPm
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
 import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
@@ -57,6 +57,7 @@ import com.example.alarmscratch.core.ui.theme.DarkerBoatSails
 import com.example.alarmscratch.core.ui.theme.LightVolcanicRock
 import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Composable
 fun AlarmCreateEditScreen(
@@ -170,7 +171,7 @@ fun DateTimeSettings(
     Column {
         // Time
         AlarmTime(
-            alarm = alarm,
+            dateTime = alarm.dateTime,
             updateTime = updateTime,
             modifier = Modifier.padding(0.dp)
         )
@@ -209,7 +210,7 @@ fun DateTimeSettings(
 
 @Composable
 fun AlarmTime(
-    alarm: Alarm,
+    dateTime: LocalDateTime,
     updateTime: (Int, Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -225,7 +226,7 @@ fun AlarmTime(
     ) {
         // Time
         Text(
-            text = alarm.get12HrTime(),
+            text = dateTime.get12HrTime(),
             color = DarkerBoatSails,
             fontSize = 64.sp,
             fontWeight = FontWeight.Bold,
@@ -234,7 +235,7 @@ fun AlarmTime(
 
         // AM/PM
         Text(
-            text = amPm(alarm = alarm),
+            text = dateTime.getAmPm(LocalContext.current),
             color = DarkerBoatSails,
             fontSize = 38.sp,
             fontWeight = FontWeight.SemiBold,
@@ -245,8 +246,8 @@ fun AlarmTime(
     // Time Selection Dialog
     if (showTimePickerDialog) {
         TimeSelectionDialog(
-            initialHour = alarm.dateTime.hour,
-            initialMinute = alarm.dateTime.minute,
+            initialHour = dateTime.hour,
+            initialMinute = dateTime.minute,
             onCancel = toggleTimePickerDialog,
             onConfirm = { hour, minute ->
                 updateTime(hour, minute)
@@ -364,6 +365,6 @@ private fun DateTimeSettingsPreview() {
 @Composable
 private fun AlarmTimePreview() {
     AlarmScratchTheme {
-        AlarmTime(alarm = consistentFutureAlarm, updateTime = { _, _ -> })
+        AlarmTime(dateTime = consistentFutureAlarm.dateTime, updateTime = { _, _ -> })
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.alarm.ui.alarmcreateedit
 
+import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -30,6 +31,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,6 +64,7 @@ fun AlarmCreateEditScreen(
     @StringRes titleRes: Int,
     alarm: Alarm,
     saveAlarm: () -> Unit,
+    scheduleAlarm: (Context) -> Unit,
     updateName: (String) -> Unit,
     updateDate: (LocalDate) -> Unit,
     updateTime: (Int, Int) -> Unit,
@@ -75,7 +78,8 @@ fun AlarmCreateEditScreen(
             AlarmCreationTopAppBar(
                 navHostController = navHostController,
                 titleRes = titleRes,
-                saveAlarm = saveAlarm
+                saveAlarm = saveAlarm,
+                scheduleAlarm = scheduleAlarm
             )
 
             // Alarm Name, and Date/Time Settings
@@ -113,7 +117,8 @@ fun AlarmCreateEditScreen(
 fun AlarmCreationTopAppBar(
     navHostController: NavHostController,
     @StringRes titleRes: Int,
-    saveAlarm: () -> Unit
+    saveAlarm: () -> Unit,
+    scheduleAlarm: (Context) -> Unit
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -136,10 +141,12 @@ fun AlarmCreationTopAppBar(
             )
         }
 
+        val context = LocalContext.current
         // Save Button
         IconButton(
             onClick = {
                 saveAlarm()
+                scheduleAlarm(context)
                 navHostController.popBackStack()
             }
         ) {
@@ -316,6 +323,7 @@ private fun AlarmCreateEditScreenPreview() {
                 weeklyRepeater = WeeklyRepeater(tueWedThu)
             ),
             saveAlarm = {},
+            scheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },
@@ -332,7 +340,8 @@ private fun AlarmCreationTopAppBarPreview() {
         AlarmCreationTopAppBar(
             navHostController = rememberNavController(),
             titleRes = R.string.alarm_creation_screen_title,
-            saveAlarm = {}
+            saveAlarm = {},
+            scheduleAlarm = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -35,6 +35,7 @@ fun AlarmEditScreen(
             titleRes = R.string.alarm_edit_screen_title,
             alarm = (alarmState as AlarmState.Success).alarm,
             saveAlarm = { coroutineScope.launch { alarmEditViewModel.saveAlarm() } },
+            scheduleAlarm = alarmEditViewModel::scheduleAlarm,
             updateName = alarmEditViewModel::updateName,
             updateDate = alarmEditViewModel::updateDate,
             updateTime = alarmEditViewModel::updateTime,
@@ -62,6 +63,7 @@ private fun AlarmEditScreenPreview() {
                 weeklyRepeater = WeeklyRepeater(tueWedThu)
             ),
             saveAlarm = {},
+            scheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -1,11 +1,13 @@
 package com.example.alarmscratch.alarm.ui.alarmedit
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.example.alarmscratch.alarm.alarmexecution.AlarmSchedulerImpl
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
@@ -66,6 +68,13 @@ class AlarmEditViewModel(
             } else {
                 alarmRepository.updateAlarm(alarm)
             }
+        }
+    }
+
+    fun scheduleAlarm(context: Context) {
+        if (_modifiedAlarm.value is AlarmState.Success) {
+            val alarmScheduler = AlarmSchedulerImpl(context)
+            alarmScheduler.scheduleAlarm((_modifiedAlarm.value as AlarmState.Success).alarm)
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -40,6 +41,7 @@ import com.example.alarmscratch.alarm.data.preview.repeatingAlarm
 import com.example.alarmscratch.alarm.data.preview.todayAlarm
 import com.example.alarmscratch.alarm.data.preview.tomorrowAlarm
 import com.example.alarmscratch.core.extension.get12HrTime
+import com.example.alarmscratch.core.extension.getAmPm
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatHull
 import com.example.alarmscratch.core.ui.theme.BoatSails
@@ -143,7 +145,7 @@ fun AlarmCard(
                     // Time
                     Row {
                         Text(
-                            text = alarm.get12HrTime(),
+                            text = alarm.dateTime.get12HrTime(),
                             fontSize = 32.sp,
                             fontWeight = if (alarm.enabled) {
                                 FontWeight.Bold
@@ -154,7 +156,7 @@ fun AlarmCard(
                             modifier = Modifier.alignByBaseline()
                         )
                         Text(
-                            text = amPm(alarm = alarm),
+                            text = alarm.dateTime.getAmPm(LocalContext.current),
                             fontWeight = if (alarm.enabled) {
                                 FontWeight.SemiBold
                             } else {
@@ -209,14 +211,6 @@ fun NoAlarmsCard(modifier: Modifier = Modifier) {
         }
     }
 }
-
-@Composable
-fun amPm(alarm: Alarm): String =
-    if (alarm.dateTime.toLocalTime().hour < 12) {
-        stringResource(id = R.string.time_am)
-    } else {
-        stringResource(id = R.string.time_pm)
-    }
 
 /*
  * Previews

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -1,0 +1,37 @@
+package com.example.alarmscratch.alarm.ui.fullscreenalert
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.alarmexecution.AlarmReceiver
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+class FullScreenAlarmActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val alarmName = intent.getStringExtra(AlarmReceiver.EXTRA_ALARM_NAME) ?: applicationContext.getString(R.string.default_alarm_name)
+        val alarmTime = intent.getStringExtra(AlarmReceiver.EXTRA_ALARM_TIME) ?: applicationContext.getString(R.string.default_alarm_time)
+
+        setContent {
+            AlarmScratchTheme {
+                FullScreenAlarmScreen(alarmName = alarmName, alarmTime = alarmTime)
+            }
+        }
+
+        turnScreenOn()
+    }
+
+    private fun turnScreenOn() {
+        setShowWhenLocked(true)
+        setTurnScreenOn(true)
+
+        window.addFlags(
+            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
+                    WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -1,0 +1,46 @@
+package com.example.alarmscratch.alarm.ui.fullscreenalert
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+@Composable
+fun FullScreenAlarmScreen(
+    alarmName: String,
+    alarmTime: String
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = alarmName)
+                Text(text = alarmTime)
+                Button(onClick = {}) {
+                    Text(text = "Dismiss Alarm")
+                }
+            }
+        }
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview
+@Composable
+private fun FullScreenAlarmScreenPreview() {
+    AlarmScratchTheme {
+        FullScreenAlarmScreen(
+            alarmName = "Alarm Name",
+            alarmTime = "Mon, 2:30 PM"
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
@@ -2,8 +2,12 @@ package com.example.alarmscratch.alarm.ui.notification
 
 import android.app.Notification
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.alarmexecution.AlarmReceiver
+import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmActivity
 
 class AlarmNotificationService(private val context: Context) {
 
@@ -23,5 +27,31 @@ class AlarmNotificationService(private val context: Context) {
 
         // TODO: Modify ID
         notificationManager.notify(1, notification)
+    }
+
+    // TODO: Check permission
+    fun showFullScreenNotification(alarmName: String, alarmTime: String) {
+        val intent = Intent(context, FullScreenAlarmActivity::class.java).apply {
+            putExtra(AlarmReceiver.EXTRA_ALARM_NAME, alarmName)
+            putExtra(AlarmReceiver.EXTRA_ALARM_TIME, alarmTime)
+        }
+
+        // TODO: Modify request code
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = Notification.Builder(context, ALARM_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(alarmName)
+            .setContentText(alarmTime)
+            .setFullScreenIntent(pendingIntent, true)
+            .build()
+
+        // TODO: Modify ID
+        notificationManager.notify(2, notification)
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
@@ -1,0 +1,27 @@
+package com.example.alarmscratch.alarm.ui.notification
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import com.example.alarmscratch.R
+
+class AlarmNotificationService(private val context: Context) {
+
+    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    companion object {
+        const val ALARM_NOTIFICATION_CHANNEL_ID = "alarm_notification_channel"
+    }
+
+    // TODO: Check permission
+    fun showNotification(alarmName: String, alarmTime: String) {
+        val notification = Notification.Builder(context, ALARM_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(alarmName)
+            .setContentText(alarmTime)
+            .build()
+
+        // TODO: Modify ID
+        notificationManager.notify(1, notification)
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
@@ -1,0 +1,29 @@
+package com.example.alarmscratch.core
+
+import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.ui.notification.AlarmNotificationService
+
+class AlarmApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        // TODO: Come up with real strings for this
+        val channel = NotificationChannel(
+            AlarmNotificationService.ALARM_NOTIFICATION_CHANNEL_ID,
+            getString(R.string.permission_channel_alarm_name),
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        channel.description = getString(R.string.permission_channel_alarm_desc)
+
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
@@ -19,7 +19,7 @@ class AlarmApplication : Application() {
         val channel = NotificationChannel(
             AlarmNotificationService.ALARM_NOTIFICATION_CHANNEL_ID,
             getString(R.string.permission_channel_alarm_name),
-            NotificationManager.IMPORTANCE_DEFAULT
+            NotificationManager.IMPORTANCE_HIGH
         )
         channel.description = getString(R.string.permission_channel_alarm_desc)
 

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -7,23 +7,6 @@ import java.time.LocalDateTime
 
 fun Alarm.isRepeating(): Boolean = weeklyRepeater.hasRepeatingDays()
 
-fun Alarm.get12HrTime(): String {
-    val time = dateTime.toLocalTime()
-    val minute = if (time.minute < 10) {
-        "0${time.minute}"
-    } else {
-        "${time.minute}"
-    }
-
-    return if (time.hour == 0) { // Midnight
-        "12:$minute"
-    } else if (time.hour <= 12) {
-        "${time.hour}:$minute"
-    } else {
-        "${time.hour - 12}:$minute"
-    }
-}
-
 /**
  * Returns a LocalDateTime with the next day the Alarm is set to go off, if and only if the Alarm is set to repeat.
  * The returned LocalDateTime is guaranteed to be set in the future.

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
@@ -30,7 +30,7 @@ fun LocalDateTime.toAlarmDateString(context: Context) : String {
         } else if (alarmDate.dayOfYear - currentDate.dayOfYear == 1) { // Alarm is for tomorrow
             context.getString(R.string.date_tomorrow)
         } else { // Alarm is for a day beyond tomorrow
-            formatDate(alarmDate)
+            formatCalendarDate(alarmDate)
         }
     } else {
         context.getString(R.string.error)
@@ -38,8 +38,35 @@ fun LocalDateTime.toAlarmDateString(context: Context) : String {
 }
 
 // TODO do something different with Locale
-private fun formatDate(date: LocalDate): String =
+private fun formatCalendarDate(date: LocalDate): String =
     "${date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)}, " +
             "${date.month.getDisplayName(TextStyle.SHORT, Locale.US)} " +
             "${date.dayOfMonth.toOrdinal()} " +
             "${date.year}"
+
+fun LocalDateTime.toNotificationDateTimeString(context: Context): String =
+    "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)}, ${get12HrTime()} ${getAmPm(context)}"
+
+fun LocalDateTime.get12HrTime(): String {
+    val time = this.toLocalTime()
+    val minute = if (time.minute < 10) {
+        "0${time.minute}"
+    } else {
+        "${time.minute}"
+    }
+
+    return if (time.hour == 0) { // Midnight
+        "12:$minute"
+    } else if (time.hour <= 12) {
+        "${time.hour}:$minute"
+    } else {
+        "${time.hour - 12}:$minute"
+    }
+}
+
+fun LocalDateTime.getAmPm(context: Context): String =
+    if (this.toLocalTime().hour < 12) {
+        context.getString(R.string.time_am)
+    } else {
+        context.getString(R.string.time_pm)
+    }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/component/SkylineHeader.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/component/SkylineHeader.kt
@@ -31,6 +31,7 @@ import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.preview.consistentFutureAlarm
 import com.example.alarmscratch.alarm.data.repository.AlarmListState
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.navigation.AlarmListScreen
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.navigation.SettingsScreen
@@ -207,7 +208,7 @@ private fun getNextAlarmText(context: Context, alarmList: List<Alarm>): String =
 
 private fun getNextAlarm(alarmList: List<Alarm>): Alarm? =
     alarmList
-        .filter { it.enabled }
+        .filter { it.enabled && it.dateTime.isAfter(LocalDateTimeUtil.nowTruncated()) }
         .minByOrNull { it.dateTime }
 
 /*

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
         ************************
     -->
     <string name="default_alarm_name">Alarm</string>
+    <string name="default_alarm_time">Now</string>
 
     <!--
         *****************

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,19 @@
     -->
     <string name="settings_general">General Settings</string>
     <string name="settings_alarm_defaults">Alarm Defaults</string>
+
+    <!--
+        ************************
+        ** Alarm Notification **
+        ************************
+    -->
+    <string name="default_alarm_name">Alarm</string>
+
+    <!--
+        *****************
+        ** Permissions **
+        *****************
+    -->
+    <string name="permission_channel_alarm_name">Alarm</string>
+    <string name="permission_channel_alarm_desc">Used for Alarm notifications</string>
 </resources>


### PR DESCRIPTION
### Description
- Add code for scheduling alarms
- Add preliminary code for executing alarms
  - When the screen is on -> display a notification
  - When the screen is off -> turn screen on and display a full screen alert
- Migrate Alarm database from Credential Protected Storage to Device Protected Storage. This is so it can be accessed while the User's device is locked in order to reschedule alarms after the device is reset. (The OS clears all scheduled alarms when the device is powered off)
- minSdk version bumped from 26 -> 27
  - This was done to allow for `setShowWhenLocked(true)` and `setTurnScreenOn(true)` to be used in `FullScreenAlarmActivity` without checking the SDK version. Market share for API 27+ is above 90% and the app is not released yet, so this is fine.
- Fix bug in SkylineHeader where it would show how much time is left until an alarm, when that alarm is in the past. Past alarms should not get a countdown.

Note: Both the Notification and the Full Screen Alert are preliminary. This code is just to get things generally set up, and it will be iterated on in later PRs.