### PR TITLE
Feature | Resizable Next Alarm Cloud

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -71,12 +71,12 @@ val snoozedAlarm =
     Alarm(
         name = "Gym",
         enabled = true,
-        dateTime = getFutureTime(plusHours = 0, plusMinutes = 30),
+        dateTime = LocalDateTimeUtil.nowTruncated(),
         weeklyRepeater = WeeklyRepeater(),
         ringtoneUriString = sampleRingtoneUriString,
         isVibrationEnabled = true,
-        snoozeDateTime = getFutureTime(plusHours = 0, plusMinutes = 30).plusMinutes(10),
-        snoozeDuration = 10
+        snoozeDateTime = LocalDateTimeUtil.nowTruncated().plusMinutes(25),
+        snoozeDuration = 25
     )
 
 // YYYY-MM-DDTHH:MM:SS
@@ -105,5 +105,12 @@ private fun getTodayAtTime24Hr(hour: Int, minute: Int): LocalDateTime =
 private fun getTomorrowAtTime24Hr(hour: Int, minute: Int): LocalDateTime =
     getTodayAtTime24Hr(hour, minute).plusDays(1)
 
-private fun getFutureTime(plusHours: Long, plusMinutes: Long): LocalDateTime =
-    LocalDateTimeUtil.nowTruncated().plusHours(plusHours).plusMinutes(plusMinutes)
+private fun getFutureTime(
+    plusDays: Long = 0,
+    plusHours: Long = 0,
+    plusMinutes: Long = 0
+): LocalDateTime =
+    LocalDateTimeUtil.nowTruncated()
+        .plusDays(plusDays)
+        .plusHours(plusHours)
+        .plusMinutes(plusMinutes)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -32,6 +32,7 @@ import com.example.alarmscratch.core.navigation.AlarmNavHost
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.navigation.NavComponent
 import com.example.alarmscratch.core.ui.core.component.LavaFloatingActionButton
+import com.example.alarmscratch.core.ui.core.component.NextAlarmCloudContent
 import com.example.alarmscratch.core.ui.core.component.SkylineHeader
 import com.example.alarmscratch.core.ui.core.component.SkylineHeaderContent
 import com.example.alarmscratch.core.ui.core.component.VolcanoNavigationBar
