### PR TITLE
Feature | Clean Coroutines

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
@@ -8,10 +8,10 @@ import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import com.example.alarmscratch.core.extension.alarmApplication
+import com.example.alarmscratch.core.extension.doAsync
 import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class AlarmActionReceiver : BroadcastReceiver() {
 
@@ -81,7 +81,7 @@ class AlarmActionReceiver : BroadcastReceiver() {
         )
 
         // Update Alarm Database and reschedule Alarm
-        CoroutineScope(Dispatchers.IO).launch {
+        doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
             // Update Alarm
             val alarmRepo = AlarmRepository(AlarmDatabase.getDatabase(context).alarmDao())
             alarmRepo.updateSnooze(id, snoozeDateTime)
@@ -96,7 +96,7 @@ class AlarmActionReceiver : BroadcastReceiver() {
 
         // Disable Alarm and reset Snooze
         val alarmId = intent.getIntExtra(EXTRA_ALARM_ID, ALARM_NO_ID)
-        CoroutineScope(Dispatchers.IO).launch {
+        doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
             val alarmRepo = AlarmRepository(AlarmDatabase.getDatabase(context).alarmDao())
             alarmRepo.dismissAlarm(alarmId)
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -15,13 +15,19 @@ import com.example.alarmscratch.settings.data.repository.GeneralSettingsReposito
 import com.example.alarmscratch.settings.data.repository.generalSettingsDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
 class AlarmNotificationService : Service() {
 
+    // Coroutine
+    private val job = SupervisorJob()
+    private val coroutineScope = CoroutineScope(job)
+
     companion object {
+        // Actions
         const val DISPLAY_ALARM_NOTIFICATION = "display_alarm_notification"
         const val DISMISS_ALARM_NOTIFICATION = "dismiss_alarm_notification"
     }
@@ -67,7 +73,7 @@ class AlarmNotificationService : Service() {
         )
 
         // Get General Settings, Launch Notification, Play Ringtone, Vibrate
-        CoroutineScope(Dispatchers.Main).launch {
+        coroutineScope.launch(Dispatchers.Main) {
             // Get General Settings
             val generalSettingsRepository = GeneralSettingsRepository(applicationContext.generalSettingsDataStore)
             val generalSettings = try {
@@ -120,5 +126,10 @@ class AlarmNotificationService : Service() {
 
         // Stop Service, which dismisses the Notification
         stopSelf()
+    }
+
+    override fun onDestroy() {
+        // Cancel coroutines
+        job.cancel()
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -78,7 +78,7 @@ class AlarmNotificationService : Service() {
             val generalSettingsRepository = GeneralSettingsRepository(applicationContext.generalSettingsDataStore)
             val generalSettings = try {
                 generalSettingsRepository.generalSettingsFlow.first()
-            } catch (e: Exception) {
+            } catch (e: NoSuchElementException) {
                 // Flow was empty. Return GeneralSettings with defaults.
                 GeneralSettings(GeneralSettingsRepository.DEFAULT_TIME_DISPLAY)
             }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -7,11 +7,11 @@ import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import com.example.alarmscratch.core.extension.alarmApplication
+import com.example.alarmscratch.core.extension.doAsync
 import com.example.alarmscratch.core.extension.isSnoozed
 import com.example.alarmscratch.core.extension.toAlarmExecutionData
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class BootCompletedReceiver : BroadcastReceiver() {
 
@@ -23,7 +23,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
                     .alarmDao()
             )
 
-            CoroutineScope(Dispatchers.IO).launch {
+            doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
                 val alarmList = alarmRepo.getAllAlarms()
                 rescheduleEligibleAlarms(context, alarmList)
             }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -29,7 +29,6 @@ import com.example.alarmscratch.settings.data.repository.GeneralSettingsReposito
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.data.repository.alarmDefaultsDataStore
 import com.example.alarmscratch.settings.data.repository.generalSettingsDataStore
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -40,7 +39,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 class AlarmCreationViewModel(
@@ -126,24 +124,20 @@ class AlarmCreationViewModel(
     fun saveAndScheduleAlarm(context: Context, onSuccess: () -> Unit) {
         if (_newAlarm.value is AlarmState.Success) {
             viewModelScope.launch {
-                withContext(Dispatchers.IO) {
-                    try {
-                        if (validateAlarm()) {
-                            val newAlarmId = saveAlarm()
-                            val newAlarm = getAlarm(newAlarmId.toInt())
-                            scheduleAlarm(context.applicationContext, newAlarm)
+                try {
+                    if (validateAlarm()) {
+                        // Save and schedule Alarm
+                        val newAlarmId = saveAlarm()
+                        val newAlarm = getAlarm(newAlarmId.toInt())
+                        scheduleAlarm(context.applicationContext, newAlarm)
 
-                            withContext(Dispatchers.Main) {
-                                onSuccess()
-                            }
-                        } else {
-                            withContext(Dispatchers.Main) {
-                                pushTriagedErrorToSnackbar()
-                            }
-                        }
-                    } catch (e: Exception) {
-                        // toInt() can throw an Exception, but it shouldn't. Just catch here to prevent a crash.
+                        // Perform supplied success action
+                        onSuccess()
+                    } else {
+                        pushTriagedErrorToSnackbar()
                     }
+                } catch (e: Exception) {
+                    // toInt() can throw an Exception, but it shouldn't. Just catch here to prevent a crash.
                 }
             }
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -27,7 +27,6 @@ import com.example.alarmscratch.settings.data.model.GeneralSettings
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsRepository
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.data.repository.generalSettingsDataStore
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -38,7 +37,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 class AlarmEditViewModel(
@@ -109,20 +107,16 @@ class AlarmEditViewModel(
     fun saveAndScheduleAlarm(context: Context, onSuccess: () -> Unit) {
         if (_modifiedAlarm.value is AlarmState.Success) {
             viewModelScope.launch {
-                withContext(Dispatchers.IO) {
-                    if (validateAlarm()) {
-                        saveAlarm()
-                        val newAlarm = getAlarm(alarmId)
-                        scheduleAlarm(context.applicationContext, newAlarm)
+                if (validateAlarm()) {
+                    // Save and schedule Alarm
+                    saveAlarm()
+                    val newAlarm = getAlarm(alarmId)
+                    scheduleAlarm(context.applicationContext, newAlarm)
 
-                        withContext(Dispatchers.Main) {
-                            onSuccess()
-                        }
-                    } else {
-                        withContext(Dispatchers.Main) {
-                            pushTriagedErrorToSnackbar()
-                        }
-                    }
+                    // Perform supplied success action
+                    onSuccess()
+                } else {
+                    pushTriagedErrorToSnackbar()
                 }
             }
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,7 +20,6 @@ import com.example.alarmscratch.alarm.ui.alarmlist.component.NoAlarmsCard
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.settings.data.model.TimeDisplay
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
-import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmListScreen(
@@ -34,15 +32,14 @@ fun AlarmListScreen(
     val generalSettingsState by alarmListViewModel.generalSettings.collectAsState()
 
     if (alarmListState is AlarmListState.Success && generalSettingsState is GeneralSettingsState.Success) {
-        val coroutineScope = rememberCoroutineScope()
         val alarmList = (alarmListState as AlarmListState.Success).alarmList
         val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
 
         AlarmListScreenContent(
             alarmList = alarmList,
             timeDisplay = generalSettings.timeDisplay,
-            onAlarmToggled = { context, alarm -> coroutineScope.launch { alarmListViewModel.toggleAlarm(context, alarm) } },
-            onAlarmDeleted = { context, alarm -> coroutineScope.launch { alarmListViewModel.cancelAndDeleteAlarm(context, alarm) } },
+            onAlarmToggled = { context, alarm -> alarmListViewModel.toggleAlarm(context, alarm) },
+            onAlarmDeleted = { context, alarm -> alarmListViewModel.cancelAndDeleteAlarm(context, alarm) },
             navigateToAlarmEditScreen = navigateToAlarmEditScreen,
             modifier = modifier
         )

--- a/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/AlarmApplication.kt
@@ -6,8 +6,12 @@ import android.app.NotificationManager
 import android.content.Context
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.ui.notification.AlarmNotification
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 
 class AlarmApplication : Application() {
+
+    val applicationScope = CoroutineScope(SupervisorJob())
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_BroadcastReveiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_BroadcastReveiver.kt
@@ -1,0 +1,21 @@
+package com.example.alarmscratch.core.extension
+
+import android.content.BroadcastReceiver
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun BroadcastReceiver.doAsync(
+    applicationScope: CoroutineScope,
+    dispatcher: CoroutineDispatcher,
+    block: suspend () -> Unit
+) {
+    val pendingResult = goAsync()
+    applicationScope.launch(dispatcher) {
+        try {
+            block()
+        } finally {
+            pendingResult.finish()
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Context.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Context.kt
@@ -1,0 +1,14 @@
+package com.example.alarmscratch.core.extension
+
+import android.content.Context
+import com.example.alarmscratch.core.AlarmApplication
+
+/**
+ * Returns the Application Context cast as AlarmApplication.
+ *
+ * Just makes the code a bit smaller.
+ *
+ * @return the AlarmApplication
+ */
+val Context.alarmApplication: AlarmApplication
+    get() = applicationContext as AlarmApplication

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -65,7 +64,6 @@ import com.example.alarmscratch.core.util.StatusBarUtil
 import com.example.alarmscratch.settings.data.repository.AlarmDefaultsState
 import com.example.alarmscratch.settings.extension.getRingtone
 import com.example.alarmscratch.settings.ui.alarmdefaults.component.SnoozeDurationDialog
-import kotlinx.coroutines.launch
 
 @Composable
 fun AlarmDefaultsScreen(
@@ -89,7 +87,6 @@ fun AlarmDefaultsScreen(
         )
 
         val context = LocalContext.current
-        val coroutineScope = rememberCoroutineScope()
         val alarmDefaults = (alarmDefaultsState as AlarmDefaultsState.Success).alarmDefaults
         // This was extracted for previews, since previews can't actually "get a Ringtone"
         // from anywhere, therefore they can't get a name to display in the preview.
@@ -102,7 +99,7 @@ fun AlarmDefaultsScreen(
             ringtoneUri = alarmDefaults.ringtoneUri,
             isVibrationEnabled = alarmDefaults.isVibrationEnabled,
             snoozeDuration = alarmDefaults.snoozeDuration,
-            saveAlarmDefaults = { coroutineScope.launch { alarmDefaultsViewModel.saveAlarmDefaults() } },
+            saveAlarmDefaults = alarmDefaultsViewModel::saveAlarmDefaults,
             toggleVibration = alarmDefaultsViewModel::toggleVibration,
             updateSnoozeDuration = alarmDefaultsViewModel::updateSnoozeDuration,
             modifier = modifier

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
@@ -45,10 +45,12 @@ class AlarmDefaultsViewModel(private val alarmDefaultsRepository: AlarmDefaultsR
         }
     }
 
-    suspend fun saveAlarmDefaults() {
+    fun saveAlarmDefaults() {
         if (_modifiedAlarmDefaults.value is AlarmDefaultsState.Success) {
             val alarmDefaults = (_modifiedAlarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
-            alarmDefaultsRepository.updateAlarmDefaults(alarmDefaults)
+            viewModelScope.launch {
+                alarmDefaultsRepository.updateAlarmDefaults(alarmDefaults)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/generalsettings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/generalsettings/GeneralSettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -47,7 +46,6 @@ import com.example.alarmscratch.core.util.StatusBarUtil
 import com.example.alarmscratch.settings.data.model.TimeDisplay
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.ui.generalsettings.component.TimeDisplayDialog
-import kotlinx.coroutines.launch
 
 @Composable
 fun GeneralSettingsScreen(
@@ -62,13 +60,12 @@ fun GeneralSettingsScreen(
     val generalSettingsState by generalSettingsViewModel.modifiedGeneralSettings.collectAsState()
 
     if (generalSettingsState is GeneralSettingsState.Success) {
-        val coroutineScope = rememberCoroutineScope()
         val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
 
         GeneralSettingsScreenContent(
             navHostController = navHostController,
             timeDisplay = generalSettings.timeDisplay,
-            saveGeneralSettings = { coroutineScope.launch { generalSettingsViewModel.saveGeneralSettings() } },
+            saveGeneralSettings = generalSettingsViewModel::saveGeneralSettings,
             updateTimeDisplay = { generalSettingsViewModel.updateTimeDisplay(it) },
             modifier = modifier
         )

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/generalsettings/GeneralSettingsViewModel.kt
@@ -45,10 +45,12 @@ class GeneralSettingsViewModel(private val generalSettingsRepository: GeneralSet
         }
     }
 
-    suspend fun saveGeneralSettings() {
+    fun saveGeneralSettings() {
         if (_modifiedGeneralSettings.value is GeneralSettingsState.Success) {
             val generalSettings = (_modifiedGeneralSettings.value as GeneralSettingsState.Success).generalSettings
-            generalSettingsRepository.updateGeneralSettings(generalSettings)
+            viewModelScope.launch {
+                generalSettingsRepository.updateGeneralSettings(generalSettings)
+            }
         }
     }
 


### PR DESCRIPTION
### Description
- Create an Application-bound `CoroutineScope` in `AlarmApplication` to be used for coroutines that need to continue running as long as the Application is alive.
  - Utilized in `AlarmActionReceiver` and `BootCompletedReceiver` for IO operations, and the work that needs to wait for it to finish.
- Call `BroadcastReceiver.goAsync()` in all `BroadcastReceivers` before doing work outside of the Main thread. This functionality is implemented inside an extension function `BroadcastReceiver.doAsync()`. This function also launches a coroutine with the passed in `CoroutineContext`, which executes a given `suspend` lambda.
  - Affects `AlarmActionReceiver` and `BootCompletedReceiver`
- Improve coroutine management in `AlarmNotificationService`
- Improve coroutine related Exception handing
- Launch coroutines from `ViewModels` rather than exposing suspend functions to client code. This allows for migration away from Composable-bound `CoroutineScopes`.