### PR TITLE
Feature | Alarm Defaults on Alarm Creation

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
@@ -14,5 +14,6 @@ data class Alarm(
     val enabled: Boolean = true,
     val dateTime: LocalDateTime = LocalDateTimeUtil.nowTruncated(),
     val weeklyRepeater: WeeklyRepeater = WeeklyRepeater(),
-    val ringtoneUriString: String
+    val ringtoneUriString: String,
+    val isVibrationEnabled: Boolean = false
 )

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -17,7 +17,8 @@ val repeatingAlarm =
         //  Alarm is going to go off based on the WeeklyRepeater
         dateTime = getTomorrowAtTime24Hr(hour = 8, minute = 30, second = 0),
         weeklyRepeater = WeeklyRepeater(encodedRepeatingDays = tueWedThu),
-        ringtoneUriString = sampleRingtoneUriString
+        ringtoneUriString = sampleRingtoneUriString,
+        isVibrationEnabled = true
     )
 
 val todayAlarm =
@@ -26,7 +27,8 @@ val todayAlarm =
         enabled = true,
         dateTime = getTodayAtTime24Hr(hour = 23, minute = 59, second = 0),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString
+        ringtoneUriString = sampleRingtoneUriString,
+        isVibrationEnabled = false
     )
 
 val tomorrowAlarm =
@@ -35,7 +37,8 @@ val tomorrowAlarm =
         enabled = false,
         dateTime = getTomorrowAtTime24Hr(hour = 14, minute = 0, second = 0),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString
+        ringtoneUriString = sampleRingtoneUriString,
+        isVibrationEnabled = true
     )
 
 // TODO do exception handling for java code
@@ -45,7 +48,8 @@ val calendarAlarm =
         enabled = true,
         dateTime = LocalDateTime.parse("2024-12-25T00:05:00"),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString
+        ringtoneUriString = sampleRingtoneUriString,
+        isVibrationEnabled = false
     )
 
 // TODO do exception handling for java code
@@ -55,7 +59,8 @@ val consistentFutureAlarm: Alarm =
         enabled = true,
         dateTime = LocalDateTimeUtil.nowTruncated().plusHours(8).plusMinutes(45),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString
+        ringtoneUriString = sampleRingtoneUriString,
+        isVibrationEnabled = true
     )
 
 // YYYY-MM-DDTHH:MM:SS

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -63,6 +63,7 @@ fun AlarmCreationScreen(
             updateTime = alarmCreationViewModel::updateTime,
             addDay = alarmCreationViewModel::addDay,
             removeDay = alarmCreationViewModel::removeDay,
+            toggleVibration = alarmCreationViewModel::toggleVibration,
             modifier = modifier
         )
     }
