### PR TITLE
Feature | Snackbar on Alarm Toggle

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -87,9 +87,6 @@ fun AlarmCreationScreen(
 @Preview
 @Composable
 private fun AlarmCreationScreenPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
-    val snackbarFlow = snackbarChannel.receiveAsFlow()
-
     AlarmScratchTheme {
         AlarmCreateEditScreen(
             navHostController = rememberNavController(),
@@ -113,7 +110,7 @@ private fun AlarmCreationScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarFlow
+            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -87,9 +87,6 @@ fun AlarmEditScreen(
 @Preview
 @Composable
 private fun AlarmEditScreenPreview() {
-    val snackbarChannel = Channel<ValidationResult.Error<ValidationError>>()
-    val snackbarFlow = snackbarChannel.receiveAsFlow()
-
     AlarmScratchTheme {
         AlarmCreateEditScreen(
             navHostController = rememberNavController(),
@@ -114,7 +111,7 @@ private fun AlarmEditScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
-            snackbarFlow = snackbarFlow
+            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -11,7 +11,10 @@ import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmListState
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.core.extension.toAlarmExecutionData
+import com.example.alarmscratch.core.extension.toScheduleString
 import com.example.alarmscratch.core.extension.withFuturizedDateTime
+import com.example.alarmscratch.core.ui.snackbar.SnackbarEvent
+import com.example.alarmscratch.core.ui.snackbar.global.GlobalSnackbarController
 import com.example.alarmscratch.settings.data.model.GeneralSettings
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsRepository
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
@@ -65,6 +68,10 @@ class AlarmListViewModel(
         }
     }
 
+    /*
+     * Modify
+     */
+
     fun toggleAlarm(context: Context, alarm: Alarm) {
         viewModelScope.launch {
             val modifiedAlarm = alarm
@@ -75,6 +82,7 @@ class AlarmListViewModel(
 
             if (modifiedAlarm.enabled) {
                 scheduleAlarm(context, modifiedAlarm)
+                showSnackbar(SnackbarEvent(modifiedAlarm.toScheduleString(context)))
             } else {
                 cancelAndResetAlarm(context, modifiedAlarm)
             }
@@ -95,5 +103,13 @@ class AlarmListViewModel(
             AlarmScheduler.cancelAlarm(context, alarm.toAlarmExecutionData())
             alarmRepository.deleteAlarm(alarm)
         }
+    }
+
+    /*
+     * Snackbar
+     */
+
+    private suspend fun showSnackbar(snackbarEvent: SnackbarEvent) {
+        GlobalSnackbarController.sendEvent(snackbarEvent)
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/runtime/ObserveAsEvent.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/runtime/ObserveAsEvent.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.withContext
 fun <T> ObserveAsEvent(
     flow: Flow<T>,
     key: Any? = null,
-    onEvent: suspend (T) -> Unit
+    onEvent: (T) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(key1 = flow, key2 = key, key3 = lifecycleOwner.lifecycle) {

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreenViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreenViewModel.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.launch
 class CoreScreenViewModel : ViewModel() {
 
     // Snackbar
-    private val snackbarChannel = Channel<SnackbarEvent>()
-    val snackbarFlow = snackbarChannel.receiveAsFlow()
+    private val localSnackbarChannel = Channel<SnackbarEvent>()
+    val localSnackbarFlow = localSnackbarChannel.receiveAsFlow()
 
     companion object {
 
@@ -25,11 +25,11 @@ class CoreScreenViewModel : ViewModel() {
         }
     }
 
-    fun updateSnackbar(message: String?) {
+    fun retrieveSnackbarFromPrevious(message: String?) {
         if (message != null) {
             viewModelScope.launch {
                 try {
-                    snackbarChannel.send(SnackbarEvent(message))
+                    localSnackbarChannel.send(SnackbarEvent(message))
                 } catch (e: Exception) {
                     // SendChannel.send() can theoretically throw any type of Exception
                     // if called on a Channel that is already closed.

--- a/app/src/main/java/com/example/alarmscratch/core/ui/snackbar/global/GlobalSnackbarController.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/snackbar/global/GlobalSnackbarController.kt
@@ -1,0 +1,27 @@
+package com.example.alarmscratch.core.ui.snackbar.global
+
+import com.example.alarmscratch.core.ui.snackbar.SnackbarEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+
+object GlobalSnackbarController {
+
+    private val snackbarChannel = Channel<SnackbarEvent>()
+    val snackbarFlow = snackbarChannel.receiveAsFlow()
+
+    suspend fun sendEvent(snackbarEvent: SnackbarEvent) {
+        try {
+            snackbarChannel.send(snackbarEvent)
+        } catch (e: Exception) {
+            // SendChannel.send() can theoretically throw any type of Exception
+            // if called on a Channel that is already closed.
+            // Re-throw CancellationException.
+            // No functionality beyond this is desired, so all other Exceptions
+            // are simply consumed to prevent crashes.
+            if (e is CancellationException) {
+                throw e
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
- Add `Snackbar` for when the Alarm is toggled on in the `AlarmListScreen`
  - `Snackbar` is sent to the `GlobalSnackbarController` from the `AlarmListScreen` and observed by the `CoreScreen`, which wraps it
- Refactor Previews in `AlarmCreationScreen`, `AlarmEditScreen`, and `CoreScreen`