### PR TITLE
Feature | Validate Modify Alarm DateTime

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -22,9 +23,11 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
             CoroutineScope(Dispatchers.IO).launch {
                 alarmRepo.getAllAlarmsFlow().collect { alarmList ->
-                    alarmList.forEach { alarm ->
-                        alarmScheduler.scheduleAlarm(alarm)
-                    }
+                    alarmList
+                        .filter { it.enabled && !it.dateTime.isBefore(LocalDateTimeUtil.nowTruncated()) }
+                        .forEach { alarm ->
+                            alarmScheduler.scheduleAlarm(alarm)
+                        }
                 }
             }
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -32,6 +32,7 @@ fun AlarmCreationScreen(
         navHostController = navHostController,
         titleRes = R.string.alarm_creation_screen_title,
         alarm = alarmState,
+        validateAlarm = alarmCreationViewModel::validateAlarm,
         saveAlarm = { coroutineScope.launch { alarmCreationViewModel.saveAlarm() } },
         scheduleAlarm = alarmCreationViewModel::scheduleAlarm,
         updateName = alarmCreationViewModel::updateName,
@@ -58,6 +59,7 @@ private fun AlarmCreationScreenPreview() {
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu)
             ),
+            validateAlarm = { true },
             saveAlarm = {},
             scheduleAlarm = {},
             updateName = {},

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -72,4 +72,6 @@ class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : Vie
     fun removeDay(day: WeeklyRepeater.Day) {
         _newAlarm.value = _newAlarm.value.copy(weeklyRepeater = _newAlarm.value.weeklyRepeater.removeDay(day))
     }
+
+    fun validateAlarm(): Boolean = _newAlarm.value.dateTime.isAfter(LocalDateTimeUtil.nowTruncated())
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -34,6 +34,7 @@ fun AlarmEditScreen(
             navHostController = navHostController,
             titleRes = R.string.alarm_edit_screen_title,
             alarm = (alarmState as AlarmState.Success).alarm,
+            validateAlarm = alarmEditViewModel::validateAlarm,
             saveAlarm = { coroutineScope.launch { alarmEditViewModel.saveAlarm() } },
             scheduleAlarm = alarmEditViewModel::scheduleAlarm,
             updateName = alarmEditViewModel::updateName,
@@ -62,6 +63,7 @@ private fun AlarmEditScreenPreview() {
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu)
             ),
+            validateAlarm = { true },
             saveAlarm = {},
             scheduleAlarm = {},
             updateName = {},

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -13,6 +13,7 @@ import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.alarm.data.repository.AlarmState
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.futurizeDateTime
 import com.example.alarmscratch.core.extension.isRepeating
 import com.example.alarmscratch.core.extension.nextRepeatingDate
@@ -114,4 +115,12 @@ class AlarmEditViewModel(
             _modifiedAlarm.value = AlarmState.Success(alarm.copy(weeklyRepeater = alarm.weeklyRepeater.removeDay(day)))
         }
     }
+
+    fun validateAlarm(): Boolean =
+        if (_modifiedAlarm.value is AlarmState.Success) {
+            val alarm = (_modifiedAlarm.value as AlarmState.Success).alarm
+            alarm.dateTime.isAfter(LocalDateTimeUtil.nowTruncated())
+        } else {
+            false
+        }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.alarm.ui.alarmlist
 
