### PR TITLE
Feature | Alarm Countdown Spacing Rounding

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -114,9 +114,18 @@ fun Alarm.getRingtone(context: Context): Ringtone =
  * Formatting
  */
 
-// TODO: This function returns some weird values if the dateTime is in the past
 fun Alarm.toCountdownString(context: Context): String {
-    val secondsTillNextAlarm = LocalDateTime.now().until(snoozeDateTime ?: dateTime, ChronoUnit.SECONDS).toDouble()
+    // Don't truncate the current time since the seconds are used here
+    val now = LocalDateTime.now()
+    val alarmExecutionTime = snoozeDateTime ?: dateTime
+
+    // If this method is called with a LocalDateTime that is not in the future,
+    // just return "0m" by default. This method is not set up to calculate for the past.
+    if (!alarmExecutionTime.isAfter(now)) {
+        return "0${context.getString(R.string.minute_abbreviation)}"
+    }
+
+    val secondsTillNextAlarm = now.until(snoozeDateTime ?: dateTime, ChronoUnit.SECONDS).toDouble()
 
     // Days
     var days = floor(secondsTillNextAlarm / 86400)

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -117,15 +117,15 @@ fun Alarm.getRingtone(context: Context): Ringtone =
 fun Alarm.toCountdownString(context: Context): String {
     // Don't truncate the current time since the seconds are used here
     val now = LocalDateTime.now()
-    val alarmExecutionTime = snoozeDateTime ?: dateTime
+    val alarmExecutionDateTime = snoozeDateTime ?: dateTime
 
     // If this method is called with a LocalDateTime that is not in the future,
     // just return "0m" by default. This method is not set up to calculate for the past.
-    if (!alarmExecutionTime.isAfter(now)) {
+    if (!alarmExecutionDateTime.isAfter(now)) {
         return "0${context.getString(R.string.minute_abbreviation)}"
     }
 
-    val secondsTillNextAlarm = now.until(snoozeDateTime ?: dateTime, ChronoUnit.SECONDS).toDouble()
+    val secondsTillNextAlarm = now.until(alarmExecutionDateTime, ChronoUnit.SECONDS).toDouble()
 
     // Days
     var days = floor(secondsTillNextAlarm / 86400)
@@ -142,7 +142,7 @@ fun Alarm.toCountdownString(context: Context): String {
             // Special Case:
             // 59.X minutes where X > 0
             //   - Round minutes down to 0, and add 1 to hour to avoid displaying "60m"
-            //   - ex: We don't want to round "1hr 59.5m" to "1hr 60m", instead we want "2h".
+            //   - Ex: We don't want to round "1hr 59.5m" to "1hr 60m", instead we want "2h"
             //   - NOTE: If hours is 23, then we should continue this same logic upwards because
             //     we also do not want to round "1d 23h 59.5m" "1d 24h", instead we want "2d".
             if (hours >= 23) {

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -152,7 +152,13 @@ fun Alarm.toCountdownString(context: Context): String {
     val stringBuilder = StringBuilder().apply {
         if (days >= 1) append("${days.toInt()}${context.getString(R.string.day_abbreviation)}")
         if (hours >= 1) append("${hours.toInt()}${context.getString(R.string.hour_abbreviation)}")
-        if (minutes >= 1) append("${minutes.toInt()}${context.getString(R.string.minute_abbreviation)}")
+        if (minutes >= 1) {
+            // Add "<" if there's only one minute left
+            if (minutes == 1.0) {
+                append("${context.getString(R.string.less_than_symbol)} ")
+            }
+            append("${minutes.toInt()}${context.getString(R.string.minute_abbreviation)}")
+        }
     }
 
     // Add spaces between each section

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -106,11 +106,11 @@ fun NextAlarmCloudContent(
                 if (countdownText.length > 7) { // Small
                     fontSize = 14.sp
                     lineHeight = 16.sp
-                } else if (countdownText.length in 4..7) { // Medium
+                } else if (countdownText.length in 5..7) { // Medium
                     // Default Text properties
                     fontSize = TextUnit.Unspecified
                     lineHeight = TextUnit.Unspecified
-                } else { // Large: length < 4
+                } else { // Large: length < 5
                     fontSize = 20.sp
                     lineHeight = 22.sp
                 }
@@ -236,7 +236,33 @@ private fun NextAlarmCloudMediumText2Preview() {
     backgroundColor = 0xFFc2e0ff
 )
 @Composable
-private fun NextAlarmCloudSnoozedAlarmLargeTextPreview() {
+private fun NextAlarmCloudLargeText1Preview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+        ) {
+            NextAlarmCloudContent(
+                selectedNavComponentDest = Destination.AlarmListScreen,
+                nextAlarmState = AlarmState.Success(
+                    alarm = consistentFutureAlarm.copy(
+                        dateTime = LocalDateTime.now().plusMinutes(1)
+                    )
+                )
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFc2e0ff
+)
+
+@Composable
+private fun NextAlarmCloudSnoozedAlarmLargeText2Preview() {
     AlarmScratchTheme {
         Box(
             contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -35,12 +35,12 @@ import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.preview.consistentFutureAlarm
 import com.example.alarmscratch.alarm.data.preview.snoozedAlarm
 import com.example.alarmscratch.alarm.data.repository.AlarmState
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.isSnoozed
 import com.example.alarmscratch.core.extension.toCountdownString
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.InCloudBlack
-import java.time.LocalDateTime
 
 @Composable
 fun NextAlarmCloud(
@@ -177,7 +177,7 @@ private fun NextAlarmCloudSmallText2Preview() {
                 selectedNavComponentDest = Destination.AlarmListScreen,
                 nextAlarmState = AlarmState.Success(
                     alarm = consistentFutureAlarm.copy(
-                        dateTime = LocalDateTime.now().plusDays(12).plusHours(10).plusMinutes(45)
+                        dateTime = LocalDateTimeUtil.nowTruncated().plusDays(12).plusHours(10).plusMinutes(45)
                     )
                 )
             )
@@ -202,7 +202,7 @@ private fun NextAlarmCloudMediumText1Preview() {
                 selectedNavComponentDest = Destination.AlarmListScreen,
                 nextAlarmState = AlarmState.Success(
                     alarm = consistentFutureAlarm.copy(
-                        dateTime = LocalDateTime.now().plusHours(20).plusMinutes(45)
+                        dateTime = LocalDateTimeUtil.nowTruncated().plusHours(20).plusMinutes(45)
                     )
                 )
             )
@@ -248,7 +248,7 @@ private fun NextAlarmCloudLargeText1Preview() {
                 selectedNavComponentDest = Destination.AlarmListScreen,
                 nextAlarmState = AlarmState.Success(
                     alarm = consistentFutureAlarm.copy(
-                        dateTime = LocalDateTime.now().plusMinutes(1)
+                        dateTime = LocalDateTimeUtil.nowTruncated().plusMinutes(1)
                     )
                 )
             )

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
@@ -18,13 +18,13 @@ import androidx.compose.ui.unit.dp
 import com.example.alarmscratch.alarm.data.preview.consistentFutureAlarm
 import com.example.alarmscratch.alarm.data.preview.snoozedAlarm
 import com.example.alarmscratch.alarm.data.repository.AlarmState
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.shared.SailBoat
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatHull
 import com.example.alarmscratch.core.ui.theme.BoatSails
 import com.example.alarmscratch.core.ui.theme.SkyBlue
-import java.time.LocalDateTime
 
 @Composable
 fun SkylineHeader(
@@ -157,7 +157,7 @@ private fun SkylineHeaderTwoLineAlarmPreview() {
                     selectedNavComponentDest = Destination.AlarmListScreen,
                     nextAlarmState = AlarmState.Success(
                         alarm = consistentFutureAlarm.copy(
-                            dateTime = LocalDateTime.now().plusDays(12).plusHours(10).plusMinutes(45)
+                            dateTime = LocalDateTimeUtil.nowTruncated().plusDays(12).plusHours(10).plusMinutes(45)
                         )
                     )
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,10 +8,11 @@
         ** CoreScreen **
         ****************
     -->
-    <!-- SkylineHeader -->
+    <!-- NextAlarmCloud -->
     <string name="day_abbreviation">d</string>
     <string name="hour_abbreviation">h</string>
     <string name="minute_abbreviation">m</string>
+    <string name="less_than_symbol">&lt;</string>
     <string name="no_active_alarms">No Active Alarms</string>
     <!-- VolcanoNavigationBar -->
     <string name="nav_alarm">Alarm</string>


### PR DESCRIPTION
### Description

`Alarm.toCountdownString()` in `_Alarm.kt`
- Fix an issue where there was a missing space between `days` and `minutes` if there were no `hours`
- Fix an issue where rounding was not bubbling up to higher time slots
  - Ex: "1h 59.5m" was rounding to "1h 60m" rather than "2h". Same for hours -> days.
- Add "<" to the beginning of the Countdown String if there's 1m or less remaining
  - Any value of 60 seconds or less will display "< 1m"
- Add special case to return "0m" if the Alarm is not set in the future
<br>

General
- Increase lower end cutoff for Medium sized font for the Countdown String from `length == 4` to `length == 5` in `NextAlarmCloud`
- Modify previews in `SkylineHeader` and `NextAlarmCloud`