### PR TITLE
Feature | Implement Alarm Partial WakeLock

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
@@ -51,10 +51,7 @@ class AlarmActionReceiver : BroadcastReceiver() {
     }
 
     private fun executeAlarm(context: Context, intent: Intent) {
-        // TODO: Grab a Wake Lock here. According to the AlarmManager docs, AlarmManger automatically grabs a CPU Wake Lock
-        //  and holds it until BroadcastReceiver.onReceive() completes. It also explicitly states that because of this, the
-        //  phone may sleep *immediately* after onReceive() completes, so if you call Context.startService() from inside
-        //  onReceive() then the phone may sleep before the Service is started.
+        WakeLockManager.acquireWakeLock(context)
 
         // Display Alarm Notification
         intent.extras?.let { extrasBundle ->

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -120,6 +120,9 @@ class AlarmNotificationService : Service() {
         // Stop Vibration
         VibrationController.stopVibration(applicationContext)
 
+        // Release WakeLock
+        WakeLockManager.releaseWakeLock()
+
         // Stop Service, which dismisses the Notification
         stopSelf()
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
@@ -38,10 +38,11 @@ object AlarmScheduler {
     }
 
     fun cancelAlarm(context: Context, alarmExecutionData: AlarmExecutionData) {
-        // Create PendingIntent to cancel Alarm
+        // Create PendingIntent to cancel Alarm.
+        // This Intent is never executed. It is only used by the AlarmManager for Alarm cancellation.
         val alarmIntent = Intent(context, AlarmActionReceiver::class.java).apply {
-            // This needs to be the same as the scheduling action.
-            // This is because the Intent must pass Intent.filterEquals(), which looks at the flag,
+            // This action needs to be the same as the scheduling action.
+            // This is because the Intent must pass Intent.filterEquals(), which looks at the action among other things,
             // in order for the AlarmManager to be able to find the Alarm with the "same Intent" to cancel.
             action = AlarmActionReceiver.ACTION_EXECUTE_ALARM
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/WakeLockManager.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/WakeLockManager.kt
@@ -1,0 +1,26 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import android.content.Context
+import android.os.PowerManager
+import android.os.PowerManager.WakeLock
+
+object WakeLockManager {
+
+    // TODO: Modify Tag
+    private const val PARTIAL_WAKE_LOCK_TAG = "alarmscratch:partial_wake_lock_tag"
+    private var partialWakeLock: WakeLock? = null
+
+    fun acquireWakeLock(context: Context) {
+        if (partialWakeLock == null) {
+            val powerManager = context.applicationContext.getSystemService(PowerManager::class.java)
+            partialWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, PARTIAL_WAKE_LOCK_TAG)
+
+            // Acquire WakeLock with 10min timeout
+            partialWakeLock?.acquire(10 * 60 * 1000L)
+        }
+    }
+
+    fun releaseWakeLock() {
+        partialWakeLock?.release().also { partialWakeLock = null }
+    }
+}


### PR DESCRIPTION
### Description
- Implement a partial `WakeLock` to ensure that the `AlarmNotificationService` gets run after being launched from `AlarmActionReceiver`
  - This is necessary due to the way the `AlarmManager` deals with `..._WAKEUP` Alarms. According to the documentation, the AlarmManager wakes the device up by acquiring a `CPU WakeLock`, and holds it as long as the Alarm's `BroadcastReceiver's` `onReceive()` method is executing. As soon as onReceive() finishes, the WakeLock is released. Because of this, as explicitly stated in the documentation, if you launch a `Service` from inside `onReceive()` it may not have a chance to actually start before the AlarmManager's WakeLock is released, so you must acquire your own WakeLock in order to ensure the Service is actually started.
    - The documentation isn't perfectly clear on this so some assumption is necessary, but after lots of research and looking at the documentation, it seems as though the AlarmManager only guarantees a hold on its WakeLock for BroadcastReceivers. Therefore, you must use a BroadcastReceiver in the Intent/PendingIntent passed to the AlarmManager when scheduling the Alarm if you want the AlarmManager to hold this WakeLock for you. Furthermore, Notifications are handled via Foreground Services, and displaying Status Bar/Full Screen Notifications is standard behavior for Alarms. Therefore you must unfortunately deal with this `AlarmManager -> BroadcastReceiver -> Service` WakeLock issue because you will need to launch a Foreground Service from your Alarm's BroadcastReceiver in order to display a Status Bar/Full Screen Notification.
  - From the documentation: https://developer.android.com/reference/android/app/AlarmManager
    - `The Alarm Manager holds a CPU wake lock as long as the alarm receiver's onReceive() method is executing. This guarantees that the phone will not sleep until you have finished handling the broadcast. Once onReceive() returns, the Alarm Manager releases this wake lock. This means that the phone will in some cases sleep as soon as your onReceive() method completes. If your alarm receiver called Context.startService(), it is possible that the phone will sleep before the requested service is launched. To prevent this, your BroadcastReceiver and Service will need to implement a separate wake lock policy to ensure that the phone continues running until the service becomes available.`