### PR TITLE
Feature | Update Date Picker Headline

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -259,7 +259,7 @@ fun DateTimeSettings(
     // Date Selection Dialog
     if (showDateSelectionDialog) {
         DateSelectionDialog(
-            alarmTime = alarm.dateTime.toLocalTime(),
+            dateTime = alarm.dateTime,
             onCancel = toggleDateSelectionDialog,
             onConfirm = { date ->
                 updateDate(date)

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDate.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDate.kt
@@ -1,0 +1,19 @@
+package com.example.alarmscratch.core.extension
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+object LocalDateUtil {
+    fun fromUtcMillis(utcTimeMillis: Long): LocalDate =
+        Instant.ofEpochMilli(utcTimeMillis)
+            .atZone(ZoneId.of("UTC"))
+            .toLocalDate()
+}
+
+/*
+ * Utility
+ */
+
+fun LocalDate.toUtcMillis(): Long =
+    atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()


### PR DESCRIPTION
### Description
 - Fix an issue where the `DateSelectionDialog` wasn't getting the `Alarm's` `DateTime`
   - This was causing there to be no initial selection when opening the `DateSelectionDialog`, which was in turn causing the `DateSelectionDialog's` headline to not initially display anything.