### PR TITLE
Feature | Fix Alarm Cancellation

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerImpl.kt
@@ -48,11 +48,20 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
     }
 
     override fun cancelAlarm(alarmExecutionData: AlarmExecutionData) {
+        // Create PendingIntent to cancel Alarm
+        val alarmIntent = Intent(context, AlarmActionReceiver::class.java).apply {
+            // This needs to be the same as the scheduling action.
+            // This is because the Intent must pass Intent.filterEquals(), which looks at the flag,
+            // in order for the AlarmManager to be able to find the Alarm with the "same Intent" to cancel.
+            action = AlarmActionReceiver.ACTION_EXECUTE_ALARM
+        }
+
+        // Cancel Alarm
         alarmManager.cancel(
             PendingIntent.getBroadcast(
                 context,
                 alarmExecutionData.id,
-                Intent(context, AlarmActionReceiver::class.java),
+                alarmIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         )

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -42,7 +42,7 @@ fun AlarmListScreen(
             alarmList = alarmList,
             timeDisplay = generalSettings.timeDisplay,
             onAlarmToggled = { context, alarm -> coroutineScope.launch { alarmListViewModel.toggleAlarm(context, alarm) } },
-            onAlarmDeleted = { alarm -> coroutineScope.launch { alarmListViewModel.deleteAlarm(alarm) } },
+            onAlarmDeleted = { context, alarm -> coroutineScope.launch { alarmListViewModel.cancelAndDeleteAlarm(context, alarm) } },
             navigateToAlarmEditScreen = navigateToAlarmEditScreen,
             modifier = modifier
         )
@@ -54,7 +54,7 @@ fun AlarmListScreenContent(
     alarmList: List<Alarm>,
     timeDisplay: TimeDisplay,
     onAlarmToggled: (Context, Alarm) -> Unit,
-    onAlarmDeleted: (Alarm) -> Unit,
+    onAlarmDeleted: (Context, Alarm) -> Unit,
     navigateToAlarmEditScreen: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -96,7 +96,7 @@ private fun AlarmListScreenPreview() {
             alarmList = alarmSampleDataHardCodedIds,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -114,7 +114,7 @@ private fun AlarmListScreenNoAlarmsPreview() {
             alarmList = emptyList(),
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -84,7 +84,8 @@ class AlarmListViewModel(
         AlarmSchedulerImpl(context).cancelAlarm(alarm.toAlarmExecutionData())
     }
 
-    suspend fun deleteAlarm(alarm: Alarm) {
+    suspend fun cancelAndDeleteAlarm(context: Context, alarm: Alarm) {
+        cancelAlarm(context, alarm)
         alarmRepository.deleteAlarm(alarm)
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmCard.kt
@@ -62,7 +62,7 @@ fun AlarmCard(
     alarm: Alarm,
     timeDisplay: TimeDisplay,
     onAlarmToggled: (Context, Alarm) -> Unit,
-    onAlarmDeleted: (Alarm) -> Unit,
+    onAlarmDeleted: (Context, Alarm) -> Unit,
     navigateToAlarmEditScreen: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -136,7 +136,7 @@ fun AlarmCard(
             AlarmCardDropdownMenu(
                 isExpanded = isDropdownExpanded,
                 onExpansionToggled = onDropdownExpansionToggled,
-                onAlarmDeleted = { onAlarmDeleted(alarm) },
+                onAlarmDeleted = { onAlarmDeleted(context, alarm) },
                 modifier = Modifier.align(Alignment.TopEnd)
             )
 
@@ -293,7 +293,7 @@ private fun AlarmCardRepeating12HourPreview() {
             alarm = repeatingAlarm,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -311,7 +311,7 @@ private fun AlarmCardRepeating24HourPreview() {
             alarm = todayAlarm,
             timeDisplay = TimeDisplay.TwentyFourHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -329,7 +329,7 @@ private fun SnoozedAlarmPreview() {
             alarm = snoozedAlarm,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -360,7 +360,7 @@ private fun AlarmCardTodayPreview() {
             alarm = todayAlarm,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -378,7 +378,7 @@ private fun AlarmCardTomorrowPreview() {
             alarm = tomorrowAlarm,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )
@@ -396,7 +396,7 @@ private fun AlarmCardCalendarPreview() {
             alarm = calendarAlarm,
             timeDisplay = TimeDisplay.TwelveHour,
             onAlarmToggled = { _, _ -> },
-            onAlarmDeleted = {},
+            onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
         )

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -159,7 +159,7 @@ private fun CoreScreenAlarmListPreview() {
                 alarmList = alarmListState.alarmList,
                 timeDisplay = TimeDisplay.TwelveHour,
                 onAlarmToggled = { _, _ -> },
-                onAlarmDeleted = {},
+                onAlarmDeleted = { _, _ -> },
                 navigateToAlarmEditScreen = {},
                 modifier = Modifier.padding(20.dp)
             )
@@ -194,7 +194,7 @@ private fun CoreScreenAlarmListNoAlarmsPreview() {
                 alarmList = alarmListState.alarmList,
                 timeDisplay = TimeDisplay.TwelveHour,
                 onAlarmToggled = { _, _ -> },
-                onAlarmDeleted = {},
+                onAlarmDeleted = { _, _ -> },
                 navigateToAlarmEditScreen = {},
                 modifier = Modifier.padding(20.dp)
             )


### PR DESCRIPTION
### Description
- Fix issue where Alarm cancellation wasn't cancelling Alarms
  - This was happening because there was no action being set on the Intent. According to the documentation, `AlarmManager.cancel()` cancels all Alarms with "matching Intents". This is determined by `Intent.filterEquals()`, which checks various Intent properties, including the action. Since I had not set any action on the cancellation Intent, cancellation was doing nothing.
- Add Alarm cancellation to Alarm deletion in `AlarmCard`