### PR TITLE
Feature | Unsaved Changes Dialog

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
@@ -105,4 +105,33 @@ class WeeklyRepeater(encodedRepeatingDays: Int = 0) {
             .filter { it.value }
             .map { it.key.threeLetterShorthand }
             .joinToString(separator = ", ")
+
+    /*
+     * Compare
+     */
+
+    override fun equals(other: Any?): Boolean =
+        if (this === other) {
+            true
+        } else if (other as? WeeklyRepeater != null) {
+            this.toEncodedRepeatingDays() == other.toEncodedRepeatingDays()
+        } else {
+            false
+        }
+
+    /**
+     * Returns toEncodedRepeatingDays().hashCode() + 1.
+     * 1 is added to the result to prevent false positives when comparing the hash code
+     * of a WeeklyRepeater to the hash code of null. This false positive will occur when
+     * the WeeklyRepeater has no repeating days. This is because both 0.hashCode()
+     * and null.hashCode() equal 0.
+     *
+     * @return the hash code of this WeeklyRepeater
+     */
+    override fun hashCode(): Int =
+        // TODO: This is good enough for now when it comes to comparing 2 WeeklyRepeaters, or WeeklyRepeater and null.
+        //  However, this function breaks the hash code contract in certain situations.
+        //  Ex: WeeklyRepeater.equals(1) = false, however, WeeklyRepeater(0).hashCode() and 1.hashCode() both equal 1.
+        //  Come up with a unique way of calculating this.
+        this.toEncodedRepeatingDays().hashCode() + 1
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/WeeklyRepeater.kt
@@ -123,15 +123,11 @@ class WeeklyRepeater(encodedRepeatingDays: Int = 0) {
      * Returns toEncodedRepeatingDays().hashCode() + 1.
      * 1 is added to the result to prevent false positives when comparing the hash code
      * of a WeeklyRepeater to the hash code of null. This false positive will occur when
-     * the WeeklyRepeater has no repeating days. This is because both 0.hashCode()
-     * and null.hashCode() equal 0.
+     * the WeeklyRepeater has no repeating days. This is because toEncodedRepeatingDays()
+     * can return 0, and both 0.hashCode() and null.hashCode() equal 0.
      *
      * @return the hash code of this WeeklyRepeater
      */
     override fun hashCode(): Int =
-        // TODO: This is good enough for now when it comes to comparing 2 WeeklyRepeaters, or WeeklyRepeater and null.
-        //  However, this function breaks the hash code contract in certain situations.
-        //  Ex: WeeklyRepeater.equals(1) = false, however, WeeklyRepeater(0).hashCode() and 1.hashCode() both equal 1.
-        //  Come up with a unique way of calculating this.
         this.toEncodedRepeatingDays().hashCode() + 1
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -39,6 +39,7 @@ fun AlarmCreationScreen(
     val alarmState by alarmCreationViewModel.newAlarm.collectAsState()
     val generalSettingsState by alarmCreationViewModel.generalSettings.collectAsState()
     val isNameValid by alarmCreationViewModel.isNameValid.collectAsState()
+    val showUnsavedChangesDialog by alarmCreationViewModel.showUnsavedChangesDialog.collectAsState()
 
     // Flow
     val snackbarFlow = alarmCreationViewModel.snackbarFlow
@@ -75,6 +76,11 @@ fun AlarmCreationScreen(
             updateSnoozeDuration = alarmCreationViewModel::updateSnoozeDuration,
             isNameValid = isNameValid,
             snackbarFlow = snackbarFlow,
+            tryNavigateUp = { alarmCreationViewModel.tryNavigateUp(navHostController) },
+            tryNavigateBack = { alarmCreationViewModel.tryNavigateBack(navHostController) },
+            showUnsavedChangesDialog = showUnsavedChangesDialog,
+            unsavedChangesLeave = { alarmCreationViewModel.unsavedChangesLeave(navHostController) },
+            unsavedChangesStay = alarmCreationViewModel::unsavedChangesStay,
             modifier = modifier
         )
     }
@@ -110,6 +116,11 @@ private fun AlarmCreationScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -116,12 +116,12 @@ private fun AlarmCreationScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow(),
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
+            unsavedChangesStay = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -540,12 +540,12 @@ private fun AlarmCreateEditScreen12HourPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            snackbarFlow = snackbarFlow,
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = snackbarFlow
+            unsavedChangesStay = {}
         )
     }
 }
