### PR TITLE
Feature | Manage Status Bar Color

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -10,10 +10,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -68,6 +71,7 @@ import com.example.alarmscratch.core.ui.theme.DarkerBoatSails
 import com.example.alarmscratch.core.ui.theme.LightVolcanicRock
 import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 import com.example.alarmscratch.core.ui.theme.VolcanicRock
+import com.example.alarmscratch.core.util.StatusBarUtil
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -89,6 +93,9 @@ fun AlarmCreateEditScreen(
     removeDay: (WeeklyRepeater.Day) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // Configure Status Bar
+    StatusBarUtil.setDarkStatusBar()
+
     // State
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
@@ -121,6 +128,8 @@ fun AlarmCreateEditScreen(
         containerColor = MaterialTheme.colorScheme.surface,
         contentColor = BoatSails,
         modifier = modifier
+            .background(color = MediumVolcanicRock)
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
@@ -1,14 +1,25 @@
 package com.example.alarmscratch.core
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.ui.graphics.toArgb
 import com.example.alarmscratch.core.navigation.AlarmApp
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.ui.theme.AndroidDarkScrim
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(AndroidDarkScrim.toArgb())
+        )
+
         setContent {
             AlarmScratchTheme {
                 AlarmApp()

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
@@ -24,7 +24,8 @@ fun AlarmApp() {
         composable<Destination.CoreScreen> {
             CoreScreen(
                 rootNavHostController = navHostController,
-                navigateToAlarmCreationScreen = { navHostController.navigateSingleTop(Destination.AlarmCreationScreen) }
+                navigateToAlarmCreationScreen = { navHostController.navigateSingleTop(Destination.AlarmCreationScreen) },
+                modifier = Modifier.fillMaxSize()
             )
         }
 

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -44,7 +44,8 @@ import com.example.alarmscratch.settings.SettingsScreen
 @Composable
 fun CoreScreen(
     rootNavHostController: NavHostController,
-    navigateToAlarmCreationScreen: () -> Unit
+    navigateToAlarmCreationScreen: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     // Configure Status Bar
     StatusBarUtil.setLightStatusBar()
@@ -58,6 +59,7 @@ fun CoreScreen(
 
     // Core Screen wrapping an Internal Screen
     CoreScreenContent(
+        modifier = modifier,
         header = { SkylineHeader(selectedNavComponentDest = selectedNavComponentDest) },
         onFabClicked = navigateToAlarmCreationScreen,
         navigationBar = {
@@ -79,6 +81,7 @@ fun CoreScreen(
 
 @Composable
 fun CoreScreenContent(
+    modifier: Modifier = Modifier,
     header: @Composable () -> Unit,
     onFabClicked: () -> Unit,
     navigationBar: @Composable () -> Unit,
@@ -86,8 +89,7 @@ fun CoreScreenContent(
 ) {
     Surface(
         color = Color.Transparent,
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = modifier
             .background(color = SkyBlue)
             .windowInsetsPadding(WindowInsets.systemBars)
     ) {

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,7 +36,9 @@ import com.example.alarmscratch.core.ui.core.component.SkylineHeaderContent
 import com.example.alarmscratch.core.ui.core.component.VolcanoNavigationBar
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BottomOceanBlue
+import com.example.alarmscratch.core.ui.theme.SkyBlue
 import com.example.alarmscratch.core.ui.theme.TopOceanBlue
+import com.example.alarmscratch.core.util.StatusBarUtil
 import com.example.alarmscratch.settings.SettingsScreen
 
 @Composable
@@ -41,6 +46,9 @@ fun CoreScreen(
     rootNavHostController: NavHostController,
     navigateToAlarmCreationScreen: () -> Unit
 ) {
+    // Configure Status Bar
+    StatusBarUtil.setLightStatusBar()
+
     // Navigation
     val localNavHostController = rememberNavController()
     val currentBackStackEntry by localNavHostController.currentBackStackEntryAsState()
@@ -78,7 +86,10 @@ fun CoreScreenContent(
 ) {
     Surface(
         color = Color.Transparent,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = SkyBlue)
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -48,6 +51,7 @@ import com.example.alarmscratch.core.ui.theme.DarkerBoatSails
 import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 import com.example.alarmscratch.core.ui.theme.SelectedGreen
 import com.example.alarmscratch.core.ui.theme.VolcanicRock
+import com.example.alarmscratch.core.util.StatusBarUtil
 
 @Composable
 fun RingtonePickerScreen(
@@ -55,6 +59,9 @@ fun RingtonePickerScreen(
     modifier: Modifier,
     ringtonePickerViewModel: RingtonePickerViewModel = viewModel(factory = RingtonePickerViewModel.Factory)
 ) {
+    // Configure Status Bar
+    StatusBarUtil.setDarkStatusBar()
+
     // State
     val ringtoneDataList = ringtonePickerViewModel.ringtoneDataList
     val selectedRingtoneUri by ringtonePickerViewModel.selectedRingtoneUri.collectAsState()
@@ -93,7 +100,11 @@ fun RingtonePickerScreenContent(
     val isRowPlaying: (String) -> Boolean = { isRingtonePlaying && isRowSelected(it) }
     val rowColor: (String) -> Color = { if (isRowSelected(it)) VolcanicRock else DarkVolcanicRock }
 
-    Surface(modifier = modifier) {
+    Surface(
+        modifier = modifier
+            .background(color = MediumVolcanicRock)
+            .windowInsetsPadding(WindowInsets.systemBars)
+    ) {
         Column {
             // Top App Bar
             RingtonePickerTopAppBar(

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
@@ -38,3 +38,6 @@ val NavTextActive = OtherLavaRed
 val NavIconInactive = LightVolcanicRock
 val NavTextInactive = LightVolcanicRock
 val NavIndicator = VolcanicRock
+
+// OS Default Clones
+val AndroidDarkScrim = Color(red = 0x1b, green = 0x1b, blue = 0x1b, alpha = 0x80)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
@@ -40,4 +40,5 @@ val NavTextInactive = LightVolcanicRock
 val NavIndicator = VolcanicRock
 
 // OS Default Clones
-val AndroidDarkScrim = Color(red = 0x1b, green = 0x1b, blue = 0x1b, alpha = 0x80)
+// Alpha value modified from 0x80
+val AndroidDarkScrim = Color(red = 0x1b, green = 0x1b, blue = 0x1b, alpha = 0xFF)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Theme.kt
@@ -3,7 +3,6 @@ package com.example.alarmscratch.core.ui.theme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
-import com.example.alarmscratch.core.util.StatusBarUtil
 
 // Comments below are for what these colors would change by default.
 // Some of these Composables' attributes have been modified in the code,
@@ -66,9 +65,6 @@ private val NauticalColorScheme = darkColorScheme(
 
 @Composable
 fun AlarmScratchTheme(content: @Composable () -> Unit) {
-    // Configure Status Bar
-    StatusBarUtil.setLightStatusBar()
-
     // Set theme
     MaterialTheme(
         colorScheme = NauticalColorScheme,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Theme.kt
@@ -1,13 +1,9 @@
 package com.example.alarmscratch.core.ui.theme
 
-import android.app.Activity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
+import com.example.alarmscratch.core.util.StatusBarUtil
 
 // Comments below are for what these colors would change by default.
 // Some of these Composables' attributes have been modified in the code,
@@ -70,16 +66,8 @@ private val NauticalColorScheme = darkColorScheme(
 
 @Composable
 fun AlarmScratchTheme(content: @Composable () -> Unit) {
-    // Change status bar colors
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = SkyBlue.toArgb()
-            // color scheme is always the same, so make the StatusBar text and icons always white
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
-        }
-    }
+    // Configure Status Bar
+    StatusBarUtil.setLightStatusBar()
 
     // Set theme
     MaterialTheme(

--- a/app/src/main/java/com/example/alarmscratch/core/util/StatusBarUtil.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/util/StatusBarUtil.kt
@@ -1,0 +1,33 @@
+package com.example.alarmscratch.core.util
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+@SuppressLint("ComposableNaming")
+object StatusBarUtil {
+
+    @Composable
+    fun setLightStatusBar() {
+        setStatusBarTextAndIconColor(useLightColors = true)
+    }
+
+    @Composable
+    fun setDarkStatusBar() {
+        setStatusBarTextAndIconColor(useLightColors = false)
+    }
+
+    @Composable
+    private fun setStatusBarTextAndIconColor(useLightColors: Boolean) {
+        val localView = LocalView.current
+        if (!localView.isInEditMode && localView.context is Activity) {
+            SideEffect {
+                val window = (localView.context as Activity).window
+                WindowCompat.getInsetsController(window, localView).isAppearanceLightStatusBars = useLightColors
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/settings/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/AlarmDefaultsScreen.kt
@@ -1,7 +1,11 @@
 package com.example.alarmscratch.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.SportsMartialArts
@@ -16,11 +20,19 @@ import androidx.compose.ui.unit.sp
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
+import com.example.alarmscratch.core.util.StatusBarUtil
 
 @Composable
 fun AlarmDefaultsScreen(modifier: Modifier = Modifier) {
+    // Configure Status Bar
+    StatusBarUtil.setDarkStatusBar()
+
     // TODO: Temporary code
-    Surface(modifier = modifier) {
+    Surface(
+        modifier = modifier
+            .background(color = MediumVolcanicRock)
+            .windowInsetsPadding(WindowInsets.systemBars)
+    ) {
         Column {
             Text(text = "Alarm Defaults", fontSize = 38.sp, modifier = Modifier.padding(start = 15.dp, top = 15.dp))
             SettingsComponent(icon = Icons.Default.SportsMartialArts, nameRes = R.string.settings_general, onClick = {})


### PR DESCRIPTION
### Description
- Ensure that the Status Bar color is consistent with the current screen
  - This was achieved by enabling Edge to Edge mode, and adding insets to the screens. Google is going to be enforcing Edge to Edge as the standard starting in Android 15, so this approach made the most sense.
- Extract `CoreScreen's` `fillMaxSize()` Modifier to its NavHost