### PR TITLE
Feature | Set Up Preferences DataStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,8 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
-    // DataStore
-    implementation(libs.androidx.datastore)
+    // Preferences DataStore
+    implementation(libs.androidx.preferences.datastore)
 
     testImplementation(libs.junit)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation("androidx.compose.material:material-icons-extended:1.6.6")
+    implementation(libs.androidx.compose.material.icons)
 
     // Lifecycle
     implementation(libs.androidx.lifecycle.process)
@@ -75,6 +75,9 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
+
+    // DataStore
+    implementation(libs.androidx.datastore)
 
     testImplementation(libs.junit)
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -19,6 +19,7 @@ import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
+import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import kotlinx.coroutines.launch
 
@@ -32,12 +33,9 @@ fun AlarmCreationScreen(
     // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
     // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
     // then the new Ringtone's URI will be saved here.
-    val ringtoneUriString: String? =
-        navHostController
-            .currentBackStackEntry
-            ?.savedStateHandle
-            ?.get(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
-    alarmCreationViewModel.updateRingtone(ringtoneUriString)
+    alarmCreationViewModel.updateRingtone(
+        navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+    )
 
     // State
     val alarmState by alarmCreationViewModel.newAlarm.collectAsState()

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -25,7 +25,7 @@ class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : Vie
     private val _newAlarm = MutableStateFlow(
         Alarm(
             dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
-            ringtoneUriString = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)?.toString() ?: ""
+            ringtoneUriString = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)?.toString() ?: RingtoneData.NO_RINGTONE_URI
         )
     )
     val newAlarm: StateFlow<Alarm> = _newAlarm.asStateFlow()

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -20,6 +20,7 @@ import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
+import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import kotlinx.coroutines.launch
 