@@ -143,18 +144,22 @@ private fun CoreScreenAlarmListPreview() {
         CoreScreenContent(
             header = {
                 SkylineHeaderContent(
-                    selectedNavComponentDest = selectedNavComponentDest,
-                    nextAlarmState = AlarmState.Success(alarmSampleDataHardCodedIds.first())
+                    nextAlarmIndicator = {
+                        NextAlarmCloudContent(
+                            selectedNavComponentDest = selectedNavComponentDest,
+                            nextAlarmState = AlarmState.Success(alarmSampleDataHardCodedIds.first())
+                        )
+                    }
                 )
             },
+            onFabClicked = {},
             navigationBar = {
                 VolcanoNavigationBar(
                     selectedNavComponentDest = selectedNavComponentDest,
                     onDestinationChange = {},
                     modifier = Modifier.fillMaxWidth()
                 )
-            },
-            onFabClicked = {}
+            }
         ) {
             AlarmListScreenContent(
                 alarmList = alarmListState.alarmList,
@@ -178,18 +183,22 @@ private fun CoreScreenAlarmListNoAlarmsPreview() {
         CoreScreenContent(
             header = {
                 SkylineHeaderContent(
-                    selectedNavComponentDest = selectedNavComponentDest,
-                    nextAlarmState = AlarmState.Error(Throwable())
+                    nextAlarmIndicator = {
+                        NextAlarmCloudContent(
+                            selectedNavComponentDest = selectedNavComponentDest,
+                            nextAlarmState = AlarmState.Error(Throwable())
+                        )
+                    }
                 )
             },
+            onFabClicked = {},
             navigationBar = {
                 VolcanoNavigationBar(
                     selectedNavComponentDest = selectedNavComponentDest,
                     onDestinationChange = {},
                     modifier = Modifier.fillMaxWidth()
                 )
-            },
-            onFabClicked = {}
+            }
         ) {
             AlarmListScreenContent(
                 alarmList = alarmListState.alarmList,
@@ -212,18 +221,22 @@ private fun CoreScreenSettingsPreview() {
         CoreScreenContent(
             header = {
                 SkylineHeaderContent(
-                    selectedNavComponentDest = selectedNavComponentDest,
-                    nextAlarmState = AlarmState.Success(alarmSampleDataHardCodedIds.first())
+                    nextAlarmIndicator = {
+                        NextAlarmCloudContent(
+                            selectedNavComponentDest = selectedNavComponentDest,
+                            nextAlarmState = AlarmState.Success(alarmSampleDataHardCodedIds.first())
+                        )
+                    }
                 )
             },
+            onFabClicked = {},
             navigationBar = {
                 VolcanoNavigationBar(
                     selectedNavComponentDest = selectedNavComponentDest,
                     onDestinationChange = {},
                     modifier = Modifier.fillMaxWidth()
                 )
-            },
-            onFabClicked = {}
+            }
         ) {
             SettingsScreen(
                 navigateToGeneralSettingsScreen = {},

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -46,10 +46,10 @@ import java.time.LocalDateTime
 fun NextAlarmCloud(
     selectedNavComponentDest: Destination,
     modifier: Modifier = Modifier,
-    skylineHeaderViewModel: SkylineHeaderViewModel = viewModel(factory = SkylineHeaderViewModel.Factory)
+    nextAlarmCloudViewModel: NextAlarmCloudViewModel = viewModel(factory = NextAlarmCloudViewModel.Factory)
 ) {
     // State
-    val nextAlarmState by skylineHeaderViewModel.nextAlarm.collectAsState()
+    val nextAlarmState by nextAlarmCloudViewModel.nextAlarm.collectAsState()
 
     NextAlarmCloudContent(
         selectedNavComponentDest = selectedNavComponentDest,
@@ -64,6 +64,7 @@ fun NextAlarmCloudContent(
     nextAlarmState: AlarmState,
     modifier: Modifier = Modifier
 ) {
+    // Countdown Text Properties
     var fontSize: TextUnit
     var lineHeight: TextUnit
 

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -1,0 +1,274 @@
+package com.example.alarmscratch.core.ui.core.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Alarm
+import androidx.compose.material.icons.filled.AlarmOff
+import androidx.compose.material.icons.filled.Snooze
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.data.preview.consistentFutureAlarm
+import com.example.alarmscratch.alarm.data.preview.snoozedAlarm
+import com.example.alarmscratch.alarm.data.repository.AlarmState
+import com.example.alarmscratch.core.extension.isSnoozed
+import com.example.alarmscratch.core.extension.toCountdownString
+import com.example.alarmscratch.core.navigation.Destination
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.ui.theme.InCloudBlack
+import java.time.LocalDateTime
+
+@Composable
+fun NextAlarmCloud(
+    selectedNavComponentDest: Destination,
+    modifier: Modifier = Modifier,
+    skylineHeaderViewModel: SkylineHeaderViewModel = viewModel(factory = SkylineHeaderViewModel.Factory)
+) {
+    // State
+    val nextAlarmState by skylineHeaderViewModel.nextAlarm.collectAsState()
+
+    NextAlarmCloudContent(
+        selectedNavComponentDest = selectedNavComponentDest,
+        nextAlarmState = nextAlarmState,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun NextAlarmCloudContent(
+    selectedNavComponentDest: Destination,
+    nextAlarmState: AlarmState,
+    modifier: Modifier = Modifier
+) {
+    var fontSize: TextUnit
+    var lineHeight: TextUnit
+
+    Box(
+        modifier = modifier
+            .clip(shape = CircleShape)
+            .background(color = Color.White)
+    ) {
+        // Next Alarm Icon and Text
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .width(120.dp)
+                .heightIn(min = 50.dp)
+                .padding(horizontal = 8.dp)
+        ) {
+            if (selectedNavComponentDest == Destination.AlarmListScreen) {
+                // Next Alarm Data
+                val alarmIcon =
+                    if (nextAlarmState is AlarmState.Success) {
+                        if (nextAlarmState.alarm.isSnoozed()) {
+                            Icons.Default.Snooze
+                        } else {
+                            Icons.Default.Alarm
+                        }
+                    } else {
+                        Icons.Default.AlarmOff
+                    }
+                val countdownText =
+                    if (nextAlarmState is AlarmState.Success) {
+                        nextAlarmState.alarm.toCountdownString(LocalContext.current)
+                    } else {
+                        stringResource(id = R.string.no_active_alarms)
+                    }
+
+                // You cannot simultaneously apply both fontSize and lineHeight to the same AnnotatedString.
+                // Therefore a normal String is used, and these values will be applied directly to the Text Composable.
+                if (countdownText.length > 7) { // Small
+                    fontSize = 14.sp
+                    lineHeight = 16.sp
+                } else if (countdownText.length in 4..7) { // Medium
+                    // Default Text properties
+                    fontSize = TextUnit.Unspecified
+                    lineHeight = TextUnit.Unspecified
+                } else { // Large: length < 4
+                    fontSize = 20.sp
+                    lineHeight = 22.sp
+                }
+
+                // Alarm Icon
+                Icon(
+                    imageVector = alarmIcon,
+                    contentDescription = null,
+                    tint = InCloudBlack,
+                    modifier = Modifier.padding(end = 4.dp, bottom = 2.dp)
+                )
+                // Countdown Text
+                Text(
+                    text = countdownText,
+                    color = InCloudBlack,
+                    fontSize = fontSize,
+                    fontWeight = FontWeight.SemiBold,
+                    lineHeight = lineHeight
+                )
+            }
+        }
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudNoAlarmsSmallText1Preview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Error(Throwable())
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudSmallText2Preview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Success(
+                    alarm = consistentFutureAlarm.copy(
+                        dateTime = LocalDateTime.now().plusDays(12).plusHours(10).plusMinutes(45)
+                    )
+                )
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudMediumText1Preview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Success(
+                    alarm = consistentFutureAlarm.copy(
+                        dateTime = LocalDateTime.now().plusHours(20).plusMinutes(45)
+                    )
+                )
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudMediumText2Preview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudSnoozedAlarmLargeTextPreview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Success(alarm = snoozedAlarm)
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+@Composable
+private fun NextAlarmCloudSettingsScreenPreview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.SettingsScreen,
+                nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -78,7 +78,6 @@ fun NextAlarmCloudContent(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .align(Alignment.Center)
                 .width(120.dp)
                 .heightIn(min = 50.dp)
                 .padding(horizontal = 8.dp)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloudViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloudViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-class SkylineHeaderViewModel(private val alarmRepository: AlarmRepository) : ViewModel() {
+class NextAlarmCloudViewModel(private val alarmRepository: AlarmRepository) : ViewModel() {
 
     val nextAlarm: StateFlow<AlarmState> =
         alarmRepository.getAllAlarmsFlow()
@@ -43,7 +43,7 @@ class SkylineHeaderViewModel(private val alarmRepository: AlarmRepository) : Vie
                 // TODO: Do something about this
                 val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
 
-                return SkylineHeaderViewModel(
+                return NextAlarmCloudViewModel(
                     alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao())
                 ) as T
             }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
@@ -3,66 +3,43 @@ package com.example.alarmscratch.core.ui.core.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Alarm
-import androidx.compose.material.icons.filled.AlarmOff
-import androidx.compose.material.icons.filled.Snooze
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.preview.consistentFutureAlarm
 import com.example.alarmscratch.alarm.data.preview.snoozedAlarm
 import com.example.alarmscratch.alarm.data.repository.AlarmState
-import com.example.alarmscratch.core.extension.isSnoozed
-import com.example.alarmscratch.core.extension.toCountdownString
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.shared.SailBoat
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatHull
 import com.example.alarmscratch.core.ui.theme.BoatSails
-import com.example.alarmscratch.core.ui.theme.InCloudBlack
 import com.example.alarmscratch.core.ui.theme.SkyBlue
+import java.time.LocalDateTime
 
 @Composable
 fun SkylineHeader(
     selectedNavComponentDest: Destination,
-    modifier: Modifier = Modifier,
-    skylineHeaderViewModel: SkylineHeaderViewModel = viewModel(factory = SkylineHeaderViewModel.Factory)
+    modifier: Modifier = Modifier
 ) {
-    // State
-    val nextAlarmState by skylineHeaderViewModel.nextAlarm.collectAsState()
-
     SkylineHeaderContent(
-        selectedNavComponentDest = selectedNavComponentDest,
-        nextAlarmState = nextAlarmState,
+        nextAlarmIndicator = { NextAlarmCloud(selectedNavComponentDest = selectedNavComponentDest) },
         modifier = modifier
     )
 }
 
 @Composable
 fun SkylineHeaderContent(
-    selectedNavComponentDest: Destination,
-    nextAlarmState: AlarmState,
+    nextAlarmIndicator: @Composable () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -95,66 +72,25 @@ fun SkylineHeaderContent(
                     .background(color = Color.White)
             )
 
-            // Small part of Large Cloud
+            // Next Alarm Indicator
             Box(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .width(75.dp)
-                    .height(30.dp)
-                    .offset(x = (-40).dp, y = 30.dp)
-                    .clip(shape = CircleShape)
-                    .background(color = Color.White)
-            )
-
-            // Main part of Large Cloud
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .width(110.dp)
-                    .height(50.dp)
                     .offset(x = 0.dp, y = 5.dp)
-                    .clip(shape = CircleShape)
-                    .background(color = Color.White)
             ) {
-                // Next Alarm Icon and Text
-                Row(
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if (selectedNavComponentDest == Destination.AlarmListScreen) {
-                        // Next Alarm Info
-                        val alarmIcon =
-                            if (nextAlarmState is AlarmState.Success) {
-                                if (nextAlarmState.alarm.isSnoozed()) {
-                                    Icons.Default.Snooze
-                                } else {
-                                    Icons.Default.Alarm
-                                }
-                            } else {
-                                Icons.Default.AlarmOff
-                            }
-                        val countdownText =
-                            if (nextAlarmState is AlarmState.Success) {
-                                nextAlarmState.alarm.toCountdownString(LocalContext.current)
-                            } else {
-                                stringResource(id = R.string.no_active_alarms)
-                            }
+                // Small part of Cloud
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .width(75.dp)
+                        .height(30.dp)
+                        .offset(x = (-22).dp, y = 5.dp)
+                        .clip(shape = CircleShape)
+                        .background(color = Color.White)
+                )
 
-                        // Alarm Icon
-                        Icon(
-                            imageVector = alarmIcon,
-                            tint = InCloudBlack,
-                            contentDescription = null,
-                            modifier = Modifier.padding(end = 4.dp, bottom = 2.dp)
-                        )
-                        // Countdown Text
-                        Text(
-                            text = countdownText,
-                            fontWeight = FontWeight.SemiBold,
-                            color = InCloudBlack
-                        )
-                    }
-                }
+                // Large part of Cloud
+                nextAlarmIndicator()
             }
 
             // Sun
@@ -198,11 +134,34 @@ fun SkylineHeaderContent(
 
 @Preview
 @Composable
-private fun SkylineHeaderStandardAlarmPreview() {
+private fun SkylineHeaderOneLineAlarmPreview() {
     AlarmScratchTheme {
         SkylineHeaderContent(
-            selectedNavComponentDest = Destination.AlarmListScreen,
-            nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+            nextAlarmIndicator = {
+                NextAlarmCloudContent(
+                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+                )
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SkylineHeaderTwoLineAlarmPreview() {
+    AlarmScratchTheme {
+        SkylineHeaderContent(
+            nextAlarmIndicator = {
+                NextAlarmCloudContent(
+                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    nextAlarmState = AlarmState.Success(
+                        alarm = consistentFutureAlarm.copy(
+                            dateTime = LocalDateTime.now().plusDays(12).plusHours(10).plusMinutes(45)
+                        )
+                    )
+                )
+            }
         )
     }
 }
@@ -212,8 +171,12 @@ private fun SkylineHeaderStandardAlarmPreview() {
 private fun SkylineHeaderSnoozedAlarmPreview() {
     AlarmScratchTheme {
         SkylineHeaderContent(
-            selectedNavComponentDest = Destination.AlarmListScreen,
-            nextAlarmState = AlarmState.Success(alarm = snoozedAlarm)
+            nextAlarmIndicator = {
+                NextAlarmCloudContent(
+                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    nextAlarmState = AlarmState.Success(alarm = snoozedAlarm)
+                )
+            }
         )
     }
 }
@@ -223,8 +186,12 @@ private fun SkylineHeaderSnoozedAlarmPreview() {
 private fun SkylineHeaderNoAlarmsPreview() {
     AlarmScratchTheme {
         SkylineHeaderContent(
-            selectedNavComponentDest = Destination.AlarmListScreen,
-            nextAlarmState = AlarmState.Error(Throwable())
+            nextAlarmIndicator = {
+                NextAlarmCloudContent(
+                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    nextAlarmState = AlarmState.Error(Throwable())
+                )
+            }
         )
     }
 }
@@ -234,8 +201,12 @@ private fun SkylineHeaderNoAlarmsPreview() {
 private fun SkylineHeaderSettingsScreenPreview() {
     AlarmScratchTheme {
         SkylineHeaderContent(
-            selectedNavComponentDest = Destination.SettingsScreen,
-            nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+            nextAlarmIndicator = {
+                NextAlarmCloudContent(
+                    selectedNavComponentDest = Destination.SettingsScreen,
+                    nextAlarmState = AlarmState.Success(alarm = consistentFutureAlarm)
+                )
+            }
         )
     }
 }


### PR DESCRIPTION
### Description
- Make the Next Alarm Indicator cloud resizable
- Extract the Next Alarm Indicator cloud into `NextAlarmCloud.kt`
- Rename `SkylineHeaderViewModel` to `NextAlarmCloudViewModel`
  - Move usage from `SkylineHeader` to `NextAlarmCloud`
- Slight modifications to Alarms and functions in `AlarmPreviewData`