### PR TITLE
Feature | Don't Futurize Alarm on Toggle Off

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -67,7 +67,9 @@ class AlarmListViewModel(
 
     fun toggleAlarm(context: Context, alarm: Alarm) {
         viewModelScope.launch {
-            val modifiedAlarm = alarm.copy(enabled = !alarm.enabled, dateTime = alarm.dateTime).withFuturizedDateTime()
+            val modifiedAlarm = alarm
+                .copy(enabled = !alarm.enabled)
+                .run { if (enabled) withFuturizedDateTime() else this }
 
             alarmRepository.updateAlarm(modifiedAlarm)
 


### PR DESCRIPTION
### Description
- On the `AlarmListScreen`, only futurize Alarm time when toggling the Alarm on. Previously, the Alarm time was also being futurized when toggling the Alarm off.
- Remove redundant setting of `alarm.dateTime` in `AlarmListViewModel.toggleAlarm()`