### PR TITLE
Feature | Play Alarm When Silent

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
@@ -37,6 +37,16 @@ class RingtonePlayer {
             audioFocusRequest?.let { request ->
                 ringtone?.let { ring ->
                     manager.requestAudioFocus(request)
+
+                    // Ringtone.setStreamType() is deprecated. However, it is the only way to get
+                    // the Ringtone to play when the Device is set to Silent, which is standard
+                    // behavior for an Alarm app.
+                    //
+                    // Side Note: AudioAttributes.Builder().setLegacyStreamType() looks like it's
+                    // supposed to do the same thing, but it doesn't work for this.
+                    // AudioAttributes.Builder().setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED) also
+                    // does not get the Ringtone to play while the Device is set to Silent.
+                    ring.streamType = AudioManager.STREAM_ALARM
                     ring.play()
                 }
             }

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
@@ -40,7 +40,7 @@ class RingtonePlayer {
 
                     // Ringtone.setStreamType() is deprecated. However, it is the only way to get
                     // the Ringtone to play when the Device is set to Silent, which is standard
-                    // behavior for an Alarm app.
+                    // behavior for an alarm app.
                     //
                     // Side Note: AudioAttributes.Builder().setLegacyStreamType() looks like it's
                     // supposed to do the same thing, but it doesn't work for this.


### PR DESCRIPTION
### Description
- Make the Ringtone play when the User's Device is set to Silent
  - This is standard behavior for an alarm app. See Google's alarm app for an example.
  - Unfortunately, to achieve this functionality I had to use a deprecated method; `Ringtone.setStreamType()`. This was the only way I could find to make the Ringtone actually make noise when the Device was set to Silent. Without this, the Alarm doesn't make any sound.
    - For whatever reason, `AudioAttributes.Builder().setLegacyStreamType()` does not achieve the same effect of making the Ringtone play when the Device is set to Silent. It seems like it should, but it doesn't. Furthermore, I also tried using `AudioAttributes.Builder().setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)`, but that didn't work either.