@@ -573,12 +573,12 @@ private fun AlarmCreateEditScreen24HourPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            snackbarFlow = snackbarFlow,
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = snackbarFlow
+            unsavedChangesStay = {}
         )
     }
 }
@@ -606,12 +606,12 @@ private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Error(AlarmValidator.NameError.ILLEGAL_CHARACTER),
+            snackbarFlow = snackbarFlow,
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = snackbarFlow
+            unsavedChangesStay = {}
         )
     }
 }
@@ -639,12 +639,12 @@ private fun AlarmCreateEditScreenErrorOnlyWhitespacePreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Error(AlarmValidator.NameError.ONLY_WHITESPACE),
+            snackbarFlow = snackbarFlow,
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = snackbarFlow
+            unsavedChangesStay = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -1,6 +1,7 @@
 package com.example.alarmscratch.alarm.ui.alarmcreateedit
 
 import android.content.Context
+import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -79,6 +80,7 @@ import com.example.alarmscratch.core.extension.get24HourTime
 import com.example.alarmscratch.core.extension.getAmPm
 import com.example.alarmscratch.core.ui.shared.CustomTopAppBar
 import com.example.alarmscratch.core.ui.shared.RowSelectionItem
+import com.example.alarmscratch.core.ui.shared.UnsavedChangesDialog
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
 import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
@@ -116,6 +118,11 @@ fun AlarmCreateEditScreen(
     updateSnoozeDuration: (Int) -> Unit,
     isNameValid: ValidationResult<AlarmValidator.NameError>,
     snackbarFlow: Flow<ValidationResult.Error<ValidationError>>,
+    tryNavigateUp: () -> Unit,
+    tryNavigateBack: () -> Unit,
+    showUnsavedChangesDialog: Boolean,
+    unsavedChangesLeave: () -> Unit,
+    unsavedChangesStay: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Configure Status Bar
@@ -137,12 +144,17 @@ fun AlarmCreateEditScreen(
         }
     }
 
+    // Intercept back navigation via the system back button
+    BackHandler {
+        tryNavigateBack()
+    }
+
     Scaffold(
         topBar = {
             CustomTopAppBar(
                 titleRes = titleRes,
                 navigationButton = {
-                    IconButton(onClick = navHostController::navigateUp) {
+                    IconButton(onClick = tryNavigateUp) {
                         Icon(imageVector = Icons.AutoMirrored.Default.ArrowBack, contentDescription = null)
                     }
                 },
@@ -236,6 +248,14 @@ fun AlarmCreateEditScreen(
                 modifier = Modifier.padding(top = 20.dp)
             )
         }
+    }
+
+    // Unsaved Changes Dialog
+    if (showUnsavedChangesDialog) {
+        UnsavedChangesDialog(
+            onLeave = unsavedChangesLeave,
+            onStay = unsavedChangesStay
+        )
     }
 }
 
@@ -520,6 +540,11 @@ private fun AlarmCreateEditScreen12HourPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = snackbarFlow
         )
     }
@@ -548,6 +573,11 @@ private fun AlarmCreateEditScreen24HourPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = snackbarFlow
         )
     }
@@ -576,6 +606,11 @@ private fun AlarmCreateEditScreenErrorIllegalCharacterPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Error(AlarmValidator.NameError.ILLEGAL_CHARACTER),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = snackbarFlow
         )
     }
@@ -604,6 +639,11 @@ private fun AlarmCreateEditScreenErrorOnlyWhitespacePreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Error(AlarmValidator.NameError.ONLY_WHITESPACE),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = snackbarFlow
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -39,6 +39,7 @@ fun AlarmEditScreen(
     val alarmState by alarmEditViewModel.modifiedAlarm.collectAsState()
     val generalSettingsState by alarmEditViewModel.generalSettings.collectAsState()
     val isNameValid by alarmEditViewModel.isNameValid.collectAsState()
+    val showUnsavedChangesDialog by alarmEditViewModel.showUnsavedChangesDialog.collectAsState()
 
     // Flow
     val snackbarFlow = alarmEditViewModel.snackbarFlow
@@ -75,6 +76,11 @@ fun AlarmEditScreen(
             updateSnoozeDuration = alarmEditViewModel::updateSnoozeDuration,
             isNameValid = isNameValid,
             snackbarFlow = snackbarFlow,
+            tryNavigateUp = { alarmEditViewModel.tryNavigateUp(navHostController) },
+            tryNavigateBack = { alarmEditViewModel.tryNavigateBack(navHostController) },
+            showUnsavedChangesDialog = showUnsavedChangesDialog,
+            unsavedChangesLeave = { alarmEditViewModel.unsavedChangesLeave(navHostController) },
+            unsavedChangesStay = alarmEditViewModel::unsavedChangesStay,
             modifier = modifier
         )
     }