+import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,8 +32,8 @@ fun AlarmListScreen(
 
     // Actions
     val coroutineScope = rememberCoroutineScope()
-    val onAlarmToggled: (Alarm) -> Unit = { alarm ->
-        coroutineScope.launch { alarmListViewModel.updateAlarm(alarm) }
+    val onAlarmToggled: (Context, Alarm) -> Unit = { context, alarm ->
+        coroutineScope.launch { alarmListViewModel.toggleAlarm(context, alarm) }
     }
     val onAlarmDeleted: (Alarm) -> Unit = { alarm ->
         coroutineScope.launch { alarmListViewModel.deleteAlarm(alarm) }
@@ -51,7 +52,7 @@ fun AlarmListScreen(
 @Composable
 fun AlarmListScreenContent(
     alarmListState: AlarmListState,
-    onAlarmToggled: (Alarm) -> Unit,
+    onAlarmToggled: (Context, Alarm) -> Unit,
     onAlarmDeleted: (Alarm) -> Unit,
     navigateToAlarmEditScreen: (Int) -> Unit,
     modifier: Modifier = Modifier
@@ -103,7 +104,7 @@ private fun AlarmListScreenPreview() {
     AlarmScratchTheme {
         AlarmListScreenContent(
             alarmListState = AlarmListState.Success(alarmList = alarmSampleDataHardCodedIds),
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
@@ -120,7 +121,7 @@ private fun AlarmListScreenNoAlarmsPreview() {
     AlarmScratchTheme {
         AlarmListScreenContent(
             alarmListState = AlarmListState.Success(emptyList()),
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.alarm.ui.alarmlist.component
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -52,7 +53,7 @@ import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 @Composable
 fun AlarmCard(
     alarm: Alarm,
-    onAlarmToggled: (Alarm) -> Unit,
+    onAlarmToggled: (Context, Alarm) -> Unit,
     onAlarmDeleted: (Alarm) -> Unit,
     navigateToAlarmEditScreen: (Int) -> Unit,
     modifier: Modifier = Modifier
@@ -175,10 +176,12 @@ fun AlarmCard(
                 }
             }
 
+            val context = LocalContext.current
+
             // Alarm Switch
             Switch(
                 checked = alarm.enabled,
-                onCheckedChange = { onAlarmToggled(alarm) },
+                onCheckedChange = { onAlarmToggled(context, alarm) },
                 colors = SwitchDefaults.colors(uncheckedTrackColor = MediumVolcanicRock),
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
@@ -225,7 +228,7 @@ private fun AlarmCardRepeatingPreview() {
     AlarmScratchTheme {
         AlarmCard(
             alarm = repeatingAlarm,
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
@@ -255,7 +258,7 @@ private fun AlarmCardTodayPreview() {
     AlarmScratchTheme {
         AlarmCard(
             alarm = todayAlarm,
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
@@ -272,7 +275,7 @@ private fun AlarmCardTomorrowPreview() {
     AlarmScratchTheme {
         AlarmCard(
             alarm = tomorrowAlarm,
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
@@ -289,7 +292,7 @@ private fun AlarmCardCalendarPreview() {
     AlarmScratchTheme {
         AlarmCard(
             alarm = calendarAlarm,
-            onAlarmToggled = {},
+            onAlarmToggled = { _, _ -> },
             onAlarmDeleted = {},
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
@@ -12,7 +12,7 @@ object LocalDateTimeUtil {
 }
 
 fun LocalDateTime.futurizeDateTime(): LocalDateTime =
-    if (!isAfter(LocalDateTime.now())) {
+    if (isBefore(LocalDateTimeUtil.nowTruncated())) {
         plusDays(1)
     } else {
         this

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
@@ -12,7 +12,7 @@ object LocalDateTimeUtil {
 }
 
 fun LocalDateTime.futurizeDateTime(): LocalDateTime =
-    if (isBefore(LocalDateTimeUtil.nowTruncated())) {
+    if (!isAfter(LocalDateTimeUtil.nowTruncated())) {
         plusDays(1)
     } else {
         this

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
@@ -11,12 +11,21 @@ object LocalDateTimeUtil {
     fun nowTruncated(): LocalDateTime = LocalDateTime.now().withSecond(0).withNano(0)
 }
 
-fun LocalDateTime.futurizeDateTime(): LocalDateTime =
-    if (!isAfter(LocalDateTimeUtil.nowTruncated())) {
-        plusDays(1)
+fun LocalDateTime.futurizeDateTime(): LocalDateTime {
+    val currentDateTime = LocalDateTimeUtil.nowTruncated()
+    return if (!this.isAfter(currentDateTime)) {
+        val potentialAlarm = LocalDateTime.of(currentDateTime.toLocalDate(), this.toLocalTime())
+
+        // Add the minimum amount of days required to futurize the Alarm
+        if (!potentialAlarm.isAfter(currentDateTime)) {
+            potentialAlarm.plusDays(1)
+        } else {
+            potentialAlarm
+        }
     } else {
         this
     }
+}
 
 fun LocalDateTime.toAlarmDateString(context: Context) : String {
     val currentDateTime = LocalDateTimeUtil.nowTruncated()

--- a/app/src/main/java/com/example/alarmscratch/core/ui/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/CoreScreen.kt
@@ -144,7 +144,7 @@ private fun CoreScreenAlarmListPreview() {
         ) {
             AlarmListScreenContent(
                 alarmListState = alarmListState,
-                onAlarmToggled = {},
+                onAlarmToggled = { _, _ -> },
                 onAlarmDeleted = {},
                 navigateToAlarmEditScreen = {},
                 modifier = Modifier.padding(20.dp)
@@ -178,7 +178,7 @@ private fun CoreScreenAlarmListNoAlarmsPreview() {
         ) {
             AlarmListScreenContent(
                 alarmListState = alarmListState,
-                onAlarmToggled = {},
+                onAlarmToggled = { _, _ -> },
                 onAlarmDeleted = {},
                 navigateToAlarmEditScreen = {},
                 modifier = Modifier.padding(20.dp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <!-- AlarmCreateEditScreen -->
     <string name="alarm_name_placeholder">Alarm name</string>
     <string name="repeating_alarm_date_label">Every:</string>
+    <string name="validation_alarm_in_past">Alarms cannot be set in the past</string>
     <!-- AlarmTimePickerDialog -->
     <string name="select_time">Select time</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
### Description
- Add code to validate Alarm DateTimes, and automatically modify them if necessary
- Add a Snackbar to AlarmCreateEditScreen to let the User know that they can't set an Alarm in the past, when they try to save an Alarm that's set in the past
- Fix an issue in BootCompletedReceiver where disabled Alarms, and Alarms set in the past were being scheduled on device boot
- Fix an issue in _LocalDateTime.kt where `futurizeDateTime()` wasn't properly modifying Alarms to be set in the future. It was previously incapable of "futurizing" Alarms that are set more than one day in the past. It also wasn't taking the time of the Alarm into account.
- Add code to AlarmListViewModel to ensure that Alarms are set in the future while toggling them on or off, and automatically futurize them if they are in the past
- Add code to AlarmListViewModel to schedule or cancel Alarms when toggling them on or off