@@ -83,7 +84,8 @@ private fun AlarmCreationScreenPreview() {
             alarm = Alarm(
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu),
-                ringtoneUriString = sampleRingtoneData.fullUriString
+                ringtoneUriString = sampleRingtoneData.fullUriString,
+                isVibrationEnabled = true
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
@@ -93,7 +95,8 @@ private fun AlarmCreationScreenPreview() {
             updateDate = {},
             updateTime = { _, _ -> },
             addDay = {},
-            removeDay = {}
+            removeDay = {},
+            toggleVibration = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -15,6 +15,7 @@ import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
+import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
@@ -30,37 +31,41 @@ fun AlarmCreationScreen(
     modifier: Modifier = Modifier,
     alarmCreationViewModel: AlarmCreationViewModel = viewModel(factory = AlarmCreationViewModel.Factory)
 ) {
-    // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
-    // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
-    // then the new Ringtone's URI will be saved here.
-    alarmCreationViewModel.updateRingtone(
-        navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
-    )
-
     // State
     val alarmState by alarmCreationViewModel.newAlarm.collectAsState()
-    val context = LocalContext.current
-    val coroutineScope = rememberCoroutineScope()
-    // This was extracted for previews, since previews can't actually "get a Ringtone"
-    // from anywhere, therefore they can't get a name to display in the preview.
-    val alarmRingtoneName = alarmState.getRingtone(context).getTitle(context)
 
-    AlarmCreateEditScreen(
-        navHostController = navHostController,
-        navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
-        titleRes = R.string.alarm_creation_screen_title,
-        alarm = alarmState,
-        alarmRingtoneName = alarmRingtoneName,
-        validateAlarm = alarmCreationViewModel::validateAlarm,
-        saveAlarm = { coroutineScope.launch { alarmCreationViewModel.saveAlarm() } },
-        scheduleAlarm = alarmCreationViewModel::scheduleAlarm,
-        updateName = alarmCreationViewModel::updateName,
-        updateDate = alarmCreationViewModel::updateDate,
-        updateTime = alarmCreationViewModel::updateTime,
-        addDay = alarmCreationViewModel::addDay,
-        removeDay = alarmCreationViewModel::removeDay,
-        modifier = modifier
-    )
+    if (alarmState is AlarmState.Success) {
+        // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
+        // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
+        // then the new Ringtone's URI will be saved here.
+        alarmCreationViewModel.updateRingtone(
+            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+        )
+
+        val context = LocalContext.current
+        val coroutineScope = rememberCoroutineScope()
+        val alarm = (alarmState as AlarmState.Success).alarm
+        // This was extracted for previews, since previews can't actually "get a Ringtone"
+        // from anywhere, therefore they can't get a name to display in the preview.
+        val alarmRingtoneName = alarm.getRingtone(context).getTitle(context)
+
+        AlarmCreateEditScreen(
+            navHostController = navHostController,
+            navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
+            titleRes = R.string.alarm_creation_screen_title,
+            alarm = alarm,
+            alarmRingtoneName = alarmRingtoneName,
+            validateAlarm = alarmCreationViewModel::validateAlarm,
+            saveAlarm = { coroutineScope.launch { alarmCreationViewModel.saveAlarm() } },
+            scheduleAlarm = alarmCreationViewModel::scheduleAlarm,
+            updateName = alarmCreationViewModel::updateName,
+            updateDate = alarmCreationViewModel::updateDate,
+            updateTime = alarmCreationViewModel::updateTime,
+            addDay = alarmCreationViewModel::addDay,
+            removeDay = alarmCreationViewModel::removeDay,
+            modifier = modifier
+        )
+    }
 }
 
 /*

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -52,7 +52,8 @@ class AlarmCreationViewModel(
                         _newAlarm.value = AlarmState.Success(
                             Alarm(
                                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
-                                ringtoneUriString = alarmDefaults.ringtoneUri
+                                ringtoneUriString = alarmDefaults.ringtoneUri,
+                                isVibrationEnabled = alarmDefaults.isVibrationEnabled
                             )
                         )
                     }
@@ -139,6 +140,13 @@ class AlarmCreationViewModel(
         ) {
             val alarm = (_newAlarm.value as AlarmState.Success).alarm
             _newAlarm.value = AlarmState.Success(alarm.copy(ringtoneUriString = ringtoneUriString))
+        }
+    }
+
+    fun toggleVibration() {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(isVibrationEnabled = !alarm.isVibrationEnabled))
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -1,34 +1,64 @@
 package com.example.alarmscratch.alarm.ui.alarmcreate
 
 import android.content.Context
-import android.media.RingtoneManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.alarmscratch.alarm.alarmexecution.AlarmSchedulerImpl
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.futurizeDateTime
 import com.example.alarmscratch.core.extension.isRepeating
 import com.example.alarmscratch.core.extension.nextRepeatingDate
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsState
+import com.example.alarmscratch.settings.data.repository.alarmDefaultsDataStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 
-class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : ViewModel() {
+class AlarmCreationViewModel(
+    private val alarmDefaultsRepository: AlarmDefaultsRepository,
+    private val alarmRepository: AlarmRepository
+) : ViewModel() {
 
-    private val _newAlarm = MutableStateFlow(
-        Alarm(
-            dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
-            ringtoneUriString = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)?.toString() ?: RingtoneData.NO_RINGTONE_URI
-        )
-    )
-    val newAlarm: StateFlow<Alarm> = _newAlarm.asStateFlow()
+    private val alarmDefaults: MutableStateFlow<AlarmDefaultsState> = MutableStateFlow(AlarmDefaultsState.Loading)
+    private val _newAlarm: MutableStateFlow<AlarmState> = MutableStateFlow(AlarmState.Loading)
+    val newAlarm: StateFlow<AlarmState> = _newAlarm.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            alarmDefaultsRepository.alarmDefaultsFlow
+                .map<AlarmDefaults, AlarmDefaultsState> { alarmDefaults -> AlarmDefaultsState.Success(alarmDefaults) }
+                .catch { throwable -> emit(AlarmDefaultsState.Error(throwable)) }
+                .collect { alarmDefaultsState ->
+                    // Get AlarmDefaultsState
+                    alarmDefaults.value = alarmDefaultsState
+
+                    // Create new Alarm with AlarmDefaults
+                    if (alarmDefaults.value is AlarmDefaultsState.Success) {
+                        val alarmDefaults = (alarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
+                        _newAlarm.value = AlarmState.Success(
+                            Alarm(
+                                dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
+                                ringtoneUriString = alarmDefaults.ringtoneUri
+                            )
+                        )
+                    }
+                }
+        }
+    }
 
     companion object {
 
@@ -39,6 +69,7 @@ class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : Vie
                 val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
 
                 return AlarmCreationViewModel(
+                    alarmDefaultsRepository = AlarmDefaultsRepository(application.alarmDefaultsDataStore),
                     alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao())
                 ) as T
             }
@@ -46,45 +77,76 @@ class AlarmCreationViewModel(private val alarmRepository: AlarmRepository) : Vie
     }
 
     suspend fun saveAlarm() {
-        if (_newAlarm.value.isRepeating()) {
-            alarmRepository.insertAlarm(_newAlarm.value.copy(dateTime = _newAlarm.value.nextRepeatingDate()))
-        } else {
-            alarmRepository.insertAlarm(_newAlarm.value)
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            if (alarm.isRepeating()) {
+                alarmRepository.insertAlarm(alarm.copy(dateTime = alarm.nextRepeatingDate()))
+            } else {
+                alarmRepository.insertAlarm(alarm)
+            }
         }
     }
 
     fun scheduleAlarm(context: Context) {
-        val alarmScheduler = AlarmSchedulerImpl(context)
-        alarmScheduler.scheduleAlarm(_newAlarm.value)
-    }
-
-    fun updateName(name: String) {
-        _newAlarm.value = _newAlarm.value.copy(name = name)
-    }
-
-    fun updateDate(date: LocalDate) {
-        _newAlarm.value = _newAlarm.value.copy(dateTime = _newAlarm.value.dateTime.withDayOfYear(date.dayOfYear))
-    }
-
-    fun updateTime(hour: Int, minute: Int) {
-        _newAlarm.value = _newAlarm.value.copy(
-            dateTime = _newAlarm.value.dateTime.withHour(hour).withMinute(minute).futurizeDateTime()
-        )
-    }
-
-    fun addDay(day: WeeklyRepeater.Day) {
-        _newAlarm.value = _newAlarm.value.copy(weeklyRepeater = _newAlarm.value.weeklyRepeater.addDay(day))
-    }
-
-    fun removeDay(day: WeeklyRepeater.Day) {
-        _newAlarm.value = _newAlarm.value.copy(weeklyRepeater = _newAlarm.value.weeklyRepeater.removeDay(day))
-    }
-
-    fun updateRingtone(ringtoneUriString: String?) {
-        if (ringtoneUriString != null && ringtoneUriString != RingtoneData.NO_RINGTONE_URI) {
-            _newAlarm.value = _newAlarm.value.copy(ringtoneUriString = ringtoneUriString)
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            AlarmSchedulerImpl(context).scheduleAlarm(alarm)
         }
     }
 
-    fun validateAlarm(): Boolean = _newAlarm.value.dateTime.isAfter(LocalDateTimeUtil.nowTruncated())
+    fun updateName(name: String) {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(name = name))
+        }
+    }
+
+    fun updateDate(date: LocalDate) {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(dateTime = alarm.dateTime.withDayOfYear(date.dayOfYear)))
+        }
+    }
+
+    fun updateTime(hour: Int, minute: Int) {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(
+                alarm.copy(dateTime = alarm.dateTime.withHour(hour).withMinute(minute).futurizeDateTime())
+            )
+        }
+    }
+
+    fun addDay(day: WeeklyRepeater.Day) {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(weeklyRepeater = alarm.weeklyRepeater.addDay(day)))
+        }
+    }
+
+    fun removeDay(day: WeeklyRepeater.Day) {
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(weeklyRepeater = alarm.weeklyRepeater.removeDay(day)))
+        }
+    }
+
+    fun updateRingtone(ringtoneUriString: String?) {
+        if (
+            _newAlarm.value is AlarmState.Success &&
+            ringtoneUriString != null &&
+            ringtoneUriString != RingtoneData.NO_RINGTONE_URI
+        ) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            _newAlarm.value = AlarmState.Success(alarm.copy(ringtoneUriString = ringtoneUriString))
+        }
+    }
+
+    fun validateAlarm(): Boolean =
+        if (_newAlarm.value is AlarmState.Success) {
+            val alarm = (_newAlarm.value as AlarmState.Success).alarm
+            alarm.dateTime.isAfter(LocalDateTimeUtil.nowTruncated())
+        } else {
+            false
+        }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -98,6 +98,7 @@ fun AlarmCreateEditScreen(
     updateTime: (Int, Int) -> Unit,
     addDay: (WeeklyRepeater.Day) -> Unit,
     removeDay: (WeeklyRepeater.Day) -> Unit,
+    toggleVibration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Configure Status Bar
@@ -197,6 +198,8 @@ fun AlarmCreateEditScreen(
             AlarmAlertSettings(
                 navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(alarm.ringtoneUriString) },
                 selectedRingtone = alarmRingtoneName,
+                isVibrationEnabled = alarm.isVibrationEnabled,
+                toggleVibration = toggleVibration,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -359,12 +362,10 @@ fun DayOfWeekButton(
 fun AlarmAlertSettings(
     navigateToRingtonePickerScreen: () -> Unit,
     selectedRingtone: String,
+    isVibrationEnabled: Boolean,
+    toggleVibration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // TODO: Temporary state
-    var vibrationEnabled by rememberSaveable { mutableStateOf(false) }
-    val toggleVibration: () -> Unit = { vibrationEnabled = !vibrationEnabled }
-
     Column(modifier = modifier) {
         // Alert Icon and Text
         Row(modifier = Modifier.padding(start = 20.dp)) {
@@ -395,7 +396,7 @@ fun AlarmAlertSettings(
             rowLabelResId = R.string.alarm_create_edit_alarm_vibration_label,
             choiceComponent = {
                 Switch(
-                    checked = vibrationEnabled,
+                    checked = isVibrationEnabled,
                     onCheckedChange = { toggleVibration() },
                     colors = SwitchDefaults.colors(
                         checkedTrackColor = WayDarkerBoatSails,
@@ -422,7 +423,8 @@ private fun AlarmCreateEditScreenPreview() {
             alarm = Alarm(
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu),
-                ringtoneUriString = sampleRingtoneData.fullUriString
+                ringtoneUriString = sampleRingtoneData.fullUriString,
+                isVibrationEnabled = true
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
@@ -432,7 +434,8 @@ private fun AlarmCreateEditScreenPreview() {
             updateDate = {},
             updateTime = { _, _ -> },
             addDay = {},
-            removeDay = {}
+            removeDay = {},
+            toggleVibration = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -63,6 +63,7 @@ fun AlarmEditScreen(
             updateTime = alarmEditViewModel::updateTime,
             addDay = alarmEditViewModel::addDay,
             removeDay = alarmEditViewModel::removeDay,
+            toggleVibration = alarmEditViewModel::toggleVibration,
             modifier = modifier
         )
     }
@@ -84,7 +85,8 @@ private fun AlarmEditScreenPreview() {
                 name = "Meeting",
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu),
-                ringtoneUriString = sampleRingtoneData.fullUriString
+                ringtoneUriString = sampleRingtoneData.fullUriString,
+                isVibrationEnabled = true
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
@@ -94,7 +96,8 @@ private fun AlarmEditScreenPreview() {
             updateDate = {},
             updateTime = { _, _ -> },
             addDay = {},
-            removeDay = {}
+            removeDay = {},
+            toggleVibration = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -129,6 +129,13 @@ class AlarmEditViewModel(
         }
     }
 
+    fun toggleVibration() {
+        if (_modifiedAlarm.value is AlarmState.Success) {
+            val alarm = (_modifiedAlarm.value as AlarmState.Success).alarm
+            _modifiedAlarm.value = AlarmState.Success(alarm.copy(isVibrationEnabled = !alarm.isVibrationEnabled))
+        }
+    }
+
     fun validateAlarm(): Boolean =
         if (_modifiedAlarm.value is AlarmState.Success) {
             val alarm = (_modifiedAlarm.value as AlarmState.Success).alarm

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -86,6 +86,8 @@ fun AlarmDefaultsScreen(
         val context = LocalContext.current
         val coroutineScope = rememberCoroutineScope()
         val alarmDefaults = (alarmDefaultsState as AlarmDefaultsState.Success).alarmDefaults
+        // This was extracted for previews, since previews can't actually "get a Ringtone"
+        // from anywhere, therefore they can't get a name to display in the preview.
         val ringtoneName = alarmDefaults.getRingtone(context).getTitle(context)
 
         AlarmDefaultsScreenContent(


### PR DESCRIPTION
### Description
- Integrate `AlarmDefaultsRepository` into `AlarmCreationViewModel` so that newly created Alarms will start out with the defaults from the DataStore
- Add `isVibrationEnabled` property to `Alarms` so that `AlarmDefaults.isVibrationEnabled` has something to map to
  - `Alarm.isVibrationEnabled` will of course also be used in the future to determine whether vibration should occur when an Alarm goes off. Vibration functionality has not yet been implemented.