### PR TITLE
Feature | Alarm Validation

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -16,6 +16,7 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
+import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
@@ -34,6 +35,7 @@ fun AlarmCreationScreen(
     // State
     val alarmState by alarmCreationViewModel.newAlarm.collectAsState()
     val generalSettingsState by alarmCreationViewModel.generalSettings.collectAsState()
+    val isAlarmNameValid by alarmCreationViewModel.isAlarmNameValid.collectAsState()
 
     if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
@@ -57,7 +59,6 @@ fun AlarmCreationScreen(
             alarm = alarm,
             alarmRingtoneName = alarmRingtoneName,
             timeDisplay = generalSettings.timeDisplay,
-            validateAlarm = alarmCreationViewModel::validateAlarm,
             saveAndScheduleAlarm = { alarmCreationViewModel.saveAndScheduleAlarm(context) },
             updateName = alarmCreationViewModel::updateName,
             updateDate = alarmCreationViewModel::updateDateAndResetWeeklyRepeater,
@@ -66,6 +67,8 @@ fun AlarmCreationScreen(
             removeDay = alarmCreationViewModel::removeDay,
             toggleVibration = alarmCreationViewModel::toggleVibration,
             updateSnoozeDuration = alarmCreationViewModel::updateSnoozeDuration,
+            validateAlarm = alarmCreationViewModel::validateAlarm,
+            isAlarmNameValid = isAlarmNameValid,
             modifier = modifier
         )
     }
@@ -92,7 +95,6 @@ private fun AlarmCreationScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             timeDisplay = TimeDisplay.TwelveHour,
-            validateAlarm = { true },
             saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
@@ -100,7 +102,9 @@ private fun AlarmCreationScreenPreview() {
             addDay = {},
             removeDay = {},
             toggleVibration = {},
-            updateSnoozeDuration = {}
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Success()
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -38,10 +38,10 @@ fun AlarmCreationScreen(
     // State
     val alarmState by alarmCreationViewModel.newAlarm.collectAsState()
     val generalSettingsState by alarmCreationViewModel.generalSettings.collectAsState()
-    val isAlarmNameValid by alarmCreationViewModel.isAlarmNameValid.collectAsState()
+    val isNameValid by alarmCreationViewModel.isNameValid.collectAsState()
 
     // Flow
-    val snackbarFlow = alarmCreationViewModel.snackbarChannelFlow
+    val snackbarChannelFlow = alarmCreationViewModel.snackbarChannelFlow
 
     if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
@@ -73,8 +73,8 @@ fun AlarmCreationScreen(
             removeDay = alarmCreationViewModel::removeDay,
             toggleVibration = alarmCreationViewModel::toggleVibration,
             updateSnoozeDuration = alarmCreationViewModel::updateSnoozeDuration,
-            isAlarmNameValid = isAlarmNameValid,
-            snackbarFlow = snackbarFlow,
+            isNameValid = isNameValid,
+            snackbarChannelFlow = snackbarChannelFlow,
             modifier = modifier
         )
     }
@@ -112,8 +112,8 @@ private fun AlarmCreationScreenPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Success(),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -16,7 +16,7 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
-import com.example.alarmscratch.alarm.validation.AlarmValidator
+import com.example.alarmscratch.alarm.validation.ValidationError
 import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
@@ -87,7 +87,7 @@ fun AlarmCreationScreen(
 @Preview
 @Composable
 private fun AlarmCreationScreenPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -66,6 +66,8 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.AlarmDays
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.DateSelectionDialog
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.TimeSelectionDialog
+import com.example.alarmscratch.alarm.validation.AlarmValidator
+import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.extension.get12HourTime
 import com.example.alarmscratch.core.extension.get24HourTime
 import com.example.alarmscratch.core.extension.getAmPm
@@ -94,7 +96,6 @@ fun AlarmCreateEditScreen(
     alarm: Alarm,
     alarmRingtoneName: String,
     timeDisplay: TimeDisplay,
-    validateAlarm: () -> Boolean,
     saveAndScheduleAlarm: () -> Unit,
     updateName: (String) -> Unit,
     updateDate: (LocalDate) -> Unit,
@@ -103,6 +104,8 @@ fun AlarmCreateEditScreen(
     removeDay: (WeeklyRepeater.Day) -> Unit,
     toggleVibration: () -> Unit,
     updateSnoozeDuration: (Int) -> Unit,
+    validateAlarm: () -> Boolean,
+    isAlarmNameValid: ValidationResult<AlarmValidator.AlarmValidationError>,
     modifier: Modifier = Modifier
 ) {
     // Configure Status Bar
@@ -170,12 +173,21 @@ fun AlarmCreateEditScreen(
                     .padding(start = 20.dp, top = 20.dp, end = 20.dp)
                     .fillMaxWidth()
             ) {
-                // TODO: Add validation
                 // Alarm Name
                 OutlinedTextField(
                     value = alarm.name,
                     onValueChange = { updateName(it) },
                     placeholder = { Text(text = stringResource(id = R.string.alarm_name_placeholder), color = LightVolcanicRock) },
+                    supportingText = {
+                        Text(
+                            text = if (isAlarmNameValid is ValidationResult.Error) {
+                                isAlarmNameValid.error.toErrorString(LocalContext.current)
+                            } else {
+                                "" // Empty String prevents Error text from shifting UI
+                            }
+                        )
+                    },
+                    isError = isAlarmNameValid is ValidationResult.Error,
                     singleLine = true,
                     colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = DarkerBoatSails),
                     modifier = Modifier.padding(0.dp)
@@ -484,7 +496,6 @@ private fun AlarmCreateEditScreen12HourPreview() {
             alarm = repeatingAlarm,
             alarmRingtoneName = sampleRingtoneData.name,
             timeDisplay = TimeDisplay.TwelveHour,
-            validateAlarm = { true },
             saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
@@ -492,7 +503,9 @@ private fun AlarmCreateEditScreen12HourPreview() {
             addDay = {},
             removeDay = {},
             toggleVibration = {},
-            updateSnoozeDuration = {}
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Success()
         )
     }
 }
@@ -508,7 +521,6 @@ private fun AlarmCreateEditScreen24HourPreview() {
             alarm = calendarAlarm,
             alarmRingtoneName = sampleRingtoneData.name,
             timeDisplay = TimeDisplay.TwentyFourHour,
-            validateAlarm = { true },
             saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
@@ -516,7 +528,59 @@ private fun AlarmCreateEditScreen24HourPreview() {
             addDay = {},
             removeDay = {},
             toggleVibration = {},
-            updateSnoozeDuration = {}
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Success()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
+    AlarmScratchTheme {
+        AlarmCreateEditScreen(
+            navHostController = rememberNavController(),
+            navigateToRingtonePickerScreen = {},
+            titleRes = R.string.alarm_creation_screen_title,
+            alarm = repeatingAlarm.copy(name = "Illegal.String"),
+            alarmRingtoneName = sampleRingtoneData.name,
+            timeDisplay = TimeDisplay.TwelveHour,
+            saveAndScheduleAlarm = {},
+            updateName = {},
+            updateDate = {},
+            updateTime = { _, _ -> },
+            addDay = {},
+            removeDay = {},
+            toggleVibration = {},
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Error(AlarmValidator.AlarmValidationError.ILLEGAL_CHARACTER)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AlarmCreateEditScreenErrorOnlyWhitespacePreview() {
+    AlarmScratchTheme {
+        AlarmCreateEditScreen(
+            navHostController = rememberNavController(),
+            navigateToRingtonePickerScreen = {},
+            titleRes = R.string.alarm_creation_screen_title,
+            alarm = repeatingAlarm.copy(name = " "),
+            alarmRingtoneName = sampleRingtoneData.name,
+            timeDisplay = TimeDisplay.TwelveHour,
+            saveAndScheduleAlarm = {},
+            updateName = {},
+            updateDate = {},
+            updateTime = { _, _ -> },
+            addDay = {},
+            removeDay = {},
+            toggleVibration = {},
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Error(AlarmValidator.AlarmValidationError.ONLY_WHITESPACE)
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -193,7 +193,7 @@ fun AlarmCreateEditScreen(
                     supportingText = {
                         Text(
                             text = if (isNameValid is ValidationResult.Error) {
-                                isNameValid.error.toInlineErrorString(context)
+                                isNameValid.error.toInlineString(context)
                             } else {
                                 "" // Empty String prevents Error text from shifting UI
                             }
@@ -500,7 +500,7 @@ fun SnoozeSettings(
 @Preview
 @Composable
 private fun AlarmCreateEditScreen12HourPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {
@@ -528,7 +528,7 @@ private fun AlarmCreateEditScreen12HourPreview() {
 @Preview
 @Composable
 private fun AlarmCreateEditScreen24HourPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {
@@ -556,7 +556,7 @@ private fun AlarmCreateEditScreen24HourPreview() {
 @Preview
 @Composable
 private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {
@@ -584,7 +584,7 @@ private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
 @Preview
 @Composable
 private fun AlarmCreateEditScreenErrorOnlyWhitespacePreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Snooze
@@ -184,6 +185,11 @@ fun AlarmCreateEditScreen(
                     value = alarm.name,
                     onValueChange = { updateName(it) },
                     placeholder = { Text(text = stringResource(id = R.string.alarm_name_placeholder), color = LightVolcanicRock) },
+                    trailingIcon = if (isNameValid is ValidationResult.Error) {
+                        { Icon(imageVector = Icons.Default.Error, contentDescription = null) }
+                    } else {
+                        null
+                    },
                     supportingText = {
                         Text(
                             text = if (isNameValid is ValidationResult.Error) {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -71,6 +71,7 @@ import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.AlarmDays
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.DateSelectionDialog
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.component.TimeSelectionDialog
 import com.example.alarmscratch.alarm.validation.AlarmValidator
+import com.example.alarmscratch.alarm.validation.ValidationError
 import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.extension.get12HourTime
 import com.example.alarmscratch.core.extension.get24HourTime
@@ -112,8 +113,8 @@ fun AlarmCreateEditScreen(
     removeDay: (WeeklyRepeater.Day) -> Unit,
     toggleVibration: () -> Unit,
     updateSnoozeDuration: (Int) -> Unit,
-    isAlarmNameValid: ValidationResult<AlarmValidator.NameError>,
-    snackbarFlow: Flow<ValidationResult.Error<AlarmValidator.DateTimeError>>,
+    isNameValid: ValidationResult<AlarmValidator.NameError>,
+    snackbarChannelFlow: Flow<ValidationResult.Error<ValidationError>>,
     modifier: Modifier = Modifier
 ) {
     // Configure Status Bar
@@ -125,8 +126,8 @@ fun AlarmCreateEditScreen(
     // TODO: Clean this up before PR
     val context = LocalContext.current
 
-    ObserveAsEvent(flow = snackbarFlow) { validationResult ->
-        snackbarHostState.showSnackbar(message = validationResult.error.toErrorString(context))
+    ObserveAsEvent(flow = snackbarChannelFlow) { validationResult ->
+        snackbarHostState.showSnackbar(message = validationResult.error.toSnackbarString(context))
     }
 
     Scaffold(
@@ -179,14 +180,14 @@ fun AlarmCreateEditScreen(
                     placeholder = { Text(text = stringResource(id = R.string.alarm_name_placeholder), color = LightVolcanicRock) },
                     supportingText = {
                         Text(
-                            text = if (isAlarmNameValid is ValidationResult.Error) {
-                                isAlarmNameValid.error.toErrorString(LocalContext.current)
+                            text = if (isNameValid is ValidationResult.Error) {
+                                isNameValid.error.toInlineErrorString(context)
                             } else {
                                 "" // Empty String prevents Error text from shifting UI
                             }
                         )
                     },
-                    isError = isAlarmNameValid is ValidationResult.Error,
+                    isError = isNameValid is ValidationResult.Error,
                     singleLine = true,
                     colors = OutlinedTextFieldDefaults.colors(focusedBorderColor = DarkerBoatSails),
                     modifier = Modifier.padding(0.dp)
@@ -518,8 +519,8 @@ private fun AlarmCreateEditScreen12HourPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Success(),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }
@@ -546,8 +547,8 @@ private fun AlarmCreateEditScreen24HourPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Success(),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }
@@ -574,8 +575,8 @@ private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Error(AlarmValidator.NameError.ILLEGAL_CHARACTER),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Error(AlarmValidator.NameError.ILLEGAL_CHARACTER),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }
@@ -602,8 +603,8 @@ private fun AlarmCreateEditScreenErrorOnlyWhitespacePreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Error(AlarmValidator.NameError.ONLY_WHITESPACE),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Error(AlarmValidator.NameError.ONLY_WHITESPACE),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -16,6 +16,7 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
+import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
@@ -34,6 +35,7 @@ fun AlarmEditScreen(
     // State
     val alarmState by alarmEditViewModel.modifiedAlarm.collectAsState()
     val generalSettingsState by alarmEditViewModel.generalSettings.collectAsState()
+    val isAlarmNameValid by alarmEditViewModel.isAlarmNameValid.collectAsState()
 
     if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
@@ -57,7 +59,6 @@ fun AlarmEditScreen(
             alarm = alarm,
             alarmRingtoneName = alarmRingtoneName,
             timeDisplay = generalSettings.timeDisplay,
-            validateAlarm = alarmEditViewModel::validateAlarm,
             saveAndScheduleAlarm = { alarmEditViewModel.saveAndScheduleAlarm(context) },
             updateName = alarmEditViewModel::updateName,
             updateDate = alarmEditViewModel::updateDateAndResetWeeklyRepeater,
@@ -66,6 +67,8 @@ fun AlarmEditScreen(
             removeDay = alarmEditViewModel::removeDay,
             toggleVibration = alarmEditViewModel::toggleVibration,
             updateSnoozeDuration = alarmEditViewModel::updateSnoozeDuration,
+            validateAlarm = alarmEditViewModel::validateAlarm,
+            isAlarmNameValid = isAlarmNameValid,
             modifier = modifier
         )
     }
@@ -93,7 +96,6 @@ private fun AlarmEditScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             timeDisplay = TimeDisplay.TwelveHour,
-            validateAlarm = { true },
             saveAndScheduleAlarm = {},
             updateName = {},
             updateDate = {},
@@ -101,7 +103,9 @@ private fun AlarmEditScreenPreview() {
             addDay = {},
             removeDay = {},
             toggleVibration = {},
-            updateSnoozeDuration = {}
+            updateSnoozeDuration = {},
+            validateAlarm = { true },
+            isAlarmNameValid = ValidationResult.Success()
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -38,10 +38,10 @@ fun AlarmEditScreen(
     // State
     val alarmState by alarmEditViewModel.modifiedAlarm.collectAsState()
     val generalSettingsState by alarmEditViewModel.generalSettings.collectAsState()
-    val isAlarmNameValid by alarmEditViewModel.isAlarmNameValid.collectAsState()
+    val isNameValid by alarmEditViewModel.isNameValid.collectAsState()
 
     // Flow
-    val snackbarFlow = alarmEditViewModel.snackbarChannelFlow
+    val snackbarChannelFlow = alarmEditViewModel.snackbarChannelFlow
 
     if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
@@ -73,8 +73,8 @@ fun AlarmEditScreen(
             removeDay = alarmEditViewModel::removeDay,
             toggleVibration = alarmEditViewModel::toggleVibration,
             updateSnoozeDuration = alarmEditViewModel::updateSnoozeDuration,
-            isAlarmNameValid = isAlarmNameValid,
-            snackbarFlow = snackbarFlow,
+            isNameValid = isNameValid,
+            snackbarChannelFlow = snackbarChannelFlow,
             modifier = modifier
         )
     }
@@ -113,8 +113,8 @@ private fun AlarmEditScreenPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            isAlarmNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarChannelFlow
+            isNameValid = ValidationResult.Success(),
+            snackbarChannelFlow = snackbarChannelFlow
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -16,6 +16,7 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
+import com.example.alarmscratch.alarm.validation.AlarmValidator
 import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
@@ -24,6 +25,8 @@ import com.example.alarmscratch.core.extension.getStringFromBackStack
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.settings.data.model.TimeDisplay
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 
 @Composable
 fun AlarmEditScreen(
@@ -37,6 +40,9 @@ fun AlarmEditScreen(
     val generalSettingsState by alarmEditViewModel.generalSettings.collectAsState()
     val isAlarmNameValid by alarmEditViewModel.isAlarmNameValid.collectAsState()
 
+    // Flow
+    val snackbarFlow = alarmEditViewModel.snackbarChannelFlow
+
     if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
         // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
         // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
@@ -45,11 +51,11 @@ fun AlarmEditScreen(
             navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
         )
 
-        val context = LocalContext.current
+        val localContext = LocalContext.current
         val alarm = (alarmState as AlarmState.Success).alarm
         // This was extracted for previews, since previews can't actually "get a Ringtone"
         // from anywhere, therefore they can't get a name to display in the preview.
-        val alarmRingtoneName = alarm.getRingtone(context).getTitle(context)
+        val alarmRingtoneName = alarm.getRingtone(localContext).getTitle(localContext)
         val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
 
         AlarmCreateEditScreen(
@@ -59,7 +65,7 @@ fun AlarmEditScreen(
             alarm = alarm,
             alarmRingtoneName = alarmRingtoneName,
             timeDisplay = generalSettings.timeDisplay,
-            saveAndScheduleAlarm = { alarmEditViewModel.saveAndScheduleAlarm(context) },
+            saveAndScheduleAlarm = { context, onSuccess -> alarmEditViewModel.saveAndScheduleAlarm(context, onSuccess) },
             updateName = alarmEditViewModel::updateName,
             updateDate = alarmEditViewModel::updateDateAndResetWeeklyRepeater,
             updateTime = alarmEditViewModel::updateTime,
@@ -67,8 +73,8 @@ fun AlarmEditScreen(
             removeDay = alarmEditViewModel::removeDay,
             toggleVibration = alarmEditViewModel::toggleVibration,
             updateSnoozeDuration = alarmEditViewModel::updateSnoozeDuration,
-            validateAlarm = alarmEditViewModel::validateAlarm,
             isAlarmNameValid = isAlarmNameValid,
+            snackbarFlow = snackbarFlow,
             modifier = modifier
         )
     }
@@ -81,6 +87,9 @@ fun AlarmEditScreen(
 @Preview
 @Composable
 private fun AlarmEditScreenPreview() {
+    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
+
     AlarmScratchTheme {
         AlarmCreateEditScreen(
             navHostController = rememberNavController(),
@@ -96,7 +105,7 @@ private fun AlarmEditScreenPreview() {
             ),
             alarmRingtoneName = sampleRingtoneData.name,
             timeDisplay = TimeDisplay.TwelveHour,
-            saveAndScheduleAlarm = {},
+            saveAndScheduleAlarm = { _, _ -> },
             updateName = {},
             updateDate = {},
             updateTime = { _, _ -> },
@@ -104,8 +113,8 @@ private fun AlarmEditScreenPreview() {
             removeDay = {},
             toggleVibration = {},
             updateSnoozeDuration = {},
-            validateAlarm = { true },
-            isAlarmNameValid = ValidationResult.Success()
+            isAlarmNameValid = ValidationResult.Success(),
+            snackbarFlow = snackbarChannelFlow
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -16,7 +16,7 @@ import com.example.alarmscratch.alarm.data.preview.sampleRingtoneData
 import com.example.alarmscratch.alarm.data.preview.tueWedThu
 import com.example.alarmscratch.alarm.data.repository.AlarmState
 import com.example.alarmscratch.alarm.ui.alarmcreateedit.AlarmCreateEditScreen
-import com.example.alarmscratch.alarm.validation.AlarmValidator
+import com.example.alarmscratch.alarm.validation.ValidationError
 import com.example.alarmscratch.alarm.validation.ValidationResult
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
@@ -87,7 +87,7 @@ fun AlarmEditScreen(
 @Preview
 @Composable
 private fun AlarmEditScreenPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<AlarmValidator.DateTimeError>>()
+    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
     val snackbarChannelFlow = snackbarChannel.receiveAsFlow()
 
     AlarmScratchTheme {

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
@@ -16,7 +16,6 @@ class AlarmValidator {
         ILLEGAL_CHARACTER,
         ONLY_WHITESPACE;
 
-        // TODO: Make composable override before PR
         override fun toSnackbarString(context: Context): String =
             when (this) {
                 ILLEGAL_CHARACTER, ONLY_WHITESPACE ->
@@ -35,7 +34,6 @@ class AlarmValidator {
     enum class DateTimeError: ValidationError {
         NOT_SET_IN_FUTURE;
 
-        // TODO: Make composable override before PR
         override fun toSnackbarString(context: Context): String =
             when (this) {
                 NOT_SET_IN_FUTURE ->

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
@@ -2,6 +2,8 @@ package com.example.alarmscratch.alarm.validation
 
 import android.content.Context
 import com.example.alarmscratch.R
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import java.time.LocalDateTime
 
 class AlarmValidator {
 
@@ -10,10 +12,22 @@ class AlarmValidator {
         private val ILLEGAL_CHARACTER_PATTERN = Regex("[^A-Za-z0-9 ]")
     }
 
-    enum class AlarmValidationError: ValidationError {
+    enum class DateTimeError: ValidationError {
+        NOT_SET_IN_FUTURE;
+
+        // TODO: Make composable override before PR
+        fun toErrorString(context: Context): String =
+            when (this) {
+                NOT_SET_IN_FUTURE ->
+                    context.getString(R.string.validation_alarm_in_past)
+            }
+    }
+
+    enum class NameError: ValidationError {
         ILLEGAL_CHARACTER,
         ONLY_WHITESPACE;
 
+        // TODO: Make composable override before PR
         fun toErrorString(context: Context): String =
             when (this) {
                 ILLEGAL_CHARACTER ->
@@ -23,11 +37,18 @@ class AlarmValidator {
             }
     }
 
-    fun validateName(name: String): ValidationResult<AlarmValidationError> =
+    fun validateDateTime(dateTime: LocalDateTime): ValidationResult<DateTimeError> =
+        if (!dateTime.isAfter(LocalDateTimeUtil.nowTruncated())) {
+            ValidationResult.Error(DateTimeError.NOT_SET_IN_FUTURE)
+        } else {
+            ValidationResult.Success()
+        }
+
+    fun validateName(name: String): ValidationResult<NameError> =
         if (name.contains(ILLEGAL_CHARACTER_PATTERN)) {
-            ValidationResult.Error(AlarmValidationError.ILLEGAL_CHARACTER)
+            ValidationResult.Error(NameError.ILLEGAL_CHARACTER)
         } else if (name.isNotEmpty() && name.trim().isEmpty()) {
-            ValidationResult.Error(AlarmValidationError.ONLY_WHITESPACE)
+            ValidationResult.Error(NameError.ONLY_WHITESPACE)
         } else {
             ValidationResult.Success()
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
@@ -1,0 +1,34 @@
+package com.example.alarmscratch.alarm.validation
+
+import android.content.Context
+import com.example.alarmscratch.R
+
+class AlarmValidator {
+
+    companion object {
+        // Regex Patterns
+        private val ILLEGAL_CHARACTER_PATTERN = Regex("[^A-Za-z0-9 ]")
+    }
+
+    enum class AlarmValidationError: ValidationError {
+        ILLEGAL_CHARACTER,
+        ONLY_WHITESPACE;
+
+        fun toErrorString(context: Context): String =
+            when (this) {
+                ILLEGAL_CHARACTER ->
+                    context.getString(R.string.alarm_name_illegal_character_err)
+                ONLY_WHITESPACE ->
+                    context.getString(R.string.alarm_name_only_whitespace_err)
+            }
+    }
+
+    fun validateName(name: String): ValidationResult<AlarmValidationError> =
+        if (name.contains(ILLEGAL_CHARACTER_PATTERN)) {
+            ValidationResult.Error(AlarmValidationError.ILLEGAL_CHARACTER)
+        } else if (name.isNotEmpty() && name.trim().isEmpty()) {
+            ValidationResult.Error(AlarmValidationError.ONLY_WHITESPACE)
+        } else {
+            ValidationResult.Success()
+        }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
@@ -22,7 +22,7 @@ class AlarmValidator {
                     context.getString(R.string.alarm_name_err_snackbar)
             }
 
-        fun toInlineErrorString(context: Context): String =
+        fun toInlineString(context: Context): String =
             when (this) {
                 ILLEGAL_CHARACTER ->
                     context.getString(R.string.alarm_name_illegal_character_err_inline)

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/AlarmValidator.kt
@@ -12,43 +12,49 @@ class AlarmValidator {
         private val ILLEGAL_CHARACTER_PATTERN = Regex("[^A-Za-z0-9 ]")
     }
 
-    enum class DateTimeError: ValidationError {
-        NOT_SET_IN_FUTURE;
-
-        // TODO: Make composable override before PR
-        fun toErrorString(context: Context): String =
-            when (this) {
-                NOT_SET_IN_FUTURE ->
-                    context.getString(R.string.validation_alarm_in_past)
-            }
-    }
-
     enum class NameError: ValidationError {
         ILLEGAL_CHARACTER,
         ONLY_WHITESPACE;
 
         // TODO: Make composable override before PR
-        fun toErrorString(context: Context): String =
+        override fun toSnackbarString(context: Context): String =
+            when (this) {
+                ILLEGAL_CHARACTER, ONLY_WHITESPACE ->
+                    context.getString(R.string.alarm_name_err_snackbar)
+            }
+
+        fun toInlineErrorString(context: Context): String =
             when (this) {
                 ILLEGAL_CHARACTER ->
-                    context.getString(R.string.alarm_name_illegal_character_err)
+                    context.getString(R.string.alarm_name_illegal_character_err_inline)
                 ONLY_WHITESPACE ->
-                    context.getString(R.string.alarm_name_only_whitespace_err)
+                    context.getString(R.string.alarm_name_only_whitespace_err_inline)
             }
     }
 
-    fun validateDateTime(dateTime: LocalDateTime): ValidationResult<DateTimeError> =
-        if (!dateTime.isAfter(LocalDateTimeUtil.nowTruncated())) {
-            ValidationResult.Error(DateTimeError.NOT_SET_IN_FUTURE)
-        } else {
-            ValidationResult.Success()
-        }
+    enum class DateTimeError: ValidationError {
+        NOT_SET_IN_FUTURE;
+
+        // TODO: Make composable override before PR
+        override fun toSnackbarString(context: Context): String =
+            when (this) {
+                NOT_SET_IN_FUTURE ->
+                    context.getString(R.string.alarm_datetime_in_past_err_snackbar)
+            }
+    }
 
     fun validateName(name: String): ValidationResult<NameError> =
         if (name.contains(ILLEGAL_CHARACTER_PATTERN)) {
             ValidationResult.Error(NameError.ILLEGAL_CHARACTER)
         } else if (name.isNotEmpty() && name.trim().isEmpty()) {
             ValidationResult.Error(NameError.ONLY_WHITESPACE)
+        } else {
+            ValidationResult.Success()
+        }
+
+    fun validateDateTime(dateTime: LocalDateTime): ValidationResult<DateTimeError> =
+        if (!dateTime.isAfter(LocalDateTimeUtil.nowTruncated())) {
+            ValidationResult.Error(DateTimeError.NOT_SET_IN_FUTURE)
         } else {
             ValidationResult.Success()
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/Error.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/Error.kt
@@ -1,0 +1,3 @@
+package com.example.alarmscratch.alarm.validation
+
+sealed interface Error

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/Error.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/Error.kt
@@ -1,3 +1,0 @@
-package com.example.alarmscratch.alarm.validation
-
-sealed interface Error

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationError.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationError.kt
@@ -1,0 +1,3 @@
+package com.example.alarmscratch.alarm.validation
+
+sealed interface ValidationError

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationError.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationError.kt
@@ -1,3 +1,7 @@
 package com.example.alarmscratch.alarm.validation
 
-sealed interface ValidationError
+import android.content.Context
+
+sealed interface ValidationError {
+    fun toSnackbarString(context: Context): String
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
@@ -1,8 +1,6 @@
 package com.example.alarmscratch.alarm.validation
 
-typealias ValidationError = Error
-
-sealed interface ValidationResult<out D, out E : ValidationError> {
-    data class Success<out D, out E : ValidationError>(val data: D) : ValidationResult<D, E>
-    data class Error<out D, out E : ValidationError>(val error: E) : ValidationResult<D, E>
+sealed interface ValidationResult<E : ValidationError> {
+    class Success<E : ValidationError> : ValidationResult<E>
+    data class Error<E : ValidationError>(val error: E) : ValidationResult<E>
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
@@ -1,0 +1,8 @@
+package com.example.alarmscratch.alarm.validation
+
+typealias ValidationError = Error
+
+sealed interface ValidationResult<out D, out E : ValidationError> {
+    data class Success<out D, out E : ValidationError>(val data: D) : ValidationResult<D, E>
+    data class Error<out D, out E : ValidationError>(val error: E) : ValidationResult<D, E>
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/validation/ValidationResult.kt
@@ -1,6 +1,6 @@
 package com.example.alarmscratch.alarm.validation
 
-sealed interface ValidationResult<E : ValidationError> {
-    class Success<E : ValidationError> : ValidationResult<E>
-    data class Error<E : ValidationError>(val error: E) : ValidationResult<E>
+sealed interface ValidationResult<out E : ValidationError> {
+    class Success<out E : ValidationError> : ValidationResult<E>
+    data class Error<out E : ValidationError>(val error: E) : ValidationResult<E>
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,6 @@
     <string name="section_snooze">Snooze</string>
     <string name="alarm_create_edit_alarm_snooze_duration">Duration</string>
     <string name="snooze_minutes">minutes</string>
-    <string name="validation_alarm_in_past">Alarms cannot be set in the past</string>
     <!-- AlarmTimePickerDialog -->
     <string name="select_time">Select time</string>
     <string name="cancel">Cancel</string>
@@ -58,8 +57,10 @@
     <!-- AlarmEditScreen -->
     <string name="alarm_edit_screen_title">Edit Alarm</string>
     <!-- Validation -->
-    <string name="alarm_name_illegal_character_err">Only letters, numbers, spaces allowed</string>
-    <string name="alarm_name_only_whitespace_err">Cannot be only spaces</string>
+    <string name="alarm_name_err_snackbar">Alarm name improperly formatted</string>
+    <string name="alarm_datetime_in_past_err_snackbar">Alarms cannot be set in the past</string>
+    <string name="alarm_name_illegal_character_err_inline">Only letters, numbers, spaces allowed</string>
+    <string name="alarm_name_only_whitespace_err_inline">Cannot just be spaces</string>
 
     <!--
         **************************

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="alarm_edit_screen_title">Edit Alarm</string>
     <!-- Validation -->
     <string name="alarm_name_err_snackbar">Alarm name improperly formatted</string>
-    <string name="alarm_datetime_in_past_err_snackbar">Alarms cannot be set in the past</string>
+    <string name="alarm_datetime_in_past_err_snackbar">Alarms must be set in the future</string>
     <string name="alarm_name_illegal_character_err_inline">Only letters, numbers, spaces allowed</string>
     <string name="alarm_name_only_whitespace_err_inline">Cannot just be spaces</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,9 @@
     <string name="alarm_creation_screen_title">Create Alarm</string>
     <!-- AlarmEditScreen -->
     <string name="alarm_edit_screen_title">Edit Alarm</string>
+    <!-- Validation -->
+    <string name="alarm_name_illegal_character_err">Only letters, numbers, spaces allowed</string>
+    <string name="alarm_name_only_whitespace_err">Cannot be only spaces</string>
 
     <!--
         **************************


### PR DESCRIPTION
### Description
- Add new, and rework existing validation on `AlarmCreateEditScreen`
  - DateTime (existing, rework)
    - Invalid if Alarm is not set in the future
    - DateTime errors only show in the Snackbar when attempting to save the Alarm
  - Name (new)
    - Invalid if name contains anything except letters, numbers, and spaces
    - Invalid if name only contains spaces
    - Name errors can show in the Snackbar during attempted saves, and as the Supporting Text in the TextField while typing.
      - Snackbar version is a generic message, while TextField version is specific to the error
      - Both the Snackbar and TextField versions will be on screen when the User attempts to save with an error. However, only the TextField version is shown when typing into the TextField.
- Snackbar errors are triaged if there are multiple errors to display, and only the most important error is shown. The order is as follows:
  1. DateTime errors
  2. Name errors