@@ -37,12 +38,9 @@ fun AlarmEditScreen(
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
         // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
         // then the new Ringtone's URI will be saved here.
-        val ringtoneUriString: String? =
-            navHostController
-                .currentBackStackEntry
-                ?.savedStateHandle
-                ?.get(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
-        alarmEditViewModel.updateRingtone(ringtoneUriString)
+        alarmEditViewModel.updateRingtone(
+            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+        )
 
         val context = LocalContext.current
         val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_NavHostController.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_NavHostController.kt
@@ -6,3 +6,10 @@ import com.example.alarmscratch.core.navigation.Destination
 fun NavHostController.navigateSingleTop(destination: Destination) {
     navigate(destination) { launchSingleTop = true }
 }
+
+fun NavHostController.getStringFromBackStack(key: String): String? =
+    try {
+        currentBackStackEntry?.savedStateHandle?.get(key)
+    } catch (e: Exception) {
+        null
+    }

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
@@ -11,7 +11,7 @@ import com.example.alarmscratch.alarm.ui.alarmedit.AlarmEditScreen
 import com.example.alarmscratch.core.extension.navigateSingleTop
 import com.example.alarmscratch.core.ui.core.CoreScreen
 import com.example.alarmscratch.core.ui.ringtonepicker.RingtonePickerScreen
-import com.example.alarmscratch.settings.AlarmDefaultsScreen
+import com.example.alarmscratch.settings.ui.alarmdefaults.AlarmDefaultsScreen
 
 @Composable
 fun AlarmApp() {
@@ -63,6 +63,9 @@ fun AlarmApp() {
         composable<Destination.AlarmDefaultsScreen> {
             AlarmDefaultsScreen(
                 navHostController = navHostController,
+                navigateToRingtonePickerScreen = { ringtoneUri ->
+                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUriString = ringtoneUri))
+                },
                 modifier = Modifier.fillMaxSize()
             )
         }

--- a/app/src/main/java/com/example/alarmscratch/settings/data/model/AlarmDefaults.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/model/AlarmDefaults.kt
@@ -1,0 +1,6 @@
+package com.example.alarmscratch.settings.data.model
+
+data class AlarmDefaults(
+    val ringtoneUri: String,
+    val isVibrationEnabled: Boolean
+)

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
@@ -1,6 +1,7 @@
 package com.example.alarmscratch.settings.data.repository
 
 import android.content.Context
+import android.media.RingtoneManager
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
@@ -9,51 +10,50 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.example.alarmscratch.core.data.model.RingtoneData
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
-const val ALARM_DEFAULTS_PREFERENCES_NAME = "alarm_defaults_preferences_name"
-
 val Context.alarmDefaultsDataStore by preferencesDataStore(
-    name = ALARM_DEFAULTS_PREFERENCES_NAME,
-    // TODO: Place default preferences here
+    name = AlarmDefaultsRepository.ALARM_DEFAULTS_PREFERENCES_NAME,
     corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
 )
 
-data class AlarmDefaults(
-    val ringtoneUri: String,
-    val isVibrationEnabled: Boolean
-)
-
-private object PreferencesKeys {
-    val RINGTONE_URI = stringPreferencesKey("ringtone_uri")
-    val IS_VIBRATION_ENABLED = booleanPreferencesKey("is_vibration_enabled")
-}
-
 class AlarmDefaultsRepository(private val dataStore: DataStore<Preferences>) {
+
+    companion object {
+        // Preferences name
+        const val ALARM_DEFAULTS_PREFERENCES_NAME = "alarm_defaults_preferences_name"
+
+        // Keys
+        private val KEY_RINGTONE_URI = stringPreferencesKey("ringtone_uri")
+        private val KEY_IS_VIBRATION_ENABLED = booleanPreferencesKey("is_vibration_enabled")
+
+        // Default values
+        private val DEFAULT_RINGTONE_URI =
+            RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)?.toString() ?: RingtoneData.NO_RINGTONE_URI
+        private const val DEFAULT_IS_VIBRATION_ENABLED = false
+    }
 
     val alarmDefaultsFlow: Flow<AlarmDefaults> = dataStore.data
         .catch { emit(emptyPreferences()) }
         .map { preferences ->
-            // TODO: Change these defaults
-            // Get preferences
-            val ringtoneUri = preferences[PreferencesKeys.RINGTONE_URI] ?: ""
-            val isVibrationEnabled = preferences[PreferencesKeys.IS_VIBRATION_ENABLED] ?: false
+            // TODO: Exception handling
+            // Get Preferences
+            val ringtoneUri = preferences[KEY_RINGTONE_URI] ?: DEFAULT_RINGTONE_URI
+            val isVibrationEnabled = preferences[KEY_IS_VIBRATION_ENABLED] ?: DEFAULT_IS_VIBRATION_ENABLED
 
             // Return AlarmDefaults
             AlarmDefaults(ringtoneUri, isVibrationEnabled)
         }
 
-    suspend fun updateDefaultRingtoneUri(defaultRingtoneUri: String) {
+    suspend fun updateAlarmDefaults(alarmDefaults: AlarmDefaults) {
+        // TODO: Exception handling
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.RINGTONE_URI] = defaultRingtoneUri
-        }
-    }
-
-    suspend fun updateVibration(vibrationDefault: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[PreferencesKeys.IS_VIBRATION_ENABLED] = vibrationDefault
+            preferences[KEY_RINGTONE_URI] = alarmDefaults.ringtoneUri
+            preferences[KEY_IS_VIBRATION_ENABLED] = alarmDefaults.isVibrationEnabled
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
@@ -1,0 +1,59 @@
+package com.example.alarmscratch.settings.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+const val ALARM_DEFAULTS_PREFERENCES_NAME = "alarm_defaults_preferences_name"
+
+val Context.alarmDefaultsDataStore by preferencesDataStore(
+    name = ALARM_DEFAULTS_PREFERENCES_NAME,
+    // TODO: Place default preferences here
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
+)
+
+data class AlarmDefaults(
+    val ringtoneUri: String,
+    val isVibrationEnabled: Boolean
+)
+
+private object PreferencesKeys {
+    val RINGTONE_URI = stringPreferencesKey("ringtone_uri")
+    val IS_VIBRATION_ENABLED = booleanPreferencesKey("is_vibration_enabled")
+}
+
+class AlarmDefaultsRepository(private val dataStore: DataStore<Preferences>) {
+
+    val alarmDefaultsFlow: Flow<AlarmDefaults> = dataStore.data
+        .catch { emit(emptyPreferences()) }
+        .map { preferences ->
+            // TODO: Change these defaults
+            // Get preferences
+            val ringtoneUri = preferences[PreferencesKeys.RINGTONE_URI] ?: ""
+            val isVibrationEnabled = preferences[PreferencesKeys.IS_VIBRATION_ENABLED] ?: false
+
+            // Return AlarmDefaults
+            AlarmDefaults(ringtoneUri, isVibrationEnabled)
+        }
+
+    suspend fun updateDefaultRingtoneUri(defaultRingtoneUri: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.RINGTONE_URI] = defaultRingtoneUri
+        }
+    }
+
+    suspend fun updateVibration(vibrationDefault: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.IS_VIBRATION_ENABLED] = vibrationDefault
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsState.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsState.kt
@@ -1,0 +1,9 @@
+package com.example.alarmscratch.settings.data.repository
+
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
+
+sealed interface AlarmDefaultsState {
+    data object Loading : AlarmDefaultsState
+    data class Success(val alarmDefaults: AlarmDefaults) : AlarmDefaultsState
+    data class Error(val throwable: Throwable) : AlarmDefaultsState
+}

--- a/app/src/main/java/com/example/alarmscratch/settings/extension/_AlarmDefaults.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/extension/_AlarmDefaults.kt
@@ -1,0 +1,10 @@
+package com.example.alarmscratch.settings.extension
+
+import android.content.Context
+import android.media.Ringtone
+import com.example.alarmscratch.core.data.repository.RingtoneRepository
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
+
+// TODO: Do something better here. There's a similar method in _Alarm.kt as well.
+fun AlarmDefaults.getRingtone(context: Context): Ringtone =
+    RingtoneRepository(context).getRingtone(ringtoneUri)

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -50,6 +50,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.core.data.model.RingtoneData
+import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.shared.RowSelectionItem
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
@@ -80,12 +81,9 @@ fun AlarmDefaultsScreen(
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
         // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
         // then the new Ringtone's URI will be saved here.
-        val ringtonePickerScreenUri: String? =
-            navHostController
-                .currentBackStackEntry
-                ?.savedStateHandle
-                ?.get(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
-        alarmDefaultsViewModel.updateRingtone(ringtonePickerScreenUri)
+        alarmDefaultsViewModel.updateRingtone(
+            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+        )
 
         val context = LocalContext.current
         val coroutineScope = rememberCoroutineScope()
@@ -99,9 +97,7 @@ fun AlarmDefaultsScreen(
             ringtoneUri = alarmDefaults.ringtoneUri,
             isVibrationEnabled = alarmDefaults.isVibrationEnabled,
             saveAlarmDefaults = { coroutineScope.launch { alarmDefaultsViewModel.saveAlarmDefaults() } },
-            toggleVibration = { isVibrationEnabled ->
-                coroutineScope.launch { alarmDefaultsViewModel.updateVibration(isVibrationEnabled) }
-            },
+            toggleVibration = alarmDefaultsViewModel::toggleVibration,
             modifier = modifier
         )
     }
@@ -115,7 +111,7 @@ fun AlarmDefaultsScreenContent(
     ringtoneUri: String,
     isVibrationEnabled: Boolean,
     saveAlarmDefaults: () -> Unit,
-    toggleVibration: (Boolean) -> Unit,
+    toggleVibration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -231,7 +227,7 @@ fun AlarmAlertDefaults(
     navigateToRingtonePickerScreen: () -> Unit,
     selectedRingtone: String,
     isVibrationEnabled: Boolean,
-    toggleVibration: (Boolean) -> Unit,
+    toggleVibration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -260,12 +256,12 @@ fun AlarmAlertDefaults(
 
         // Vibration toggle
         RowSelectionItem(
-            rowOnClick = { toggleVibration(!isVibrationEnabled) },
+            rowOnClick = toggleVibration,
             rowLabelResId = R.string.alarm_create_edit_alarm_vibration_label,
             choiceComponent = {
                 Switch(
                     checked = isVibrationEnabled,
-                    onCheckedChange = { toggleVibration(!isVibrationEnabled) },
+                    onCheckedChange = { toggleVibration() },
                     colors = SwitchDefaults.colors(
                         checkedTrackColor = WayDarkerBoatSails,
                         uncheckedTrackColor = DarkVolcanicRock

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -1,4 +1,4 @@
-package com.example.alarmscratch.settings
+package com.example.alarmscratch.settings.ui.alarmdefaults
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
@@ -33,21 +33,23 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
+import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.ui.shared.RowSelectionItem
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
@@ -57,39 +59,71 @@ import com.example.alarmscratch.core.ui.theme.MediumVolcanicRock
 import com.example.alarmscratch.core.ui.theme.VolcanicRock
 import com.example.alarmscratch.core.ui.theme.WayDarkerBoatSails
 import com.example.alarmscratch.core.util.StatusBarUtil
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsState
+import com.example.alarmscratch.settings.extension.getRingtone
+import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmDefaultsScreen(
     navHostController: NavHostController,
-    modifier: Modifier = Modifier
+    navigateToRingtonePickerScreen: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    alarmDefaultsViewModel: AlarmDefaultsViewModel = viewModel(factory = AlarmDefaultsViewModel.Factory)
 ) {
     // Configure Status Bar
     StatusBarUtil.setDarkStatusBar()
 
-    // TODO: Temporary code
-    val alarmRingtoneName = "Temp Ringtone"
-    val navigateToRingtonePickerScreen = {}
+    // State
+    val alarmDefaultsState by alarmDefaultsViewModel.modifiedAlarmDefaults.collectAsState()
 
-    AlarmDefaultsScreenContent(
-        navHostController = navHostController,
-        navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
-        alarmRingtoneName = alarmRingtoneName,
-        modifier = modifier
-    )
+    if (alarmDefaultsState is AlarmDefaultsState.Success) {
+        // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
+        // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
+        // then the new Ringtone's URI will be saved here.
+        val ringtonePickerScreenUri: String? =
+            navHostController
+                .currentBackStackEntry
+                ?.savedStateHandle
+                ?.get(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+        alarmDefaultsViewModel.updateRingtone(ringtonePickerScreenUri)
+
+        val context = LocalContext.current
+        val coroutineScope = rememberCoroutineScope()
+        val alarmDefaults = (alarmDefaultsState as AlarmDefaultsState.Success).alarmDefaults
+        val ringtoneName = alarmDefaults.getRingtone(context).getTitle(context)
+
+        AlarmDefaultsScreenContent(
+            navHostController = navHostController,
+            navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
+            ringtoneName = ringtoneName,
+            ringtoneUri = alarmDefaults.ringtoneUri,
+            isVibrationEnabled = alarmDefaults.isVibrationEnabled,
+            saveAlarmDefaults = { coroutineScope.launch { alarmDefaultsViewModel.saveAlarmDefaults() } },
+            toggleVibration = { isVibrationEnabled ->
+                coroutineScope.launch { alarmDefaultsViewModel.updateVibration(isVibrationEnabled) }
+            },
+            modifier = modifier
+        )
+    }
 }
 
 @Composable
 fun AlarmDefaultsScreenContent(
     navHostController: NavHostController,
-    navigateToRingtonePickerScreen: () -> Unit,
-    alarmRingtoneName: String,
+    navigateToRingtonePickerScreen: (String) -> Unit,
+    ringtoneName: String,
+    ringtoneUri: String,
+    isVibrationEnabled: Boolean,
+    saveAlarmDefaults: () -> Unit,
+    toggleVibration: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             AlarmDefaultsTopAppBar(
                 navHostController = navHostController,
-                titleRes = R.string.settings_alarm_defaults
+                titleRes = R.string.settings_alarm_defaults,
+                saveAlarmDefaults = saveAlarmDefaults
             )
         },
         containerColor = MaterialTheme.colorScheme.surface,
@@ -143,8 +177,10 @@ fun AlarmDefaultsScreenContent(
 
             // Alarm Alert Defaults
             AlarmAlertDefaults(
-                navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
-                selectedRingtone = alarmRingtoneName
+                navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(ringtoneUri) },
+                selectedRingtone = ringtoneName,
+                isVibrationEnabled = isVibrationEnabled,
+                toggleVibration = toggleVibration
             )
         }
     }
@@ -153,7 +189,8 @@ fun AlarmDefaultsScreenContent(
 @Composable
 fun AlarmDefaultsTopAppBar(
     navHostController: NavHostController,
-    @StringRes titleRes: Int
+    @StringRes titleRes: Int,
+    saveAlarmDefaults: () -> Unit
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -177,7 +214,12 @@ fun AlarmDefaultsTopAppBar(
         }
 
         // Save Button
-        IconButton(onClick = {}) {
+        IconButton(
+            onClick = {
+                saveAlarmDefaults()
+                navHostController.popBackStack()
+            }
+        ) {
             Icon(imageVector = Icons.Default.Save, contentDescription = null)
         }
     }
@@ -188,12 +230,10 @@ fun AlarmDefaultsTopAppBar(
 fun AlarmAlertDefaults(
     navigateToRingtonePickerScreen: () -> Unit,
     selectedRingtone: String,
+    isVibrationEnabled: Boolean,
+    toggleVibration: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // TODO: Temporary state
-    var vibrationEnabled by rememberSaveable { mutableStateOf(false) }
-    val toggleVibration: () -> Unit = { vibrationEnabled = !vibrationEnabled }
-
     Column(modifier = modifier) {
         // Alert Icon and Text
         Row(modifier = Modifier.padding(start = 20.dp)) {
@@ -220,12 +260,12 @@ fun AlarmAlertDefaults(
 
         // Vibration toggle
         RowSelectionItem(
-            rowOnClick = toggleVibration,
+            rowOnClick = { toggleVibration(!isVibrationEnabled) },
             rowLabelResId = R.string.alarm_create_edit_alarm_vibration_label,
             choiceComponent = {
                 Switch(
-                    checked = vibrationEnabled,
-                    onCheckedChange = { toggleVibration() },
+                    checked = isVibrationEnabled,
+                    onCheckedChange = { toggleVibration(!isVibrationEnabled) },
                     colors = SwitchDefaults.colors(
                         checkedTrackColor = WayDarkerBoatSails,
                         uncheckedTrackColor = DarkVolcanicRock
@@ -247,7 +287,11 @@ private fun AlarmDefaultsScreenPreview() {
         AlarmDefaultsScreenContent(
             navHostController = rememberNavController(),
             navigateToRingtonePickerScreen = {},
-            alarmRingtoneName = sampleRingtoneData.name
+            ringtoneName = sampleRingtoneData.name,
+            ringtoneUri = sampleRingtoneData.fullUriString,
+            isVibrationEnabled = true,
+            saveAlarmDefaults = {},
+            toggleVibration = {}
         )
     }
 }
@@ -258,7 +302,8 @@ private fun AlarmDefaultsTopAppBarPreview() {
     AlarmScratchTheme {
         AlarmDefaultsTopAppBar(
             navHostController = rememberNavController(),
-            titleRes = R.string.settings_alarm_defaults
+            titleRes = R.string.settings_alarm_defaults,
+            saveAlarmDefaults = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
@@ -63,10 +63,12 @@ class AlarmDefaultsViewModel(private val alarmDefaultsRepository: AlarmDefaultsR
         }
     }
 
-    fun updateVibration(isVibrationEnabled: Boolean) {
+    fun toggleVibration() {
         if (_modifiedAlarmDefaults.value is AlarmDefaultsState.Success) {
             val alarmDefaults = (_modifiedAlarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
-            _modifiedAlarmDefaults.value = AlarmDefaultsState.Success(alarmDefaults.copy(isVibrationEnabled = isVibrationEnabled))
+            _modifiedAlarmDefaults.value = AlarmDefaultsState.Success(
+                alarmDefaults.copy(isVibrationEnabled = !alarmDefaults.isVibrationEnabled)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
@@ -1,0 +1,72 @@
+package com.example.alarmscratch.settings.ui.alarmdefaults
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.example.alarmscratch.core.data.model.RingtoneData
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsState
+import com.example.alarmscratch.settings.data.repository.alarmDefaultsDataStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class AlarmDefaultsViewModel(private val alarmDefaultsRepository: AlarmDefaultsRepository) : ViewModel() {
+
+    private val _modifiedAlarmDefaults: MutableStateFlow<AlarmDefaultsState> = MutableStateFlow(AlarmDefaultsState.Loading)
+    val modifiedAlarmDefaults: StateFlow<AlarmDefaultsState> = _modifiedAlarmDefaults.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            alarmDefaultsRepository.alarmDefaultsFlow
+                .map<AlarmDefaults, AlarmDefaultsState> { alarmDefaults -> AlarmDefaultsState.Success(alarmDefaults) }
+                .catch { throwable -> emit(AlarmDefaultsState.Error(throwable)) }
+                .collect { alarmDefaultsState -> _modifiedAlarmDefaults.value = alarmDefaultsState }
+        }
+    }
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                // TODO: Do something about this
+                val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+
+                return AlarmDefaultsViewModel(
+                    alarmDefaultsRepository = AlarmDefaultsRepository(application.alarmDefaultsDataStore)
+                ) as T
+            }
+        }
+    }
+
+    suspend fun saveAlarmDefaults() {
+        if (_modifiedAlarmDefaults.value is AlarmDefaultsState.Success) {
+            val alarmDefaults = (_modifiedAlarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
+            alarmDefaultsRepository.updateAlarmDefaults(alarmDefaults)
+        }
+    }
+
+    fun updateRingtone(ringtoneUri: String?) {
+        if (
+            _modifiedAlarmDefaults.value is AlarmDefaultsState.Success &&
+            ringtoneUri != null &&
+            ringtoneUri != RingtoneData.NO_RINGTONE_URI
+        ) {
+            val alarmDefaults = (_modifiedAlarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
+            _modifiedAlarmDefaults.value = AlarmDefaultsState.Success(alarmDefaults.copy(ringtoneUri = ringtoneUri))
+        }
+    }
+
+    fun updateVibration(isVibrationEnabled: Boolean) {
+        if (_modifiedAlarmDefaults.value is AlarmDefaultsState.Success) {
+            val alarmDefaults = (_modifiedAlarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
+            _modifiedAlarmDefaults.value = AlarmDefaultsState.Success(alarmDefaults.copy(isVibrationEnabled = isVibrationEnabled))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ksp = "1.9.22-1.0.17"
 room = "2.6.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
-dataStore = "1.1.1"
+preferencesDataStore = "1.1.1"
 espressoCore = "3.5.1"
 androidxLifecycle = "2.8.0"
 activityCompose = "1.9.0"
@@ -19,7 +19,7 @@ serialization = "1.6.3"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore" }
+androidx-preferences-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "preferencesDataStore" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,10 +6,12 @@ ksp = "1.9.22-1.0.17"
 room = "2.6.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
+dataStore = "1.1.1"
 espressoCore = "3.5.1"
 androidxLifecycle = "2.8.0"
 activityCompose = "1.9.0"
 composeBom = "2024.04.01"
+materialIcons = "1.6.6"
 navigationCompose = "2.8.0-rc01"
 serialization = "1.6.3"
 
@@ -17,6 +19,7 @@ serialization = "1.6.3"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
@@ -24,6 +27,7 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIcons" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
### Description
- Add `Preferences DataStore` dependency to gradle file
- Create `AlarmDefaultsRepository` and other DataStore related files, and link them to the `AlarmDefaultsScreen`, providing functionality.
- Refactor NavHostController code related to passing Ringtone Uri's from the `RingtonePickerScreen`, back to the previous screen (`AlarmCreationScreen`, `AlarmEditScreen`, `AlarmDefaultsScreen`).