@@ -111,6 +117,11 @@ private fun AlarmEditScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            tryNavigateUp = {},
+            tryNavigateBack = {},
+            showUnsavedChangesDialog = false,
+            unsavedChangesLeave = {},
+            unsavedChangesStay = {},
             snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -117,12 +117,12 @@ private fun AlarmEditScreenPreview() {
             toggleVibration = {},
             updateSnoozeDuration = {},
             isNameValid = ValidationResult.Success(),
+            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow(),
             tryNavigateUp = {},
             tryNavigateBack = {},
             showUnsavedChangesDialog = false,
             unsavedChangesLeave = {},
-            unsavedChangesStay = {},
-            snackbarFlow = Channel<ValidationResult.Error<ValidationError>>().receiveAsFlow()
+            unsavedChangesStay = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/BasicDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/BasicDialog.kt
@@ -5,16 +5,21 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SportsMartialArts
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,11 +30,13 @@ import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatSails
 import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
+import com.example.alarmscratch.core.ui.theme.DarkerBoatSails
 
 // ExperimentalMaterial3Api OptIn for LocalRippleConfiguration and RippleConfiguration
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BasicDialog(
+    icon: ImageVector? = null,
     @StringRes titleRes: Int,
     @StringRes cancelTextRes: Int = R.string.cancel,
     @StringRes confirmTextRes: Int = R.string.ok,
@@ -48,12 +55,27 @@ fun BasicDialog(
             colors = CardDefaults.cardColors(containerColor = DarkVolcanicRock),
             modifier = Modifier.fillMaxWidth()
         ) {
-            // Title
-            Text(
-                text = stringResource(id = titleRes),
-                fontSize = 24.sp,
+            // Icon and Title
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
-            )
+            ) {
+                // Icon
+                if (icon != null) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = DarkerBoatSails,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                }
+
+                // Title
+                Text(
+                    text = stringResource(id = titleRes),
+                    fontSize = 24.sp
+                )
+            }
 
             // Body
             body()
@@ -86,7 +108,25 @@ fun BasicDialog(
 
 @Preview
 @Composable
-private fun BasicDialogPreview() {
+private fun BasicDialogWithIconPreview() {
+    AlarmScratchTheme {
+        BasicDialog(
+            icon = Icons.Default.SportsMartialArts,
+            titleRes = R.string.general_settings_time_display,
+            onCancel = {},
+            onConfirm = {}
+        ) {
+            Text(
+                text = "Dialog body",
+                modifier = Modifier.padding(start = 24.dp, top = 24.dp, bottom = 24.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BasicDialogWithoutIconPreview() {
     AlarmScratchTheme {
         BasicDialog(
             titleRes = R.string.general_settings_time_display,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/BasicDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/BasicDialog.kt
@@ -31,6 +31,8 @@ import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
 @Composable
 fun BasicDialog(
     @StringRes titleRes: Int,
+    @StringRes cancelTextRes: Int = R.string.cancel,
+    @StringRes confirmTextRes: Int = R.string.ok,
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
     body: @Composable () -> Unit
@@ -65,12 +67,12 @@ fun BasicDialog(
                 CompositionLocalProvider(value = LocalRippleConfiguration provides RippleConfiguration(color = BoatSails)) {
                     // Cancel Button
                     TextButton(onClick = onCancel) {
-                        Text(text = stringResource(id = R.string.cancel), color = BoatSails)
+                        Text(text = stringResource(id = cancelTextRes), color = BoatSails)
                     }
 
                     // OK Button
                     TextButton(onClick = onConfirm) {
-                        Text(text = stringResource(id = R.string.ok), color = BoatSails)
+                        Text(text = stringResource(id = confirmTextRes), color = BoatSails)
                     }
                 }
             }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
@@ -13,15 +13,15 @@ import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 
 @Composable
 fun UnsavedChangesDialog(
-    onCancel: () -> Unit,
-    onConfirm: () -> Unit
+    onLeave: () -> Unit,
+    onStay: () -> Unit
 ) {
     BasicDialog(
         titleRes = R.string.unsaved_changes_dialog_title,
         cancelTextRes = R.string.unsaved_changes_dialog_leave,
         confirmTextRes = R.string.unsaved_changes_dialog_stay,
-        onCancel = onCancel,
-        onConfirm = onConfirm
+        onCancel = onLeave,
+        onConfirm = onStay
     ) {
         Row(modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp, bottom = 2.dp)) {
             Text(text = stringResource(id = R.string.unsaved_changes_dialog_body))
@@ -38,8 +38,8 @@ fun UnsavedChangesDialog(
 private fun UnsavedChangesDialogPreview() {
     AlarmScratchTheme {
         UnsavedChangesDialog(
-            onCancel = {},
-            onConfirm = {}
+            onLeave = {},
+            onStay = {}
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
@@ -2,6 +2,8 @@ package com.example.alarmscratch.core.ui.shared
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,6 +19,7 @@ fun UnsavedChangesDialog(
     onStay: () -> Unit
 ) {
     BasicDialog(
+        icon = Icons.Default.Warning,
         titleRes = R.string.unsaved_changes_dialog_title,
         cancelTextRes = R.string.unsaved_changes_dialog_leave,
         confirmTextRes = R.string.unsaved_changes_dialog_stay,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/UnsavedChangesDialog.kt
@@ -1,0 +1,45 @@
+package com.example.alarmscratch.core.ui.shared
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.alarmscratch.R
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+@Composable
+fun UnsavedChangesDialog(
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    BasicDialog(
+        titleRes = R.string.unsaved_changes_dialog_title,
+        cancelTextRes = R.string.unsaved_changes_dialog_leave,
+        confirmTextRes = R.string.unsaved_changes_dialog_stay,
+        onCancel = onCancel,
+        onConfirm = onConfirm
+    ) {
+        Row(modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp, bottom = 2.dp)) {
+            Text(text = stringResource(id = R.string.unsaved_changes_dialog_body))
+        }
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview
+@Composable
+private fun UnsavedChangesDialogPreview() {
+    AlarmScratchTheme {
+        UnsavedChangesDialog(
+            onCancel = {},
+            onConfirm = {}
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <!-- General -->
     <string name="app_name">AlarmScratch</string>
+    <string name="cancel">Cancel</string>
+    <string name="ok">OK</string>
 
     <!--
         ****************
@@ -47,8 +49,6 @@
     <string name="snooze_minutes">minutes</string>
     <!-- AlarmTimePickerDialog -->
     <string name="select_time">Select time</string>
-    <string name="cancel">Cancel</string>
-    <string name="ok">OK</string>
     <!-- AlarmCreationScreen -->
     <string name="alarm_creation_screen_title">Create Alarm</string>
     <!-- AlarmEditScreen -->
@@ -100,6 +100,17 @@
         **************************
     -->
     <string name="snooze_duration">Snooze Duration</string>
+
+    <!--
+        **************************
+        ** UnsavedChangesDialog **
+        **************************
+    -->
+    <string name="unsaved_changes_dialog_title">Unsaved Changes</string>
+    <string name="unsaved_changes_dialog_body">There are unsaved changes on this screen. If you
+        leave without saving, your changes will be lost. Do you want to leave without saving?</string>
+    <string name="unsaved_changes_dialog_leave">Leave</string>
+    <string name="unsaved_changes_dialog_stay">Stay</string>
 
     <!--
         ************************


### PR DESCRIPTION
### Description
- Create `UnsavedChangesDialog` to alert the User when they're attempting to navigate away from a screen without saving their changes on the following screens
  - `AlarmCreateEditScreen`
    - Required individual implementation for both `AlarmCreateScreen/ViewModel` and `AlarmEditScreen/ViewModel`
  - `AlarmDefaultsScreen`
  - `GeneralSettingsScreen`
- Modify `BasicDialog` to have icon, cancel text, and confirm text parameters
- Override `equals()` and `hashCode()` in `WeeklyRepeater`. This allows for Alarms to be compared for structural equality, which is required for determining if there's unsaved changes on the Alarm Create and Edit Screens.

Note: Implementation of `UnsavedChangesDialog` on the `RingtonePickerScreen` will be performed on a subsequent PR.