### PR TITLE
Feature | Fix Alarm Countdown Text Logic

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -163,7 +163,7 @@ fun Alarm.toCountdownString(context: Context): String {
         if (hours >= 1) append("${hours.toInt()}${context.getString(R.string.hour_abbreviation)}")
         if (minutes >= 1) {
             // Add "<" if there's only one minute left
-            if (minutes == 1.0) {
+            if (minutes == 1.0 && hours == 0.0 && days == 0.0) {
                 append("${context.getString(R.string.less_than_symbol)} ")
             }
             append("${minutes.toInt()}${context.getString(R.string.minute_abbreviation)}")


### PR DESCRIPTION
### Description
- Fix issue where the Alarm Countdown Text was displaying "<" before minutes when it should not have.
  - Before: "<" was always in front of minutes when `minutes == 1`, even if there were hours or days left. For example, it would incorrectly display the Countdown Text as "1d 2h < 1m" when it should be "1d 2h 1m".
  - After: Countdown Text only displays "<" in front of minutes when there is a total time of 1 minute or less until the next Alarm goes off.