### PR TITLE
Feature | Time Selection Dialog Dismissibility

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/TimeSelectionDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/TimeSelectionDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
@@ -73,7 +74,13 @@ fun TimeSelectionDialog(
     //  Decided to move on and just lock to TimeInput in Landscape for now.
     val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
 
-    Dialog(onDismissRequest = onCancel) {
+    Dialog(
+        onDismissRequest = onCancel,
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
+    ) {
         Card(
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
             modifier = Modifier.width(IntrinsicSize.Min)

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/TimeSelectionDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/component/TimeSelectionDialog.kt
@@ -70,8 +70,8 @@ fun TimeSelectionDialog(
         is24Hour = is24Hour
     )
     var showFullTimePicker by rememberSaveable { mutableStateOf(true) }
-    // TODO: Ran into a weird layout issue with TimePicker in Landscape.
-    //  Decided to move on and just lock to TimeInput in Landscape for now.
+    // TimeSelectionPicker gets extremely wonky when compressed vertically
+    // Keep track of orientation in order to lock to TimeSelectionInput in landscape
     val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
 
     Dialog(


### PR DESCRIPTION
### Description
- Make `TimeSelectionDialog` non-dismissible on back press and click outside
- Remove a TODO in `TimeSelecitonDialog` regarding its layout issues in landscape orientation
  - In landscape, the SDK's `TimeSelectionPicker` completely breaks if there's not enough vertical space for it. Oddly, making its container scrollable doesn't fix this, as if it doesn't register. Even if I could make it not break in this scenario and make it scrollable, given `TimeSelectionPicker's` gesture based nature, I don't think this would be a good idea. Therefore, I'm sticking with locking it to `TimeSelectionInput` on landscape.
    - It may be possible to detect if there's enough space to lay `TimeSelectionPicker` out without having to squish it vertically, therefore allowing it to be used in landscape on accommodating devices such as tablets. However, this is low priority relative to other work so I will not be investigating right now.