### PR TITLE
Feature | Clean Up Outdated Alarms

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -9,45 +9,90 @@ import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.alarmApplication
 import com.example.alarmscratch.core.extension.doAsync
+import com.example.alarmscratch.core.extension.isDirty
+import com.example.alarmscratch.core.extension.isRepeating
 import com.example.alarmscratch.core.extension.isSnoozed
+import com.example.alarmscratch.core.extension.nextRepeatingDateTime
 import com.example.alarmscratch.core.extension.toAlarmExecutionData
 import kotlinx.coroutines.Dispatchers
 
 class BootCompletedReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (context != null && intent?.action == Intent.ACTION_LOCKED_BOOT_COMPLETED) {
-            val alarmRepo = AlarmRepository(
-                AlarmDatabase
-                    .getDatabase(context.createDeviceProtectedStorageContext())
-                    .alarmDao()
-            )
-
-            doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
-                val alarmList = alarmRepo.getAllAlarms()
-                rescheduleEligibleAlarms(context, alarmList)
+        if (context != null && intent != null) {
+            when (intent.action) {
+                Intent.ACTION_LOCKED_BOOT_COMPLETED ->
+                    cleanAndRescheduleAlarms(context)
             }
+        }
+    }
+
+    private fun cleanAndRescheduleAlarms(context: Context) {
+        val alarmRepository = AlarmRepository(
+            AlarmDatabase
+                .getDatabase(context.createDeviceProtectedStorageContext())
+                .alarmDao()
+        )
+
+        doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
+            // Clean Alarms
+            cleanAllAlarms(alarmRepository)
+
+            // Reschedule Alarms
+            // Re-query the database to get up to date Alarm data after cleaning the Alarms
+            rescheduleEligibleAlarms(context, alarmRepository.getAllAlarms())
+        }
+    }
+
+    private suspend fun cleanAllAlarms(alarmRepository: AlarmRepository) {
+        alarmRepository.getAllAlarms().forEach { cleanAlarm(it, alarmRepository) }
+    }
+
+    /**
+     * Cleans dirty Alarms as determined by Alarm.isDirty().
+     * Alarms that are already clean are a no-op.
+     *
+     * To clean an Alarm is to:
+     * 1) Reset snooze
+     * 2) If Alarm is repeating -> set to next repeating DateTime
+     * 3) If Alarm is not repeating -> disable Alarm
+     *
+     * @param alarm Alarm candidate for cleaning
+     * @param alarmRepository repository in which cleaned Alarms are updated
+     */
+    private suspend fun cleanAlarm(alarm: Alarm, alarmRepository: AlarmRepository) {
+        if (alarm.isDirty()) {
+            // Clean Alarm
+            val cleanAlarm = alarm.run {
+                if (isRepeating()) {
+                    copy(dateTime = nextRepeatingDateTime(), snoozeDateTime = null)
+                } else {
+                    copy(enabled = false, snoozeDateTime = null)
+                }
+            }
+
+            // Update database
+            alarmRepository.updateAlarm(cleanAlarm)
         }
     }
 
     /**
      * Reschedule Alarms if they meet the following criteria:
-     *
      * 1) Are enabled
-     * 2) Are scheduled to execute either now, or in the future
+     * 2) Are configured to execute in the future
      *
      * @param context Context to be used for scheduling Alarms
      * @param alarmList List of Alarms to potentially reschedule
      */
     private fun rescheduleEligibleAlarms(context: Context, alarmList: List<Alarm>) {
+        val now = LocalDateTimeUtil.nowTruncated()
         alarmList
             .filter { alarm ->
                 alarm.enabled &&
-                        if (!alarm.isSnoozed()) {
-                            !alarm.dateTime.isBefore(LocalDateTimeUtil.nowTruncated())
+                        if (alarm.isSnoozed()) {
+                            alarm.snoozeDateTime?.isAfter(now) == true
                         } else {
-                            // TODO: Think of a better default behavior for this
-                            alarm.snoozeDateTime?.isBefore(LocalDateTimeUtil.nowTruncated())?.not() ?: false
+                            alarm.dateTime.isAfter(now)
                         }
             }
             .forEach { AlarmScheduler.scheduleAlarm(context, it.toAlarmExecutionData()) }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -53,9 +53,9 @@ class BootCompletedReceiver : BroadcastReceiver() {
      * Alarms that are already clean are a no-op.
      *
      * To clean an Alarm is to:
-     * 1) Reset snooze
-     * 2) If Alarm is repeating -> set to next repeating DateTime
-     * 3) If Alarm is not repeating -> disable Alarm
+     * - Reset snooze
+     * - If Alarm is repeating -> set to next repeating date/time
+     * - If Alarm is not repeating -> disable Alarm
      *
      * @param alarm Alarm candidate for cleaning
      * @param alarmRepository repository in which cleaned Alarms are updated

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -129,6 +129,26 @@ fun Alarm.isRepeating(): Boolean =
 fun Alarm.isSnoozed(): Boolean =
     snoozeDateTime != null
 
+/**
+ * Returns whether or not the Alarm is dirty. Dirty Alarms are those that have invalid configurations.
+ * This can happen if the phone is off during a time in which an Alarm is scheduled to execute.
+ *
+ * Returns true if, and only if, both of the following conditions are met:
+ * 1) Alarm is enabled
+ * 2) Alarm is not configured to go off in the future, taking snooze into account
+ *
+ * @return true if the Alarm is dirty, false otherwise
+ */
+fun Alarm.isDirty(): Boolean {
+    val now = LocalDateTimeUtil.nowTruncated()
+    return enabled &&
+            if (isSnoozed()) {
+                snoozeDateTime?.isAfter(now) == false
+            } else {
+                !dateTime.isAfter(now)
+            }
+}
+
 fun Alarm.getRingtone(context: Context): Ringtone =
     RingtoneRepository(context).getRingtone(ringtoneUriString)
 


### PR DESCRIPTION
### Description
- On device boot, clean `Alarms` that are in an invalid configuration (dirty). This will modify the `Alarm` in the database.
  - Ex: this can happen when the Device is off during a time in which an Alarm is scheduled to execute. In this scenario, the dirty Alarm is still enabled and configured to be executed in the past, after the User boots their Device.
  - Dirty repeating Alarms will have their snooze cleared, remain enabled, and will be configured to execute on the next valid repeating day/time. They will then be rescheduled with the `AlarmScheduler`.
  - Dirty non-repeating Alarms will have their snooze cleared and be disabled. They will not be rescheduled with the `AlarmScheduler`.
- Reorder filtering logic in `BootCompletedReceiver.rescheduleEligibleAlarms()` for clarity
- Modify filtering logic in `BootCompletedReceiver.rescheduleEligibleAlarms()` to no longer include Alarms that are scheduled to go off in the current minute. Only Alarms scheduled in the future will now pass.