### PR TITLE
Feature | Convert System Default Ringtone

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.alarmscratch.alarm.ui.alarmcreate
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -24,8 +23,10 @@ import com.example.alarmscratch.core.extension.toAlarmExecutionData
 import com.example.alarmscratch.core.extension.toScheduleString
 import com.example.alarmscratch.core.extension.withFuturizedDateTime
 import com.example.alarmscratch.core.ui.snackbar.SnackbarEvent
+import com.example.alarmscratch.settings.data.model.AlarmDefaults
 import com.example.alarmscratch.settings.data.model.GeneralSettings
 import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository
+import com.example.alarmscratch.settings.data.repository.AlarmDefaultsState
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsRepository
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.data.repository.alarmDefaultsDataStore
@@ -44,7 +45,6 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 
 class AlarmCreationViewModel(
-    application: Application,
     private val alarmRepository: AlarmRepository,
     private val alarmDefaultsRepository: AlarmDefaultsRepository,
     private val generalSettingsRepository: GeneralSettingsRepository,
@@ -57,6 +57,7 @@ class AlarmCreationViewModel(
     val newAlarm: StateFlow<AlarmState> = _newAlarm.asStateFlow()
 
     // Settings
+    private val alarmDefaults: MutableStateFlow<AlarmDefaultsState> = MutableStateFlow(AlarmDefaultsState.Loading)
     val generalSettings: StateFlow<GeneralSettingsState> =
         generalSettingsRepository.generalSettingsFlow
             .map<GeneralSettings, GeneralSettingsState> { generalSettings -> GeneralSettingsState.Success(generalSettings) }
@@ -83,20 +84,29 @@ class AlarmCreationViewModel(
 
     init {
         viewModelScope.launch {
-            // Create initial Alarm
-            val alarmDefaults = alarmDefaultsRepository.getAlarmDefaults(application)
-            val alarmState = AlarmState.Success(
-                Alarm(
-                    dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
-                    ringtoneUriString = alarmDefaults.ringtoneUri,
-                    isVibrationEnabled = alarmDefaults.isVibrationEnabled,
-                    snoozeDuration = alarmDefaults.snoozeDuration
-                )
-            )
+            alarmDefaultsRepository.alarmDefaultsFlow
+                .map<AlarmDefaults, AlarmDefaultsState> { alarmDefaults -> AlarmDefaultsState.Success(alarmDefaults) }
+                .catch { throwable -> emit(AlarmDefaultsState.Error(throwable)) }
+                .collect { alarmDefaultsState ->
+                    // Get AlarmDefaultsState
+                    alarmDefaults.value = alarmDefaultsState
 
-            // Update state
-            referenceAlarm.value = alarmState
-            _newAlarm.value = alarmState
+                    // Create new Alarm with AlarmDefaults
+                    if (alarmDefaults.value is AlarmDefaultsState.Success) {
+                        val alarmDefaults = (alarmDefaults.value as AlarmDefaultsState.Success).alarmDefaults
+                        val alarmState = AlarmState.Success(
+                            Alarm(
+                                dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
+                                ringtoneUriString = alarmDefaults.ringtoneUri,
+                                isVibrationEnabled = alarmDefaults.isVibrationEnabled,
+                                snoozeDuration = alarmDefaults.snoozeDuration
+                            )
+                        )
+                        // Update state
+                        referenceAlarm.value = alarmState
+                        _newAlarm.value = alarmState
+                    }
+                }
         }
     }
 
@@ -109,9 +119,8 @@ class AlarmCreationViewModel(
                 val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
 
                 return AlarmCreationViewModel(
-                    application = application,
                     alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao()),
-                    alarmDefaultsRepository = AlarmDefaultsRepository(application.alarmDefaultsDataStore),
+                    alarmDefaultsRepository = AlarmDefaultsRepository(application, application.alarmDefaultsDataStore),
                     generalSettingsRepository = GeneralSettingsRepository(application.generalSettingsDataStore),
                     alarmValidator = AlarmValidator()
                 ) as T

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -88,6 +88,7 @@ class AlarmEditViewModel(
                 .map<Alarm, AlarmState> { alarm -> AlarmState.Success(alarm) }
                 .catch { throwable -> emit(AlarmState.Error(throwable)) }
                 .collect { alarmState ->
+                    // Update state
                     referenceAlarm.value = alarmState
                     _modifiedAlarm.value = alarmState
                 }

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.settings.data.repository
 
+import android.app.Application
 import android.content.Context
 import android.media.RingtoneManager
 import androidx.datastore.core.DataStore
@@ -13,18 +14,29 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.data.repository.RingtoneRepository
+import com.example.alarmscratch.core.extension.alarmApplication
 import com.example.alarmscratch.settings.data.model.AlarmDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 val Context.alarmDefaultsDataStore by preferencesDataStore(
     name = AlarmDefaultsRepository.ALARM_DEFAULTS_PREFERENCES_NAME,
     corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
 )
 
-class AlarmDefaultsRepository(private val dataStore: DataStore<Preferences>) {
+class AlarmDefaultsRepository(
+    application: Application,
+    private val dataStore: DataStore<Preferences>
+) {
+
+    init {
+        application.alarmApplication.applicationScope.launch {
+            initRingtoneUri(application)
+        }
+    }
 
     companion object {
         // Preferences name
@@ -43,6 +55,23 @@ class AlarmDefaultsRepository(private val dataStore: DataStore<Preferences>) {
     }
 
     /*
+     * Initialization
+     */
+
+    private suspend fun initRingtoneUri(context: Context) {
+        val preferences = dataStore.data.catch { emit(emptyPreferences()) }.firstOrNull()
+        if (preferences != null) {
+            val ringtoneUri = preferences[KEY_RINGTONE_URI]
+            // Ringtone URI is not set. Initialize it.
+            if (ringtoneUri == null) {
+                dataStore.edit {
+                    it[KEY_RINGTONE_URI] = RingtoneRepository(context).tryGetNonGenericSystemDefaultUri()
+                }
+            }
+        }
+    }
+
+    /*
      * Read
      */
 
@@ -58,20 +87,6 @@ class AlarmDefaultsRepository(private val dataStore: DataStore<Preferences>) {
             // Return AlarmDefaults
             AlarmDefaults(ringtoneUri, isVibrationEnabled, snoozeDuration)
         }
-
-    suspend fun getAlarmDefaults(context: Context): AlarmDefaults =
-        dataStore.data
-            .catch { emit(emptyPreferences()) }
-            .map { preferences ->
-                // Get Preferences
-                val ringtoneUri = preferences[KEY_RINGTONE_URI]
-                    ?: RingtoneRepository(context).tryGetNonGenericSystemDefaultUri()
-                val isVibrationEnabled = preferences[KEY_IS_VIBRATION_ENABLED] ?: DEFAULT_IS_VIBRATION_ENABLED
-                val snoozeDuration = preferences[KEY_SNOOZE_DURATION] ?: DEFAULT_SNOOZE_DURATION
-
-                // Return AlarmDefaults
-                AlarmDefaults(ringtoneUri, isVibrationEnabled, snoozeDuration)
-            }.first()
 
     /*
      * Write

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsViewModel.kt
@@ -49,7 +49,7 @@ class AlarmDefaultsViewModel(private val alarmDefaultsRepository: AlarmDefaultsR
                 val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
 
                 return AlarmDefaultsViewModel(
-                    alarmDefaultsRepository = AlarmDefaultsRepository(application.alarmDefaultsDataStore)
+                    alarmDefaultsRepository = AlarmDefaultsRepository(application, application.alarmDefaultsDataStore)
                 ) as T
             }
         }


### PR DESCRIPTION
### Description
- Initialize the `AlarmDefaults` `DataStore` with a default value for `ringtone_uri`
  - Start with the System Default Alarm Ringtone. Then try to find a match, by name, in the list of Ringtones returned by `RingtoneManager.cursor` set to `RingtoneManager.TYPE_ALARM`.
    - The purpose of doing all of this is because while the System Default Ringtone will redirect to a Ringtone returned by `RingtoneManager.cursor`, the `Uri` of the System Default will not match the corresponding Ringtone found in `RingtoneManager.cursor`. This is because the System Default has its own unique `Uri` which stays the same no matter what Ringtone is set as the System Default. This is a problem when loading the `RingtonePickerScreen` since that screen displays the currently selected Ringtone by matching `Uri's`. Furthermore, the System Default Ringtone's name will always take the form "Default (Ringtone Name)". This will show up on the `AlarmCreateEditScreen` and may be confusing to Users since the System Default, and App Default Ringtone will not necessarily match up. There's more to be said on that, but I don't want to make this paragraph too big.