### PR TITLE
Feature | Fix New Alarm Scheduling ID Issue

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
@@ -13,13 +13,16 @@ interface AlarmDao {
 
     // TODO: Think about onConflict param more
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(alarm: Alarm)
+    suspend fun insert(alarm: Alarm): Long
 
     @Update
     suspend fun update(alarm: Alarm)
 
     @Delete
     suspend fun delete(alarm: Alarm)
+
+    @Query("SELECT * from alarms WHERE id = :id")
+    suspend fun getAlarm(id: Int): Alarm
 
     @Query("SELECT * from alarms WHERE id = :id")
     fun getAlarmFlow(id: Int): Flow<Alarm>

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmRepository.kt
@@ -12,6 +12,8 @@ class AlarmRepository(private val alarmDao: AlarmDao) {
 
     suspend fun deleteAlarm(alarm: Alarm) = alarmDao.delete(alarm = alarm)
 
+    suspend fun getAlarm(id: Int): Alarm = alarmDao.getAlarm(id = id)
+
     fun getAlarmFlow(id: Int): Flow<Alarm> = alarmDao.getAlarmFlow(id = id)
 
     fun getAllAlarmsFlow(): Flow<List<Alarm>> = alarmDao.getAllAlarmsFlow()

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -3,7 +3,6 @@ package com.example.alarmscratch.alarm.ui.alarmcreate
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,7 +21,6 @@ import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
 import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
-import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmCreationScreen(
@@ -43,7 +41,6 @@ fun AlarmCreationScreen(
         )
 
         val context = LocalContext.current
-        val coroutineScope = rememberCoroutineScope()
         val alarm = (alarmState as AlarmState.Success).alarm
         // This was extracted for previews, since previews can't actually "get a Ringtone"
         // from anywhere, therefore they can't get a name to display in the preview.
@@ -56,8 +53,7 @@ fun AlarmCreationScreen(
             alarm = alarm,
             alarmRingtoneName = alarmRingtoneName,
             validateAlarm = alarmCreationViewModel::validateAlarm,
-            saveAlarm = { coroutineScope.launch { alarmCreationViewModel.saveAlarm() } },
-            scheduleAlarm = alarmCreationViewModel::scheduleAlarm,
+            saveAndScheduleAlarm = { alarmCreationViewModel.saveAndScheduleAlarm(context) },
             updateName = alarmCreationViewModel::updateName,
             updateDate = alarmCreationViewModel::updateDate,
             updateTime = alarmCreationViewModel::updateTime,
@@ -89,8 +85,7 @@ private fun AlarmCreationScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
-            saveAlarm = {},
-            scheduleAlarm = {},
+            saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -1,6 +1,5 @@
 package com.example.alarmscratch.alarm.ui.alarmcreateedit
 
-import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -91,8 +90,7 @@ fun AlarmCreateEditScreen(
     alarm: Alarm,
     alarmRingtoneName: String,
     validateAlarm: () -> Boolean,
-    saveAlarm: () -> Unit,
-    scheduleAlarm: (Context) -> Unit,
+    saveAndScheduleAlarm: () -> Unit,
     updateName: (String) -> Unit,
     updateDate: (LocalDate) -> Unit,
     updateTime: (Int, Int) -> Unit,
@@ -105,7 +103,6 @@ fun AlarmCreateEditScreen(
     StatusBarUtil.setDarkStatusBar()
 
     // State
-    val context = LocalContext.current
     val snackbarString = stringResource(id = R.string.validation_alarm_in_past)
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
@@ -128,9 +125,7 @@ fun AlarmCreateEditScreen(
                     IconButton(
                         onClick = {
                             if (validateAlarm()) {
-                                saveAlarm()
-                                // TODO: Only schedule alarm if enabled
-                                scheduleAlarm(context)
+                                saveAndScheduleAlarm()
                                 navHostController.popBackStack()
                             } else {
                                 showSnackbar(snackbarString)
@@ -428,8 +423,7 @@ private fun AlarmCreateEditScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
-            saveAlarm = {},
-            scheduleAlarm = {},
+            saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -3,7 +3,6 @@ package com.example.alarmscratch.alarm.ui.alarmedit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,7 +21,6 @@ import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
 import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
-import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmEditScreen(
@@ -43,7 +41,6 @@ fun AlarmEditScreen(
         )
 
         val context = LocalContext.current
-        val coroutineScope = rememberCoroutineScope()
         val alarm = (alarmState as AlarmState.Success).alarm
         // This was extracted for previews, since previews can't actually "get a Ringtone"
         // from anywhere, therefore they can't get a name to display in the preview.
@@ -56,8 +53,7 @@ fun AlarmEditScreen(
             alarm = alarm,
             alarmRingtoneName = alarmRingtoneName,
             validateAlarm = alarmEditViewModel::validateAlarm,
-            saveAlarm = { coroutineScope.launch { alarmEditViewModel.saveAlarm() } },
-            scheduleAlarm = alarmEditViewModel::scheduleAlarm,
+            saveAndScheduleAlarm = { alarmEditViewModel.saveAndScheduleAlarm(context) },
             updateName = alarmEditViewModel::updateName,
             updateDate = alarmEditViewModel::updateDate,
             updateTime = alarmEditViewModel::updateTime,
@@ -90,8 +86,7 @@ private fun AlarmEditScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             validateAlarm = { true },
-            saveAlarm = {},
-            scheduleAlarm = {},
+            saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },


### PR DESCRIPTION
### Description
- Fix issue where newly created Alarms wouldn't display the Alert Notification when they would go off. With the functionality before this PR the Alarm would have to be rescheduled (ex: via Device Reset, Alarm Edit, Alarm disable/enable) for the Alert Notification to actually be shown. Explaining this issue is a bit complicated, so I will explain in 4 parts: Setup, Issue, Solution, and Questions.
  - **Setup:** `AlarmCreationViewModel` does not save anything to the Database until the User hits the Save Button to save the Alarm. Until the User hits the Save Button, the New Alarm is held in a temporary Alarm object for edits. Furthermore, that temporary Alarm is created with the `default Alarm.id value of 0`. This default value has to be 0 due to the fact that `Alarm.id` is the Primary Key for Alarms in the Database, and it's using `@PrimaryKey(autoGenerate = true)`. When using `@PrimaryKey(autoGenerate = true)` on a non-nullable `Int`, `Insert` methods treat 0 as "not set" while inserting them. Therefore, 0 is required here for proper Primary Key management via `Room`.
  - **Issue:** Because of the aforementioned, the Alarm is scheduled with `AlarmManager` with a `Broadcast PendingIntent` that contains an Alarm ID of 0 (from the aforementioned temporary Alarm object in `AlarmCreationViewModel`). This Alarm ID is eventually passed to `startForeground()` in `AlarmNotificationService`. According to the `Service.startForeground()` documentation, the ID passed to `startForeground()` must not be 0. If you pass 0 then nothing will happen.
  - **Solution:** Instead of scheduling the Alarm in `AlarmCreationViewModel` with the temporary Alarm, we instead save the Alarm to the Database first in order to get a real ID on it, then retrieve that Alarm from the Database so we can schedule the Alarm with the real ID.
    - Note: I've also duplicated this behavior in `AlarmEditViewModel` for good measure.
  - **Questions:**
    - Q: Why store temporary Alarm objects in the ViewModels? Why not not do everything in the Database?
      - A: I don't want to push changes to the Database until the User is sure that's what they want. If I do everything in the Database, then I'd have to delete/undo the new/edited Alarm in the Database if they cancel, which would be unnecessary overhead.
    - Q: Why not just pass something other than the Alarm ID to `startForeground()`?
      - A: I may do that eventually, but even if I do, I want to be sure I'm passing the full blown fully up to date real Alarm data to the `AlarmManager` when scheduling. This way there's no question as to whether or not things were up to date because the Alarm data that's passed to `AlarmManager` will be from the up to date real Alarm from the Database, with the Database being the single source of truth in regards to scheduling Alarms. Therefore, either way I still want this specific fix from this PR.