### PR TITLE
Feature | Alarm Vibration UI

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -71,6 +73,7 @@ import com.example.alarmscratch.core.ui.theme.DarkerBoatSails
 import com.example.alarmscratch.core.ui.theme.LightVolcanicRock
 import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 import com.example.alarmscratch.core.ui.theme.VolcanicRock
+import com.example.alarmscratch.core.ui.theme.WayDarkerBoatSails
 import com.example.alarmscratch.core.util.StatusBarUtil
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -385,6 +388,10 @@ fun AlarmAlertSettings(
     selectedRingtone: String,
     modifier: Modifier = Modifier
 ) {
+    // Temporary state
+    var vibrationEnabled by rememberSaveable { mutableStateOf(false) }
+    val toggleVibration: () -> Unit = { vibrationEnabled = !vibrationEnabled }
+
     Column(modifier = modifier) {
         // Alert Icon and Text
         Row {
@@ -414,6 +421,29 @@ fun AlarmAlertSettings(
             Text(text = stringResource(id = R.string.alarm_create_edit_alarm_sound_label))
             // Ringtone name
             Text(text = selectedRingtone)
+        }
+
+        // Vibration toggle
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { toggleVibration() }
+                .padding(start = 12.dp, top = 12.dp, bottom = 12.dp)
+        ) {
+            // Vibration label
+            Text(text = stringResource(id = R.string.alarm_create_edit_alarm_vibration_label))
+
+            // Vibration Switch
+            Switch(
+                checked = vibrationEnabled,
+                onCheckedChange = { toggleVibration() },
+                colors = SwitchDefaults.colors(
+                    checkedTrackColor = WayDarkerBoatSails,
+                    uncheckedTrackColor = DarkVolcanicRock
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -12,11 +12,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -137,8 +140,9 @@ fun AlarmCreateEditScreen(
     ) { innerPadding ->
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
         ) {
             // Alarm Name, and Date/Time Settings
             Column(

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -142,7 +143,7 @@ fun AlarmCreateEditScreen(
             // Alarm Name, and Date/Time Settings
             Column(
                 modifier = Modifier
-                    .padding(20.dp)
+                    .padding(start = 20.dp, top = 20.dp, end = 20.dp)
                     .fillMaxWidth()
             ) {
                 // TODO: Add validation
@@ -168,13 +169,14 @@ fun AlarmCreateEditScreen(
                     color = VolcanicRock,
                     modifier = Modifier.padding(top = 12.dp, bottom = 12.dp)
                 )
-
-                // Alarm Alert Settings
-                AlarmAlertSettings(
-                    navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(alarm.ringtoneUriString) },
-                    selectedRingtone = alarmRingtoneName
-                )
             }
+
+            // Alarm Alert Settings
+            AlarmAlertSettings(
+                navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(alarm.ringtoneUriString) },
+                selectedRingtone = alarmRingtoneName,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
@@ -394,7 +396,7 @@ fun AlarmAlertSettings(
 
     Column(modifier = modifier) {
         // Alert Icon and Text
-        Row {
+        Row(modifier = Modifier.padding(start = 20.dp)) {
             Icon(
                 imageVector = Icons.Default.NotificationsActive,
                 contentDescription = null,
@@ -410,41 +412,51 @@ fun AlarmAlertSettings(
         }
 
         // Sound/Ringtone selection
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { navigateToRingtonePickerScreen() }
-                .padding(start = 12.dp, top = 12.dp, bottom = 12.dp)
-        ) {
-            // Sound label
-            Text(text = stringResource(id = R.string.alarm_create_edit_alarm_sound_label))
-            // Ringtone name
-            Text(text = selectedRingtone)
-        }
+        AlarmSettingsRowItem(
+            rowOnClick = { navigateToRingtonePickerScreen() },
+            rowLabelResId = R.string.alarm_create_edit_alarm_sound_label,
+            choiceComponent = { Text(text = selectedRingtone) }
+        )
 
         // Vibration toggle
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { toggleVibration() }
-                .padding(start = 12.dp, top = 12.dp, bottom = 12.dp)
-        ) {
-            // Vibration label
-            Text(text = stringResource(id = R.string.alarm_create_edit_alarm_vibration_label))
-
-            // Vibration Switch
-            Switch(
-                checked = vibrationEnabled,
-                onCheckedChange = { toggleVibration() },
-                colors = SwitchDefaults.colors(
-                    checkedTrackColor = WayDarkerBoatSails,
-                    uncheckedTrackColor = DarkVolcanicRock
+        AlarmSettingsRowItem(
+            rowOnClick = { toggleVibration() },
+            rowLabelResId = R.string.alarm_create_edit_alarm_vibration_label,
+            choiceComponent = {
+                Switch(
+                    checked = vibrationEnabled,
+                    onCheckedChange = { toggleVibration() },
+                    colors = SwitchDefaults.colors(
+                        checkedTrackColor = WayDarkerBoatSails,
+                        uncheckedTrackColor = DarkVolcanicRock
+                    )
                 )
-            )
-        }
+            }
+        )
+    }
+}
+
+@Composable
+fun AlarmSettingsRowItem(
+    rowOnClick: () -> Unit,
+    @StringRes rowLabelResId: Int,
+    choiceComponent: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { rowOnClick() }
+            .minimumInteractiveComponentSize()
+            .padding(start = 32.dp, end = 20.dp)
+    ) {
+        // Settings label
+        Text(text = stringResource(id = rowLabelResId))
+
+        // Settings choice
+        choiceComponent()
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="repeating_alarm_date_label">Every:</string>
     <string name="section_alert">Alert</string>
     <string name="alarm_create_edit_alarm_sound_label">Sound</string>
+    <string name="alarm_create_edit_alarm_vibration_label">Vibration</string>
     <string name="validation_alarm_in_past">Alarms cannot be set in the past</string>
     <!-- AlarmTimePickerDialog -->
     <string name="select_time">Select time</string>


### PR DESCRIPTION
### Description
- Add UI for the option to enable/disable vibration on the Alarm Create/Edit Screen
  - This component uses temporary code for its state. The real backing code for this will be implemented in a future PR.
- Rework/refactor the Alarm Create/Edit Screen's structure to allow for the basic settings rows to take up the full width of the screen
- Create the `AlarmSettingsRowItem` Composable to allow for easier uniformity between the simpler settings, which are just basic rows
  - This Composable makes use of `Modifier.minimumInteractiveComponentSize()` for row size uniformity. Without this, the Vibration Toggle row would be larger than the Sound Selection row. This is because its Switch, which internally makes use of `Modifier.minimumInteractiveComponentSize()`, takes up more vertical space than the text used in the Sound Selection row. Rather than adding hard-coded padding to text-only rows, this method utilizes a more accurate and reusable approach. As long as the Settings Rows' text is smaller than any interactive components in the list of Settings, and the interactive components do not exceed the minimum interactive size, all Settings rows will be uniformly sized vertically.
- Make the Alarm Create/Edit Screen scrollable