### PR TITLE
Feature | Modify Alarm Date Text

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
@@ -46,6 +46,9 @@ class WeeklyRepeater(encodedRepeatingDays: Int = 0) {
     fun isRepeatingOn(day: Day): Boolean =
         repeatingDayMap[day] ?: false
 
+    fun isRepeatingEveryDay(): Boolean =
+        repeatingDayMap.filterValues { !it }.isEmpty()
+
     fun getRepeatingDays(): List<Day> =
         repeatingDayMap.filterValues { it }.keys.toList()
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -45,12 +45,11 @@ val tomorrowAlarm =
         snoozeDuration = 15
     )
 
-// TODO do exception handling for java code
 val calendarAlarm =
     Alarm(
         name = "",
         enabled = true,
-        dateTime = LocalDateTime.parse("2024-12-25T00:05:00"),
+        dateTime = LocalDateTimeUtil.nowTruncated().plusDays(2),
         weeklyRepeater = WeeklyRepeater(),
         ringtoneUriString = sampleRingtoneUriString,
         isVibrationEnabled = false,

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -49,7 +49,7 @@ val calendarAlarm =
     Alarm(
         name = "",
         enabled = true,
-        dateTime = LocalDateTimeUtil.nowTruncated().plusDays(2),
+        dateTime = getFutureTime(plusDays = 2),
         weeklyRepeater = WeeklyRepeater(),
         ringtoneUriString = sampleRingtoneUriString,
         isVibrationEnabled = false,

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -7,6 +7,7 @@ import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import java.time.LocalDateTime
 
 const val tueWedThu: Int = 28
+const val everyDay: Int = 127
 private const val sampleRingtoneUriString = "content://settings/system/alarm_alert"
 
 val repeatingAlarm =

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
@@ -15,6 +15,7 @@ import com.example.alarmscratch.alarm.data.preview.calendarAlarm
 import com.example.alarmscratch.alarm.data.preview.repeatingAlarm
 import com.example.alarmscratch.alarm.data.preview.todayAlarm
 import com.example.alarmscratch.alarm.data.preview.tomorrowAlarm
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.isRepeating
 import com.example.alarmscratch.core.extension.toAlarmDateString
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
@@ -106,6 +107,22 @@ private fun AlarmDaysBeyondTomorrowPreview() {
     AlarmScratchTheme {
         AlarmDays(
             alarm = calendarAlarm,
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF373736
+)
+@Composable
+private fun AlarmDaysBeforeTodayPreview() {
+    AlarmScratchTheme {
+        AlarmDays(
+            alarm = todayAlarm.copy(
+                dateTime = LocalDateTimeUtil.nowTruncated().minusDays(1)
+            ),
             modifier = Modifier.padding(20.dp)
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
+import com.example.alarmscratch.alarm.data.preview.calendarAlarm
 import com.example.alarmscratch.alarm.data.preview.everyDay
 import com.example.alarmscratch.alarm.data.preview.repeatingAlarm
 import com.example.alarmscratch.alarm.data.preview.todayAlarm
@@ -126,7 +127,7 @@ private fun AlarmDaysTomorrowPreview() {
 private fun AlarmDaysBeyondTomorrowPreview() {
     AlarmScratchTheme {
         AlarmDays(
-            alarm = todayAlarm.copy(dateTime = LocalDateTimeUtil.nowTruncated().plusDays(2)),
+            alarm = calendarAlarm,
             modifier = Modifier.padding(20.dp)
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/AlarmDays.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
-import com.example.alarmscratch.alarm.data.preview.calendarAlarm
+import com.example.alarmscratch.alarm.data.preview.everyDay
 import com.example.alarmscratch.alarm.data.preview.repeatingAlarm
 import com.example.alarmscratch.alarm.data.preview.todayAlarm
 import com.example.alarmscratch.alarm.data.preview.tomorrowAlarm
@@ -38,10 +38,13 @@ private fun RepeatingAlarmDays(
     repeatingDays: WeeklyRepeater,
     modifier: Modifier = Modifier
 ) {
-    Text(
-        text = "${stringResource(id = R.string.repeating_alarm_date_label)} ${repeatingDays.toAlarmCreationDateString()}",
-        modifier = modifier
-    )
+    val dateText = if (repeatingDays.isRepeatingEveryDay()) {
+        stringResource(id = R.string.repeating_alarm_every_day)
+    } else {
+        "${stringResource(id = R.string.repeating_alarm_date_label)} ${repeatingDays.toAlarmCreationDateString()}"
+    }
+
+    Text(text = dateText, modifier = modifier)
 }
 
 @Composable
@@ -49,7 +52,10 @@ private fun NonRepeatingAlarmDays(
     dateTime: LocalDateTime,
     modifier: Modifier = Modifier
 ) {
-    Text(text = dateTime.toAlarmDateString(context = LocalContext.current), modifier = modifier)
+    Text(
+        text = dateTime.toAlarmDateString(context = LocalContext.current),
+        modifier = modifier
+    )
 }
 
 /*
@@ -65,6 +71,20 @@ private fun AlarmDaysRepeatingPreview() {
     AlarmScratchTheme {
         AlarmDays(
             alarm = repeatingAlarm,
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF373736
+)
+@Composable
+private fun AlarmDaysRepeatingEveryDayPreview() {
+    AlarmScratchTheme {
+        AlarmDays(
+            alarm = repeatingAlarm.copy(weeklyRepeater = WeeklyRepeater(everyDay)),
             modifier = Modifier.padding(20.dp)
         )
     }
@@ -106,7 +126,7 @@ private fun AlarmDaysTomorrowPreview() {
 private fun AlarmDaysBeyondTomorrowPreview() {
     AlarmScratchTheme {
         AlarmDays(
-            alarm = calendarAlarm,
+            alarm = todayAlarm.copy(dateTime = LocalDateTimeUtil.nowTruncated().plusDays(2)),
             modifier = Modifier.padding(20.dp)
         )
     }
@@ -120,9 +140,7 @@ private fun AlarmDaysBeyondTomorrowPreview() {
 private fun AlarmDaysBeforeTodayPreview() {
     AlarmScratchTheme {
         AlarmDays(
-            alarm = todayAlarm.copy(
-                dateTime = LocalDateTimeUtil.nowTruncated().minusDays(1)
-            ),
+            alarm = todayAlarm.copy(dateTime = LocalDateTimeUtil.nowTruncated().minusDays(1)),
             modifier = Modifier.padding(20.dp)
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmDate.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmDate.kt
@@ -5,10 +5,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
 import com.example.alarmscratch.alarm.data.preview.calendarAlarm
@@ -60,8 +62,13 @@ private fun NonRepeatingAlarmDate(
     enabled: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val dateText = if (enabled) {
+        dateTime.toAlarmDateString(context = LocalContext.current)
+    } else {
+        stringResource(id = R.string.not_scheduled)
+    }
     Text(
-        text = dateTime.toAlarmDateString(context = LocalContext.current),
+        text = dateText,
         fontSize = 12.sp,
         fontWeight = if (enabled) FontWeight.Medium else null,
         modifier = modifier
@@ -77,7 +84,7 @@ private fun NonRepeatingAlarmDate(
     backgroundColor = 0xFF373736
 )
 @Composable
-private fun AlarmDateRepeatingPreview() {
+private fun AlarmDateRepeatingEnabledPreview() {
     AlarmScratchTheme {
         AlarmDate(
             alarm = repeatingAlarm,
@@ -119,10 +126,10 @@ private fun AlarmDateTodayPreview() {
     backgroundColor = 0xFF373736
 )
 @Composable
-private fun AlarmDateTomorrowDisabledPreview() {
+private fun AlarmDateTomorrowPreview() {
     AlarmScratchTheme {
         AlarmDate(
-            alarm = tomorrowAlarm,
+            alarm = tomorrowAlarm.copy(enabled = true),
             modifier = Modifier.padding(20.dp)
         )
     }
@@ -137,6 +144,20 @@ private fun AlarmDateBeyondTomorrowPreview() {
     AlarmScratchTheme {
         AlarmDate(
             alarm = calendarAlarm,
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF373736
+)
+@Composable
+private fun AlarmDateNotScheduledPreview() {
+    AlarmScratchTheme {
+        AlarmDate(
+            alarm = tomorrowAlarm,
             modifier = Modifier.padding(20.dp)
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmDate.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/component/AlarmDate.kt
@@ -67,6 +67,7 @@ private fun NonRepeatingAlarmDate(
     } else {
         stringResource(id = R.string.not_scheduled)
     }
+
     Text(
         text = dateText,
         fontSize = 12.sp,

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_LocalDateTime.kt
@@ -32,21 +32,15 @@ fun LocalDateTime.getDayShorthand(): String =
  */
 
 fun LocalDateTime.toAlarmDateString(context: Context) : String {
-    val currentDateTime = LocalDateTimeUtil.nowTruncated()
-    return if (!this.isBefore(currentDateTime)) {
-        val alarmDate = this.toLocalDate()
-        val currentDate = currentDateTime.toLocalDate()
+    val alarmDate = this.toLocalDate()
+    val currentDate = LocalDateTimeUtil.nowTruncated().toLocalDate()
 
-        // Alarm is for today
-        if (alarmDate.isEqual(currentDate)) {
-            context.getString(R.string.date_today)
-        } else if (alarmDate.dayOfYear - currentDate.dayOfYear == 1) { // Alarm is for tomorrow
-            context.getString(R.string.date_tomorrow)
-        } else { // Alarm is for a day beyond tomorrow
-            formatCalendarDate(alarmDate)
-        }
-    } else {
-        context.getString(R.string.error)
+    return if (alarmDate.isEqual(currentDate)) { // Alarm is for today
+        context.getString(R.string.date_today)
+    } else if (alarmDate.dayOfYear - currentDate.dayOfYear == 1) { // Alarm is for tomorrow
+        context.getString(R.string.date_tomorrow)
+    } else { // Alarm is for a day either before today, or beyond tomorrow
+        formatCalendarDate(alarmDate)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <resources>
     <!-- General -->
     <string name="app_name">AlarmScratch</string>
-    <string name="error">Error</string>
 
     <!--
         ****************
@@ -28,6 +27,7 @@
     <string name="date_tomorrow">Tomorrow</string>
     <string name="time_am">AM</string>
     <string name="time_pm">PM</string>
+    <string name="not_scheduled">Not scheduled</string>
     <string name="snooze_indicator">Snoozed until -</string>
     <!-- AlarmCardMenu -->
     <string name="menu_delete">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <!-- AlarmCreateEditScreen -->
     <string name="alarm_name_placeholder">Alarm name</string>
     <string name="repeating_alarm_date_label">Every:</string>
+    <string name="repeating_alarm_every_day">Every day</string>
     <string name="section_alert">Alert</string>
     <string name="alarm_create_edit_alarm_sound_label">Sound</string>
     <string name="alarm_create_edit_alarm_vibration_label">Vibration</string>


### PR DESCRIPTION
### Description
- `AlarmListScreen` now says "Not scheduled" instead of "Error" in the date field for disabled non-repeating Alarms
- `AlarmCreateEditScreen` now says the full calendar date instead of "Error" for non-repeating Alarms that are set in the past
  - This situation can occur when editing a disabled non-repeating Alarm that went off in the past, but was never deleted by the User
- `LocalDateTime.toAlarmDateString()` was modified to always return either "Today", "Tomorrow", or the calendar date as part of the above behavior for `AlarmListScreen` and `AlarmCreateEditScreen`.
  - Previously, it would return "Error" if the Alarm was set in the past
- `AlarmCreateEditScreen` now shows "Every day" in the date field for Alarms that are set to repeat every day