### PR TITLE
Feature | Ringtone Picker Preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,12 +51,7 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
 
-    // not used yet, but used for collectAsStateWithLifecycle()
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
@@ -64,6 +59,13 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation("androidx.compose.material:material-icons-extended:1.6.6")
+
+    // Lifecycle
+    implementation(libs.androidx.lifecycle.process)
+    // Not used yet, but used for collectAsStateWithLifecycle()
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Navigation
     implementation(libs.androidx.navigation.compose)

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationActionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationActionReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.core.ringtone.RingtonePlayerManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -65,14 +65,14 @@ val alarmSampleData: List<Alarm> = listOf(repeatingAlarm, todayAlarm, tomorrowAl
  */
 val alarmSampleDataHardCodedIds: List<Alarm> = alarmSampleData.mapIndexed { index, alarm -> alarm.copy(id = index) }
 
-val sampleRingtoneData = RingtoneData(id = 0, name = "Ringtone Name", baseUri = sampleRingtoneUriString)
+val sampleRingtoneData = RingtoneData(id = 0, name = "Ringtone 1", baseUri = sampleRingtoneUriString)
 
 val ringtoneDataSampleList: List<RingtoneData> = listOf(
     sampleRingtoneData,
-    RingtoneData(id = 1, name = "Ringtone 1", baseUri = "ringtone1BaseUri"),
-    RingtoneData(id = 2, name = "Ringtone 2", baseUri = "ringtone2BaseUri"),
-    RingtoneData(id = 3, name = "Ringtone 3", baseUri = "ringtone3BaseUri"),
-    RingtoneData(id = 4, name = "Ringtone 4", baseUri = "ringtone4BaseUri")
+    RingtoneData(id = 1, name = "Ringtone 2", baseUri = "ringtone2BaseUri"),
+    RingtoneData(id = 2, name = "Ringtone 3", baseUri = "ringtone3BaseUri"),
+    RingtoneData(id = 3, name = "Ringtone 4", baseUri = "ringtone4BaseUri"),
+    RingtoneData(id = 4, name = "Ringtone 5", baseUri = "ringtone5BaseUri")
 )
 
 // TODO do exception handling for java code

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotificationService.kt
@@ -9,8 +9,8 @@ import android.graphics.drawable.Icon
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.alarmexecution.AlarmNotificationActionReceiver
 import com.example.alarmscratch.alarm.alarmexecution.AlarmReceiver
-import com.example.alarmscratch.alarm.alarmexecution.RingtonePlayerManager
 import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmActivity
+import com.example.alarmscratch.core.ringtone.RingtonePlayerManager
 
 class AlarmNotificationService(private val context: Context) {
 

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
@@ -1,4 +1,4 @@
-package com.example.alarmscratch.alarm.alarmexecution
+package com.example.alarmscratch.core.ringtone
 
 import android.content.Context
 import android.media.AudioAttributes

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
@@ -14,6 +14,9 @@ class RingtonePlayer {
     private var ringtone: Ringtone? = null
 
     fun playRingtone(context: Context, ringtoneUriString: String) {
+        // Stop currently playing Ringtone if there is one
+        stopRingtone()
+
         if (audioManager == null) {
             audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         }

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayerManager.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayerManager.kt
@@ -1,4 +1,4 @@
-package com.example.alarmscratch.alarm.alarmexecution
+package com.example.alarmscratch.core.ringtone
 
 import android.content.Context
 

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
@@ -57,6 +58,7 @@ fun RingtonePickerScreen(
     // State
     val ringtoneDataList = ringtonePickerViewModel.ringtoneDataList
     val selectedRingtoneUri by ringtonePickerViewModel.selectedRingtoneUri.collectAsState()
+    val isRingtonePlaying by ringtonePickerViewModel.isRingtonePlaying.collectAsState()
 
     // Actions
     val saveRingtone: () -> Unit = {
@@ -68,6 +70,7 @@ fun RingtonePickerScreen(
         navHostController = navHostController,
         ringtoneDataList = ringtoneDataList,
         selectedRingtoneUri = selectedRingtoneUri,
+        isRingtonePlaying = isRingtonePlaying,
         selectRingtone = ringtonePickerViewModel::selectRingtone,
         saveRingtone = saveRingtone,
         modifier = modifier
@@ -79,6 +82,7 @@ fun RingtonePickerScreenContent(
     navHostController: NavHostController,
     ringtoneDataList: List<RingtoneData>,
     selectedRingtoneUri: String,
+    isRingtonePlaying: Boolean,
     selectRingtone: (Context, String) -> Unit,
     saveRingtone: () -> Unit,
     modifier: Modifier
@@ -86,6 +90,7 @@ fun RingtonePickerScreenContent(
     // State
     val context = LocalContext.current
     val isRowSelected: (String) -> Boolean = { it == selectedRingtoneUri }
+    val isRowPlaying: (String) -> Boolean = { isRingtonePlaying && isRowSelected(it) }
     val rowColor: (String) -> Color = { if (isRowSelected(it)) VolcanicRock else DarkVolcanicRock }
 
     Surface(modifier = modifier) {
@@ -128,13 +133,26 @@ fun RingtonePickerScreenContent(
                         // Ringtone Name
                         Text(text = ringtoneData.name)
 
-                        // Selected Ringtone Icon
+                        // Ringtone playback and selection indicator Icons
                         if (isRowSelected(ringtoneData.fullUriString)) {
-                            Icon(
-                                imageVector = Icons.Default.CheckCircle,
-                                contentDescription = null,
-                                tint = SelectedGreen
-                            )
+                            Row {
+                                // Ringtone playback indicator Icon
+                                if (isRowPlaying(ringtoneData.fullUriString)) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Default.VolumeUp,
+                                        contentDescription = null,
+                                        tint = DarkerBoatSails
+                                    )
+                                    Spacer(modifier = Modifier.width(16.dp))
+                                }
+
+                                // Selected Ringtone Icon
+                                Icon(
+                                    imageVector = Icons.Default.CheckCircle,
+                                    contentDescription = null,
+                                    tint = SelectedGreen
+                                )
+                            }
                         }
                     }
                 }
@@ -188,12 +206,29 @@ fun RingtonePickerTopAppBar(
 
 @Preview
 @Composable
-private fun RingtonePickerScreenPreview() {
+private fun RingtonePickerScreenPlayingPreview() {
     AlarmScratchTheme {
         RingtonePickerScreenContent(
             navHostController = rememberNavController(),
             ringtoneDataList = ringtoneDataSampleList,
             selectedRingtoneUri = sampleRingtoneData.fullUriString,
+            isRingtonePlaying = true,
+            selectRingtone = { _, _ -> },
+            saveRingtone = {},
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun RingtonePickerScreenNotPlayingPreview() {
+    AlarmScratchTheme {
+        RingtonePickerScreenContent(
+            navHostController = rememberNavController(),
+            ringtoneDataList = ringtoneDataSampleList,
+            selectedRingtoneUri = sampleRingtoneData.fullUriString,
+            isRingtonePlaying = false,
             selectRingtone = { _, _ -> },
             saveRingtone = {},
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.core.ui.ringtonepicker
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -77,11 +79,12 @@ fun RingtonePickerScreenContent(
     navHostController: NavHostController,
     ringtoneDataList: List<RingtoneData>,
     selectedRingtoneUri: String,
-    selectRingtone: (String) -> Unit,
+    selectRingtone: (Context, String) -> Unit,
     saveRingtone: () -> Unit,
     modifier: Modifier
 ) {
     // State
+    val context = LocalContext.current
     val isRowSelected: (String) -> Boolean = { it == selectedRingtoneUri }
     val rowColor: (String) -> Color = { if (isRowSelected(it)) VolcanicRock else DarkVolcanicRock }
 
@@ -118,7 +121,7 @@ fun RingtonePickerScreenContent(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { selectRingtone(ringtoneData.fullUriString) }
+                            .clickable { selectRingtone(context, ringtoneData.fullUriString) }
                             .background(color = rowColor(ringtoneData.fullUriString))
                             .padding(start = 32.dp, top = 12.dp, end = 32.dp, bottom = 12.dp)
                     ) {
@@ -191,7 +194,7 @@ private fun RingtonePickerScreenPreview() {
             navHostController = rememberNavController(),
             ringtoneDataList = ringtoneDataSampleList,
             selectedRingtoneUri = sampleRingtoneData.fullUriString,
-            selectRingtone = {},
+            selectRingtone = { _, _ -> },
             saveRingtone = {},
             modifier = Modifier.fillMaxSize()
         )

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
@@ -35,7 +35,7 @@ class RingtonePickerViewModel(
         // This is to enable the ability to stop any currently playing Ringtone when the app is
         // placed into the background, by implementing DefaultLifecycleObserver.onStop().
         //
-        // According to the ProcessLifecycleObserver documentation, the Application's Lifecycle's ON_STOP Event
+        // According to the ProcessLifecycleOwner documentation, the Application's Lifecycle's ON_STOP Event
         // will not be dispatched if there are Activities being recreated due to a configuration change.
         // Therefore, onStop() will not be called unless the app is getting put into the background.
         //

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
@@ -1,5 +1,9 @@
 package com.example.alarmscratch.core.ui.ringtonepicker
 
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -9,6 +13,7 @@ import androidx.navigation.toRoute
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.data.repository.RingtoneRepository
 import com.example.alarmscratch.core.navigation.Destination
+import com.example.alarmscratch.core.ringtone.RingtonePlayerManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,12 +21,29 @@ import kotlinx.coroutines.flow.asStateFlow
 class RingtonePickerViewModel(
     savedStateHandle: SavedStateHandle,
     ringtoneRepository: RingtoneRepository
-) : ViewModel() {
+) : ViewModel(), DefaultLifecycleObserver {
 
     val ringtoneDataList = ringtoneRepository.getAllRingtoneData()
     private val initialRingtoneUri: String = savedStateHandle.toRoute<Destination.RingtonePickerScreen>().ringtoneUriString
     private val _selectedRingtoneUri: MutableStateFlow<String> = MutableStateFlow(initialRingtoneUri)
     val selectedRingtoneUri: StateFlow<String> = _selectedRingtoneUri.asStateFlow()
+    private var isRingtonePlaying = false
+
+    init {
+        // Register this ViewModel to the Application's Lifecycle.
+        // This is to enable the ability to stop any currently playing Ringtone when the app is
+        // placed into the background, by implementing DefaultLifecycleObserver.onStop().
+        //
+        // According to the ProcessLifecycleObserver documentation, the Application's Lifecycle's ON_STOP Event
+        // will not be dispatched if there are Activities being recreated due to a configuration change.
+        // Therefore, onStop() will not be called unless the app is getting put into the background.
+        //
+        // "Why not just stop the Ringtone in ViewModel.onCleared()?" This is because ViewModel.onCleared() isn't called
+        // when the app is simply put into the background. However, ViewModel.onCleared() is still used to stop the Ringtone.
+        // This is because onStop() won't be called when the ViewModel is destroyed via back-navigation; however, ViewModel.onCleared()
+        // will be called in this situation. Therefore, both onStop() and onCleared() are required for proper Ringtone playback management.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+    }
 
     companion object {
 
@@ -39,8 +61,30 @@ class RingtonePickerViewModel(
         }
     }
 
-    fun selectRingtone(ringtoneUriString: String) {
+    fun selectRingtone(context: Context, ringtoneUriString: String) {
+        // Play or Stop Ringtone
+        if (isRingtonePlaying) {
+            if (ringtoneUriString == _selectedRingtoneUri.value) {
+                stopRingtone()
+            } else {
+                playRingtone(context, ringtoneUriString)
+            }
+        } else {
+            playRingtone(context, ringtoneUriString)
+        }
+
+        // Select Ringtone
         _selectedRingtoneUri.value = ringtoneUriString
+    }
+
+    private fun playRingtone(context: Context, ringtoneUri: String) {
+        RingtonePlayerManager.startAlarmSound(context, ringtoneUri)
+        isRingtonePlaying = true
+    }
+
+    private fun stopRingtone() {
+        RingtonePlayerManager.stopAlarmSound()
+        isRingtonePlaying = false
     }
 
     /**
@@ -51,5 +95,33 @@ class RingtonePickerViewModel(
      */
     fun saveRingtone(savedStateHandle: SavedStateHandle?) {
         savedStateHandle?.set(RingtoneData.KEY_FULL_RINGTONE_URI_STRING, _selectedRingtoneUri.value)
+    }
+
+    /*
+     ******************************
+     **** Lifecycle Management ****
+     ******************************
+     */
+
+    /**
+     * Stop Ringtone playback when the app is put into the background
+     *
+     * @param owner the LifecycleOwner whose state is changing
+     */
+    override fun onStop(owner: LifecycleOwner) {
+        stopRingtone()
+        super.onStop(owner)
+    }
+
+    /**
+     * Stop Ringtone playback when the ViewModel is destroyed.
+     * onCleared() will not necessarily be called when the app is simply placed into the background.
+     */
+    override fun onCleared() {
+        // If you don't call removeObserver(), then the ViewModel will leak
+        // and you'll get ghost calls to onStop() for the rest of the Application's Lifecycle.
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(this)
+        stopRingtone()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
@@ -27,7 +27,8 @@ class RingtonePickerViewModel(
     private val initialRingtoneUri: String = savedStateHandle.toRoute<Destination.RingtonePickerScreen>().ringtoneUriString
     private val _selectedRingtoneUri: MutableStateFlow<String> = MutableStateFlow(initialRingtoneUri)
     val selectedRingtoneUri: StateFlow<String> = _selectedRingtoneUri.asStateFlow()
-    private var isRingtonePlaying = false
+    private val _isRingtonePlaying: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isRingtonePlaying: StateFlow<Boolean> = _isRingtonePlaying.asStateFlow()
 
     init {
         // Register this ViewModel to the Application's Lifecycle.
@@ -63,7 +64,7 @@ class RingtonePickerViewModel(
 
     fun selectRingtone(context: Context, ringtoneUriString: String) {
         // Play or Stop Ringtone
-        if (isRingtonePlaying) {
+        if (_isRingtonePlaying.value) {
             if (ringtoneUriString == _selectedRingtoneUri.value) {
                 stopRingtone()
             } else {
@@ -79,12 +80,12 @@ class RingtonePickerViewModel(
 
     private fun playRingtone(context: Context, ringtoneUri: String) {
         RingtonePlayerManager.startAlarmSound(context, ringtoneUri)
-        isRingtonePlaying = true
+        _isRingtonePlaying.value = true
     }
 
     private fun stopRingtone() {
         RingtonePlayerManager.stopAlarmSound()
-        isRingtonePlaying = false
+        _isRingtonePlaying.value = false
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,9 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
### Description
- Add audio previews to `RingtonePickerScreen`
  - `RingtonePickerViewModel` was used to stop any currently playing Ringtone when either, 1) The app is put in the background, or 2) the User navigates away from the Ringtone Picker.
    1) To stop the Ringtone when the app is placed into the background, the `RingtonePickerViewModel` was made lifecycle aware, specifically to the Application's lifecycle.
        - `ProcessLifecycleOwner` and `DefaultLifecycleObserver.onStop()` are used to stop the Ringtone when the app goes into the background. `ProcesLifecycleOwner` is associated with the Application's lifecycle, and its documentation explicitly guarantees that it will not dispatch the `ON_STOP` Lifecycle Event until all Activities have passed through `onStop()`, plus a timed delay. According to the docs, this makes `ProcessLifecycleOwner's` `onStop()` a reliable indicator that the app is being placed in the background, as this ensures that `ProcessLifecycleOwner` will not call `onStop()` during configuration changes.
    2) To stop the Ringtone when navigating away from the Ringtone Picker, `ViewModel.onCleared()` was used.
        - `ViewModel.onCleared()` is not called when the app is simply placed into the background, which is why `ProcessLifecycleOwner` and `DefaultLifecycleObserver.onStop()` were also used, above.
- Update the UI to show a playback indicator Icon to denote the currently previewing Ringtone
- Move some classes around