### PR TITLE
Feature | Alarm List Notification Permission

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -8,7 +8,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -67,10 +66,7 @@ fun AlarmListScreen(
     alarmListViewModel.checkNotificationPermission(localContext)
 
     if (!hasNotificationPermission) {
-        NotificationPermissionOff(
-            promptPermission = notificationPermissionLauncher,
-            modifier = Modifier.fillMaxSize()
-        )
+        NotificationPermissionOff(promptPermission = notificationPermissionLauncher)
     } else {
         if (alarmListState is AlarmListState.Success && generalSettingsState is GeneralSettingsState.Success) {
             val alarmList = (alarmListState as AlarmListState.Success).alarmList

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -1,46 +1,25 @@
 package com.example.alarmscratch.alarm.ui.alarmlist
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.preview.alarmSampleDataHardCodedIds
 import com.example.alarmscratch.alarm.data.repository.AlarmListState
 import com.example.alarmscratch.alarm.ui.alarmlist.component.AlarmCard
 import com.example.alarmscratch.alarm.ui.alarmlist.component.NoAlarmsCard
+import com.example.alarmscratch.core.ui.permission.PermissionGateScreen
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.settings.data.model.TimeDisplay
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
@@ -54,51 +33,10 @@ fun AlarmListScreen(
     // State
     val alarmListState by alarmListViewModel.alarmList.collectAsState()
     val generalSettingsState by alarmListViewModel.generalSettings.collectAsState()
-    val attemptedToAskForPermission by alarmListViewModel.attemptedToAskForPermission.collectAsState()
-    val deniedPermissionList = alarmListViewModel.deniedPermissionList
 
-    // Permission logic
-    val shouldShowRequestPermissionRationale = (LocalContext.current as? Activity)
-        ?.shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)
-        ?: false
-    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        alarmListViewModel.onPermissionResult(Manifest.permission.POST_NOTIFICATIONS, isGranted)
-    }
-
-    // Must auto-call because of the nature of permissions on Android
-    LaunchedEffect(key1 = attemptedToAskForPermission) {
-        if (!attemptedToAskForPermission) {
-            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-        }
-    }
-
-    // Don't show anything until we know we've asked the User for the required permissions at least one time
-    if (attemptedToAskForPermission) {
-        // Permission Denied
-        if (deniedPermissionList.contains(Manifest.permission.POST_NOTIFICATIONS)) {
-            // The User denied the permission only once, therefore we can still display
-            // the Permission Request System Dialog
-            if (shouldShowRequestPermissionRationale) {
-                PromptAcceptPermissionSystemDialog(
-                    requestPermission = { notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            } else {
-                // The User denied the permission twice. Therefore the System will never show
-                // the Permission Request System Dialog again. Therefore we must give the User an option
-                // to manually grant the permission, since at this point the System will never show the
-                // Permission Request System Dialog ever again. Explain why the permission is needed, inform
-                // the User that they can manually accept the permission in the System Settings, and display
-                // a Button that leads to the System Settings, which they can decide if they want to press.
-                PromptAcceptPermissionSystemSettings(
-                    openSystemSettings = {},
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        } else {
-            // Permission Granted, show AlarmListScreenContent
+    PermissionGateScreen(
+        permission = Manifest.permission.POST_NOTIFICATIONS,
+        gatedScreen = {
             if (alarmListState is AlarmListState.Success && generalSettingsState is GeneralSettingsState.Success) {
                 val alarmList = (alarmListState as AlarmListState.Success).alarmList
                 val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
@@ -112,106 +50,9 @@ fun AlarmListScreen(
                     modifier = modifier
                 )
             }
-        }
-    }
-}
-
-@Composable
-fun PromptAcceptPermissionSystemDialog(
-    requestPermission: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        modifier = modifier.verticalScroll(rememberScrollState())
-    ) {
-        Column {
-            // Icon and Title
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
-            ) {
-                // Icon
-                Icon(
-                    imageVector = Icons.Default.Warning,
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = 8.dp)
-                )
-
-                // Title
-                Text(
-                    text = stringResource(id = R.string.permission_required),
-                    fontSize = 24.sp
-                )
-            }
-
-            // Body
-            Text(
-                text = stringResource(id = R.string.permission_missing_notification),
-                fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
-            )
-
-            // Request Button
-            Button(
-                onClick = requestPermission,
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(vertical = 10.dp)
-            ) {
-                Text(text = stringResource(id = R.string.permission_request))
-            }
-        }
-    }
-}
-
-@Composable
-fun PromptAcceptPermissionSystemSettings(
-    openSystemSettings: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        modifier = modifier.verticalScroll(rememberScrollState())
-    ) {
-        Column {
-            // Icon and Title
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
-            ) {
-                // Icon
-                Icon(
-                    imageVector = Icons.Default.Warning,
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = 8.dp)
-                )
-
-                // Title
-                Text(
-                    text = stringResource(id = R.string.permission_required),
-                    fontSize = 24.sp
-                )
-            }
-
-            // Body
-            Text(
-                text = "Accept Permission via System Settings",
-                fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
-            )
-
-            // Request Button
-            Button(
-                onClick = openSystemSettings,
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(vertical = 10.dp)
-            ) {
-                Text(text = "Open System Settings")
-            }
-        }
-    }
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable
@@ -282,28 +123,6 @@ private fun AlarmListScreenNoAlarmsPreview() {
             onAlarmDeleted = { _, _ -> },
             navigateToAlarmEditScreen = {},
             modifier = Modifier.padding(20.dp)
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun PromptAcceptPermissionSystemDialogPreview() {
-    AlarmScratchTheme {
-        PromptAcceptPermissionSystemDialog(
-            requestPermission = {},
-            modifier = Modifier.fillMaxWidth()
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun PromptAcceptPermissionSystemSettingsPreview() {
-    AlarmScratchTheme {
-        PromptAcceptPermissionSystemSettings(
-            openSystemSettings = {},
-            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -123,9 +123,9 @@ fun PromptAcceptPermissionSystemDialog(
 ) {
     Card(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        modifier = modifier
+        modifier = modifier.verticalScroll(rememberScrollState())
     ) {
-        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        Column {
             // Icon and Title
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -172,9 +172,9 @@ fun PromptAcceptPermissionSystemSettings(
 ) {
     Card(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        modifier = modifier
+        modifier = modifier.verticalScroll(rememberScrollState())
     ) {
-        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        Column {
             // Icon and Title
             Row(
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -1,6 +1,9 @@
 package com.example.alarmscratch.alarm.ui.alarmlist
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -19,6 +22,7 @@ import com.example.alarmscratch.settings.data.model.GeneralSettings
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsRepository
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.data.repository.generalSettingsDataStore
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -41,6 +45,7 @@ class AlarmListViewModel(
                 SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
                 AlarmListState.Loading
             )
+
     // Settings
     val generalSettings: StateFlow<GeneralSettingsState> =
         generalSettingsRepository.generalSettingsFlow
@@ -51,6 +56,10 @@ class AlarmListViewModel(
                 SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
                 GeneralSettingsState.Loading
             )
+
+    // Permissions
+    private val _hasNotificationPermission: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val hasNotificationPermission: StateFlow<Boolean> = _hasNotificationPermission
 
     companion object {
 
@@ -111,5 +120,24 @@ class AlarmListViewModel(
 
     private suspend fun showSnackbar(snackbarEvent: SnackbarEvent) {
         GlobalSnackbarController.sendEvent(snackbarEvent)
+    }
+
+    /*
+     * Permissions
+     */
+
+    fun checkNotificationPermission(context: Context) {
+        // TODO: API level check on Notification Permission
+        when (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)) {
+            PackageManager.PERMISSION_GRANTED ->
+                _hasNotificationPermission.value = true
+            PackageManager.PERMISSION_DENIED ->
+                _hasNotificationPermission.value = false
+            else ->
+                // checkSelfPermission() can only return either PackageManager.PERMISSION_GRANTED
+                // or PackageManager.PERMISSION_DENIED. However, these values are ints, so there
+                // needs to be an else here. This should never execute.
+                _hasNotificationPermission.value = false
+        }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -1,7 +1,6 @@
 package com.example.alarmscratch.alarm.ui.alarmlist
 
 import android.content.Context
-import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -20,10 +19,8 @@ import com.example.alarmscratch.settings.data.model.GeneralSettings
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsRepository
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import com.example.alarmscratch.settings.data.repository.generalSettingsDataStore
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -55,11 +52,6 @@ class AlarmListViewModel(
                 SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
                 GeneralSettingsState.Loading
             )
-
-    // Permissions
-    private val _attemptedToAskForPermission: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val attemptedToAskForPermission: StateFlow<Boolean> = _attemptedToAskForPermission.asStateFlow()
-    val deniedPermissionList = mutableStateListOf<String>()
 
     companion object {
 
@@ -120,20 +112,5 @@ class AlarmListViewModel(
 
     private suspend fun showSnackbar(snackbarEvent: SnackbarEvent) {
         GlobalSnackbarController.sendEvent(snackbarEvent)
-    }
-
-    /*
-     * Permissions
-     */
-
-    fun onPermissionResult(permission: String, isGranted: Boolean) {
-        _attemptedToAskForPermission.value = true
-
-        if (!isGranted) {
-            deniedPermissionList.add(permission)
-        } else if (deniedPermissionList.isNotEmpty()) {
-            // List can contain duplicates, remove all instances
-            deniedPermissionList.removeAll { it == permission }
-        }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -128,14 +128,12 @@ class AlarmListViewModel(
 
     fun onPermissionResult(permission: String, isGranted: Boolean) {
         _attemptedToAskForPermission.value = true
-        val permissionPreviouslyDeclined = deniedPermissionList.contains(permission)
 
-        if (!isGranted && !permissionPreviouslyDeclined) {
+        if (!isGranted) {
             deniedPermissionList.add(permission)
-        } else if (!isGranted && permissionPreviouslyDeclined) {
-            deniedPermissionList.add(permission)
-        } else if (isGranted && permissionPreviouslyDeclined) {
-            deniedPermissionList.remove(permission)
+        } else if (deniedPermissionList.isNotEmpty()) {
+            // List can contain duplicates, remove all instances
+            deniedPermissionList.removeAll { it == permission }
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
@@ -1,0 +1,24 @@
+package com.example.alarmscratch.core.ui.permission
+
+import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.StringRes
+import com.example.alarmscratch.R
+
+sealed class Permission(
+    val permissionString: String,
+    @StringRes val systemDialogBodyRes: Int,
+    @StringRes val systemSettingsBodyRes: Int,
+    @StringRes val systemDialogButtonRes: Int,
+    @StringRes val systemSettingsButtonRes: Int
+) {
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    data object PostNotifications : Permission(
+        permissionString = Manifest.permission.POST_NOTIFICATIONS,
+        systemDialogBodyRes = R.string.permission_missing_system_dialog,
+        systemSettingsBodyRes = R.string.permission_missing_system_settings,
+        systemDialogButtonRes = R.string.permission_request,
+        systemSettingsButtonRes = R.string.permission_open_system_settings
+    )
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
@@ -9,9 +9,7 @@ import com.example.alarmscratch.R
 sealed class Permission(
     val permissionString: String,
     @StringRes val systemDialogBodyRes: Int,
-    @StringRes val systemSettingsBodyRes: Int,
-    @StringRes val systemDialogButtonRes: Int = R.string.permission_request,
-    @StringRes val systemSettingsButtonRes: Int = R.string.permission_open_system_settings
+    @StringRes val systemSettingsBodyRes: Int
 ) {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     data object PostNotifications : Permission(

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
@@ -10,15 +10,13 @@ sealed class Permission(
     val permissionString: String,
     @StringRes val systemDialogBodyRes: Int,
     @StringRes val systemSettingsBodyRes: Int,
-    @StringRes val systemDialogButtonRes: Int,
-    @StringRes val systemSettingsButtonRes: Int
+    @StringRes val systemDialogButtonRes: Int = R.string.permission_request,
+    @StringRes val systemSettingsButtonRes: Int = R.string.permission_open_system_settings
 ) {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     data object PostNotifications : Permission(
         permissionString = Manifest.permission.POST_NOTIFICATIONS,
-        systemDialogBodyRes = R.string.permission_missing_system_dialog,
-        systemSettingsBodyRes = R.string.permission_missing_system_settings,
-        systemDialogButtonRes = R.string.permission_request,
-        systemSettingsButtonRes = R.string.permission_open_system_settings
+        systemDialogBodyRes = R.string.permission_missing_notifications_system_dialog,
+        systemSettingsBodyRes = R.string.permission_missing_notifications_system_settings
     )
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -1,0 +1,216 @@
+package com.example.alarmscratch.core.ui.permission
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.alarmscratch.R
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+@Composable
+fun PermissionGateScreen(
+    permission: String,
+    gatedScreen: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    permissionGateViewModel: PermissionGateViewModel = viewModel(factory = PermissionGateViewModel.Factory)
+) {
+    // State
+    val attemptedToAskForPermission by permissionGateViewModel.attemptedToAskForPermission.collectAsState()
+    val deniedPermissionList = permissionGateViewModel.deniedPermissionList
+
+    // Permission logic
+    val shouldShowRequestPermissionRationale = (LocalContext.current as? Activity)
+        ?.shouldShowRequestPermissionRationale(permission)
+        ?: false
+    val permissionRequestLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        permissionGateViewModel.onPermissionResult(permission, isGranted)
+    }
+
+    // Must auto-call because of the nature of permissions on Android
+    LaunchedEffect(key1 = attemptedToAskForPermission) {
+        if (!attemptedToAskForPermission) {
+            permissionRequestLauncher.launch(permission)
+        }
+    }
+
+    // Don't show anything until we know we've asked the User for the required permissions at least one time
+    if (attemptedToAskForPermission) {
+        // Permission Denied
+        if (deniedPermissionList.contains(permission)) {
+            // The User denied the permission only once, therefore we can still display
+            // the Permission Request System Dialog
+            if (shouldShowRequestPermissionRationale) {
+                PromptAcceptPermissionSystemDialog(
+                    showSystemDialog = { permissionRequestLauncher.launch(permission) },
+                    modifier = modifier
+                )
+            } else {
+                // The User denied the permission twice. Therefore the System will never show
+                // the Permission Request System Dialog again. Therefore we must give the User an option
+                // to manually grant the permission, since at this point the System will never show the
+                // Permission Request System Dialog ever again. Explain why the permission is needed, inform
+                // the User that they can manually accept the permission in the System Settings, and display
+                // a Button that leads to the System Settings, which they can decide if they want to press.
+                PromptAcceptPermissionSystemSettings(
+                    openSystemSettings = {},
+                    modifier = modifier
+                )
+            }
+        } else {
+            // Permission granted, show gated screen
+            gatedScreen()
+        }
+    }
+}
+
+@Composable
+fun PromptAcceptPermissionSystemDialog(
+    showSystemDialog: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = modifier.verticalScroll(rememberScrollState())
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Icon and Title
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
+            ) {
+                // Icon
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+
+                // Title
+                Text(
+                    text = stringResource(id = R.string.permission_required),
+                    fontSize = 24.sp
+                )
+            }
+
+            // Body
+            Text(
+                text = stringResource(id = R.string.permission_missing_notification),
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
+            )
+
+            // Request Button
+            Button(
+                onClick = showSystemDialog,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 10.dp)
+            ) {
+                Text(text = stringResource(id = R.string.permission_request))
+            }
+        }
+    }
+}
+
+@Composable
+fun PromptAcceptPermissionSystemSettings(
+    openSystemSettings: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = modifier.verticalScroll(rememberScrollState())
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Icon and Title
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
+            ) {
+                // Icon
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+
+                // Title
+                Text(
+                    text = stringResource(id = R.string.permission_required),
+                    fontSize = 24.sp
+                )
+            }
+
+            // Body
+            Text(
+                text = "Accept Permission via System Settings",
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
+            )
+
+            // Request Button
+            Button(
+                onClick = openSystemSettings,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 10.dp)
+            ) {
+                Text(text = "Open System Settings")
+            }
+        }
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview
+@Composable
+private fun PromptAcceptPermissionSystemDialogPreview() {
+    AlarmScratchTheme {
+        PromptAcceptPermissionSystemDialog(
+            showSystemDialog = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PromptAcceptPermissionSystemSettingsPreview() {
+    AlarmScratchTheme {
+        PromptAcceptPermissionSystemSettings(
+            openSystemSettings = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -29,7 +29,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -75,11 +78,20 @@ fun PermissionGateScreen(
     if (attemptedToAskForPermission) {
         // Permission denied
         if (deniedPermissionList.contains(permission.permissionString)) {
+            // TODO: The below 2 properties are a work around for an Android Studio bug where fromHtml() does not work with previews.
+            //  The bug mentions TextDefaults.fromHtml() instead of AnnotatedString.fromHtml(), but for reasons I'm not going to get
+            //  into for brevity, I believe it's the same thing. This will hopefully go away after updating Android Studio to Koala
+            //  or above. Since this only affects previews, just create the AnnotatedString up here and pass it to the previewed composable.
+            //  https://issuetracker.google.com/issues/139326648#comment18
+            //  https://issuetracker.google.com/issues/336161238
+            val systemDialogBodyText = AnnotatedString.fromHtml(stringResource(id = permission.systemDialogBodyRes))
+            val systemSettingsBodyText = AnnotatedString.fromHtml(stringResource(id = permission.systemSettingsBodyRes))
+
             // The User denied the permission only once, therefore we can still display
             // the Permission Request System Dialog
             if (shouldShowRequestPermissionRationale) {
                 PermissionGateScreenContent(
-                    bodyTextRes = permission.systemDialogBodyRes,
+                    bodyText = systemDialogBodyText,
                     requestButtonTextRes = permission.systemDialogButtonRes,
                     onRequest = { permissionRequestLauncher.launch(permission.permissionString) },
                     modifier = modifier
@@ -92,7 +104,7 @@ fun PermissionGateScreen(
                 // the User that they can manually accept the permission in the System Settings, and display
                 // a Button that leads to the System Settings, which they can decide if they want to press.
                 PermissionGateScreenContent(
-                    bodyTextRes = permission.systemSettingsBodyRes,
+                    bodyText = systemSettingsBodyText,
                     requestButtonTextRes = permission.systemSettingsButtonRes,
                     onRequest = {
                         systemSettingsLauncher.launch(
@@ -114,7 +126,7 @@ fun PermissionGateScreen(
 
 @Composable
 fun PermissionGateScreenContent(
-    @StringRes bodyTextRes: Int,
+    bodyText: AnnotatedString,
     @StringRes requestButtonTextRes: Int,
     onRequest: () -> Unit,
     modifier: Modifier = Modifier
@@ -145,7 +157,7 @@ fun PermissionGateScreenContent(
 
             // Body
             Text(
-                text = stringResource(id = bodyTextRes),
+                text = bodyText,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
             )
@@ -172,7 +184,9 @@ fun PermissionGateScreenContent(
 private fun PermissionGateScreenContentSystemDialogPreview() {
     AlarmScratchTheme {
         PermissionGateScreenContent(
-            bodyTextRes = R.string.permission_missing_system_dialog,
+            bodyText = buildAnnotatedString {
+                append(stringResource(id = R.string.permission_missing_notifications_system_dialog))
+            },
             requestButtonTextRes = R.string.permission_request,
             onRequest = {},
             modifier = Modifier.fillMaxWidth()
@@ -185,7 +199,9 @@ private fun PermissionGateScreenContentSystemDialogPreview() {
 private fun PermissionGateScreenContentSystemSettingsPreview() {
     AlarmScratchTheme {
         PermissionGateScreenContent(
-            bodyTextRes = R.string.permission_missing_system_settings,
+            bodyText = buildAnnotatedString {
+                append(stringResource(id = R.string.permission_missing_notifications_system_settings))
+            },
             requestButtonTextRes = R.string.permission_open_system_settings,
             onRequest = {},
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -3,6 +3,7 @@ package com.example.alarmscratch.core.ui.permission
 import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -68,8 +69,10 @@ fun PermissionGateScreen(
             // The User denied the permission only once, therefore we can still display
             // the Permission Request System Dialog
             if (shouldShowRequestPermissionRationale) {
-                PromptAcceptPermissionSystemDialog(
-                    showSystemDialog = { permissionRequestLauncher.launch(permission) },
+                PermissionGateScreenContent(
+                    bodyTextRes = R.string.permission_missing_system_dialog,
+                    requestButtonTextRes = R.string.permission_request,
+                    onRequest = { permissionRequestLauncher.launch(permission) },
                     modifier = modifier
                 )
             } else {
@@ -79,8 +82,10 @@ fun PermissionGateScreen(
                 // Permission Request System Dialog ever again. Explain why the permission is needed, inform
                 // the User that they can manually accept the permission in the System Settings, and display
                 // a Button that leads to the System Settings, which they can decide if they want to press.
-                PromptAcceptPermissionSystemSettings(
-                    openSystemSettings = {},
+                PermissionGateScreenContent(
+                    bodyTextRes = R.string.permission_missing_system_settings,
+                    requestButtonTextRes = R.string.permission_open_system_settings,
+                    onRequest = {},
                     modifier = modifier
                 )
             }
@@ -92,8 +97,10 @@ fun PermissionGateScreen(
 }
 
 @Composable
-fun PromptAcceptPermissionSystemDialog(
-    showSystemDialog: () -> Unit,
+fun PermissionGateScreenContent(
+    @StringRes bodyTextRes: Int,
+    @StringRes requestButtonTextRes: Int,
+    onRequest: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -122,68 +129,19 @@ fun PromptAcceptPermissionSystemDialog(
 
             // Body
             Text(
-                text = stringResource(id = R.string.permission_missing_system_dialog),
+                text = stringResource(id = bodyTextRes),
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
             )
 
             // Request Button
             Button(
-                onClick = showSystemDialog,
+                onClick = onRequest,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(vertical = 10.dp)
             ) {
-                Text(text = stringResource(id = R.string.permission_request))
-            }
-        }
-    }
-}
-
-@Composable
-fun PromptAcceptPermissionSystemSettings(
-    openSystemSettings: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        modifier = modifier.verticalScroll(rememberScrollState())
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            // Icon and Title
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
-            ) {
-                // Icon
-                Icon(
-                    imageVector = Icons.Default.Warning,
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = 8.dp)
-                )
-
-                // Title
-                Text(
-                    text = stringResource(id = R.string.permission_required),
-                    fontSize = 24.sp
-                )
-            }
-
-            // Body
-            Text(
-                text = stringResource(id = R.string.permission_missing_system_settings),
-                fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
-            )
-
-            // Request Button
-            Button(
-                onClick = openSystemSettings,
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(vertical = 10.dp)
-            ) {
-                Text(text = stringResource(id = R.string.permission_open_system_settings))
+                Text(text = stringResource(id = requestButtonTextRes))
             }
         }
     }
@@ -195,10 +153,12 @@ fun PromptAcceptPermissionSystemSettings(
 
 @Preview
 @Composable
-private fun PromptAcceptPermissionSystemDialogPreview() {
+private fun PermissionGateScreenContentSystemDialogPreview() {
     AlarmScratchTheme {
-        PromptAcceptPermissionSystemDialog(
-            showSystemDialog = {},
+        PermissionGateScreenContent(
+            bodyTextRes = R.string.permission_missing_system_dialog,
+            requestButtonTextRes = R.string.permission_request,
+            onRequest = {},
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -206,10 +166,12 @@ private fun PromptAcceptPermissionSystemDialogPreview() {
 
 @Preview
 @Composable
-private fun PromptAcceptPermissionSystemSettingsPreview() {
+private fun PermissionGateScreenContentSystemSettingsPreview() {
     AlarmScratchTheme {
-        PromptAcceptPermissionSystemSettings(
-            openSystemSettings = {},
+        PermissionGateScreenContent(
+            bodyTextRes = R.string.permission_missing_system_settings,
+            requestButtonTextRes = R.string.permission_open_system_settings,
+            onRequest = {},
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -92,7 +92,7 @@ fun PermissionGateScreen(
             if (shouldShowRequestPermissionRationale) {
                 PermissionGateScreenContent(
                     bodyText = systemDialogBodyText,
-                    requestButtonTextRes = permission.systemDialogButtonRes,
+                    requestButtonTextRes = R.string.permission_request,
                     onRequest = { permissionRequestLauncher.launch(permission.permissionString) },
                     modifier = modifier
                 )
@@ -105,7 +105,7 @@ fun PermissionGateScreen(
                 // a Button that leads to the System Settings, which they can decide if they want to press.
                 PermissionGateScreenContent(
                     bodyText = systemSettingsBodyText,
-                    requestButtonTextRes = permission.systemSettingsButtonRes,
+                    requestButtonTextRes = R.string.permission_open_system_settings,
                     onRequest = {
                         systemSettingsLauncher.launch(
                             Intent(

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -122,7 +122,7 @@ fun PromptAcceptPermissionSystemDialog(
 
             // Body
             Text(
-                text = stringResource(id = R.string.permission_missing_notification),
+                text = stringResource(id = R.string.permission_missing_system_dialog),
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
             )
@@ -171,7 +171,7 @@ fun PromptAcceptPermissionSystemSettings(
 
             // Body
             Text(
-                text = "Accept Permission via System Settings",
+                text = stringResource(id = R.string.permission_missing_system_settings),
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
             )
@@ -183,7 +183,7 @@ fun PromptAcceptPermissionSystemSettings(
                     .align(Alignment.CenterHorizontally)
                     .padding(vertical = 10.dp)
             ) {
-                Text(text = "Open System Settings")
+                Text(text = stringResource(id = R.string.permission_open_system_settings))
             }
         }
     }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -36,7 +36,7 @@ import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 
 @Composable
 fun PermissionGateScreen(
-    permission: String,
+    permission: Permission,
     gatedScreen: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     permissionGateViewModel: PermissionGateViewModel = viewModel(factory = PermissionGateViewModel.Factory)
@@ -47,32 +47,32 @@ fun PermissionGateScreen(
 
     // Permission logic
     val shouldShowRequestPermissionRationale = (LocalContext.current as? Activity)
-        ?.shouldShowRequestPermissionRationale(permission)
+        ?.shouldShowRequestPermissionRationale(permission.permissionString)
         ?: false
     val permissionRequestLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
-        permissionGateViewModel.onPermissionResult(permission, isGranted)
+        permissionGateViewModel.onPermissionResult(permission.permissionString, isGranted)
     }
 
     // Must auto-call because of the nature of permissions on Android
     LaunchedEffect(key1 = attemptedToAskForPermission) {
         if (!attemptedToAskForPermission) {
-            permissionRequestLauncher.launch(permission)
+            permissionRequestLauncher.launch(permission.permissionString)
         }
     }
 
     // Don't show anything until we know we've asked the User for the required permissions at least one time
     if (attemptedToAskForPermission) {
-        // Permission Denied
-        if (deniedPermissionList.contains(permission)) {
+        // Permission denied
+        if (deniedPermissionList.contains(permission.permissionString)) {
             // The User denied the permission only once, therefore we can still display
             // the Permission Request System Dialog
             if (shouldShowRequestPermissionRationale) {
                 PermissionGateScreenContent(
-                    bodyTextRes = R.string.permission_missing_system_dialog,
-                    requestButtonTextRes = R.string.permission_request,
-                    onRequest = { permissionRequestLauncher.launch(permission) },
+                    bodyTextRes = permission.systemDialogBodyRes,
+                    requestButtonTextRes = permission.systemDialogButtonRes,
+                    onRequest = { permissionRequestLauncher.launch(permission.permissionString) },
                     modifier = modifier
                 )
             } else {
@@ -83,8 +83,8 @@ fun PermissionGateScreen(
                 // the User that they can manually accept the permission in the System Settings, and display
                 // a Button that leads to the System Settings, which they can decide if they want to press.
                 PermissionGateScreenContent(
-                    bodyTextRes = R.string.permission_missing_system_settings,
-                    requestButtonTextRes = R.string.permission_open_system_settings,
+                    bodyTextRes = permission.systemSettingsBodyRes,
+                    requestButtonTextRes = permission.systemSettingsButtonRes,
                     onRequest = {},
                     modifier = modifier
                 )

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
@@ -43,8 +43,6 @@ class PermissionGateViewModel : ViewModel() {
     }
 
     fun onReturnFromSystemSettings(context: Context, permission: String) {
-        _attemptedToAskForPermission.value = true
-
         val isGranted = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
         if (isGranted && deniedPermissionList.isNotEmpty()) {
             // List can contain duplicates, remove all instances

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
@@ -1,6 +1,9 @@
 package com.example.alarmscratch.core.ui.permission
 
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.runtime.mutableStateListOf
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
@@ -34,6 +37,16 @@ class PermissionGateViewModel : ViewModel() {
         if (!isGranted) {
             deniedPermissionList.add(permission)
         } else if (deniedPermissionList.isNotEmpty()) {
+            // List can contain duplicates, remove all instances
+            deniedPermissionList.removeAll { it == permission }
+        }
+    }
+
+    fun onReturnFromSystemSettings(context: Context, permission: String) {
+        _attemptedToAskForPermission.value = true
+
+        val isGranted = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        if (isGranted && deniedPermissionList.isNotEmpty()) {
             // List can contain duplicates, remove all instances
             deniedPermissionList.removeAll { it == permission }
         }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.alarmscratch.core.ui.permission
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class PermissionGateViewModel : ViewModel() {
+
+    // Permissions
+    private val _attemptedToAskForPermission: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val attemptedToAskForPermission: StateFlow<Boolean> = _attemptedToAskForPermission.asStateFlow()
+    val deniedPermissionList = mutableStateListOf<String>()
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                PermissionGateViewModel() as T
+        }
+    }
+
+    /*
+     * Callback
+     */
+
+    fun onPermissionResult(permission: String, isGranted: Boolean) {
+        _attemptedToAskForPermission.value = true
+
+        if (!isGranted) {
+            deniedPermissionList.add(permission)
+        } else if (deniedPermissionList.isNotEmpty()) {
+            // List can contain duplicates, remove all instances
+            deniedPermissionList.removeAll { it == permission }
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/UriScheme.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/UriScheme.kt
@@ -1,0 +1,5 @@
+package com.example.alarmscratch.core.ui.permission
+
+object UriScheme {
+    const val PACKAGE = "package"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,4 +140,11 @@
     -->
     <string name="permission_channel_alarm_name">Alarm</string>
     <string name="permission_channel_alarm_desc">Used for Alarm notifications</string>
+    <string name="permission_required">Permission Required</string>
+    <string name="permission_missing_notification">Notification permissions are required to use
+        Alarms. Please request Notification permissions by pressing the Request button below,
+        and then selecting \"Allow\" on the following popup.\n\nIf you do not grant Notification
+        permissions then you will not be able to create or edit Alarms, and any Alarms that you
+        previously created *will not go off*.</string>
+    <string name="permission_request">Request</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,18 +141,20 @@
     <string name="permission_channel_alarm_name">Alarm</string>
     <string name="permission_channel_alarm_desc">Used for Alarm notifications</string>
     <string name="permission_required">Permission Required</string>
-    <string name="permission_missing_system_dialog">The Notification Permission is required to use
-        Alarms. If you do not grant the Notification Permission then you will not be able to create
-        or edit Alarms, and any Alarms that you previously created *will not go off*.
-        \n\nPlease request the Notification Permission by pressing the Request button below,
+    <string name="permission_request">Request</string>
+    <string name="permission_open_system_settings">Open System Settings</string>
+    <string name="permission_missing_notifications_system_dialog">The Notification Permission is
+        required to use Alarms. Without it you will not be able to create or edit Alarms,
+        &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
+        &lt;br&gt;&lt;br&gt;
+        Please request the Notification Permission by pressing the Request button below,
         and then selecting \"Allow\" on the following popup.</string>
-    <string name="permission_missing_system_settings">The Notification Permission is required to use
-        Alarms. If you do not grant the Notification Permission then you will not be able to create
-        or edit Alarms, and any Alarms that you previously created *will not go off*.
-        \n\nTo use Alarms, you must manually accept the Permission in the System Settings.
+    <string name="permission_missing_notifications_system_settings">The Notification Permission is
+        required to use Alarms. Without it you will not be able to create or edit Alarms,
+        &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
+        &lt;br&gt;&lt;br&gt;
+        To use Alarms, you must manually accept the Permission in the System Settings.
         To do so, press the \"Open System Settings\" button below, then navigate to \"Permissions\"
         &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
         ensure that the \"Alarm\" Notification is also enabled.</string>
-    <string name="permission_request">Request</string>
-    <string name="permission_open_system_settings">Open System Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,10 +141,18 @@
     <string name="permission_channel_alarm_name">Alarm</string>
     <string name="permission_channel_alarm_desc">Used for Alarm notifications</string>
     <string name="permission_required">Permission Required</string>
-    <string name="permission_missing_notification">Notification permissions are required to use
-        Alarms. Please request Notification permissions by pressing the Request button below,
-        and then selecting \"Allow\" on the following popup.\n\nIf you do not grant Notification
-        permissions then you will not be able to create or edit Alarms, and any Alarms that you
-        previously created *will not go off*.</string>
+    <string name="permission_missing_system_dialog">The Notification Permission is required to use
+        Alarms. If you do not grant the Notification Permission then you will not be able to create
+        or edit Alarms, and any Alarms that you previously created *will not go off*.
+        \n\nPlease request the Notification Permission by pressing the Request button below,
+        and then selecting \"Allow\" on the following popup.</string>
+    <string name="permission_missing_system_settings">The Notification Permission is required to use
+        Alarms. If you do not grant the Notification Permission then you will not be able to create
+        or edit Alarms, and any Alarms that you previously created *will not go off*.
+        \n\nTo use Alarms, you must manually accept the Permission in the System Settings.
+        To do so, press the \"Open System Settings\" button below, then navigate to \"Permissions\"
+        &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
+        ensure that the \"Alarm\" Notification is also enabled.</string>
     <string name="permission_request">Request</string>
+    <string name="permission_open_system_settings">Open System Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
         required to use Alarms. Without it you will not be able to create or edit Alarms,
         &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
         &lt;br&gt;&lt;br&gt;
-        Please request the Notification Permission by pressing the Request button below,
+        Please request the Notification Permission by pressing the \"Request\" button below,
         and then selecting \"Allow\" on the following popup.</string>
     <string name="permission_missing_notifications_system_settings">The Notification Permission is
         required to use Alarms. Without it you will not be able to create or edit Alarms,


### PR DESCRIPTION
### Description
- Gate the `AlarmListScreen` behind a permission check to `Manifest.permission.POST_NOTIFICATIONS`
  - Android's Permission System is a bit lacking in the feedback it provides to developers at runtime. Therefore, there are some things that you cannot know about the state of the Permission System through direct means. Because of this, complex logic must be set up client side to make certain determinations. My solution is very close to handling all cases, but it does have one shortcoming which I will address further down. Below is the current behavior.
    - NOTE: You cannot force the System to display the `System Permission Dialog`, you can only REQUEST that it shows. If the User has already refused the permission twice, even if on separate runs of the app, it will NEVER show the `System Permission Dialog` again unless: 1) the User reinstalls the app, 2) The User goes into the `System Settings` and manually clears the data for the app, or 3) The User goes into the `System Settings` and manually toggles the setting on, then off again. In this third scenario, if the User subsequently denies the permission even one time, it will NEVER show the `System Permission Dialog` again until the User performs one of the above 3 actions. Scenarios 1 & 2 will allow the User to again deny the permission twice before NEVER showing it again, etc. etc.
    - Permission not granted already
      - REQUEST that the System show the `System Permission Dialog`
      - If the User says no on the `System Permission Dialog`
        - Show a screen that explains to the User that the Notification permission is needed, and has a button to REQUEST that the System show the `System Permission Dialog`
        - User says yes -> Show `AlarmListScreen`
        - User says no -> The System will NEVER again show the `System Permission Dialog` when REQUESTED since the User already denied it twice. Now we display a similar screen to before explaining why the permission is needed, except this one leads to the `System Settings` so the User can manually enable the permission.
          - User enables the permission -> Show `AlarmListScreen`
          - User doesn't enable the permission -> Continue to show the same screen asking the User to go to the `System Settings`

### Uncovered Edge Case
The `System Settings` manual acceptance screen will sometimes show instead of the `Re-Request Permission` screen. This is because the `System Permission Dialog` can be dismissed on Back Press and Click Outside, which confuses the logic I've implemented to infer the state of the Permission System. The feedback from the `System Permission Dialog` is just "Permission Denied". There is no differentiation between an explicit Denial, or just a Dialog dismissal without selecting anything. Because of this, the screen asking the User to go to the `System Settings` may be wrongfully displayed instead of the screen that can re-request the `System Permission Dialog` be shown. This isn't really that big of a deal since either way the `AlarmListScreen` is being gated behind the permission, but the User experience could be better.

### Final Thoughts
The Android permission system is flawed and the feedback it returns at runtime is inadequate. All of the troubles of this API stem from the fact that the System does not tell you, specifically, when the permission has been permanently denied by the User. The feedback returned from the System via callback/return value at runtime makes absolutely no distinction between different scenarios, and simply returns either `PERMISSION_GRANTED` or `PERMISSION_DENIED`, or `true` or `false`, depending on which one of 3 methods/callbacks you're using to infer what's going on. And yes you need all 3 if you plan on showing screens to give the User an opportunity to retry the permission, and more specifically different screens depending on if the permission is permanently denied (because after it's permanently denied the User will have to manually accept the permission in the `System Settings`).

Using a `DataStore` client-side is not a viable solution to this since the amount of times a User can deny the permission before it's permanently denied varies. It would also need to be maintained reliably, which would likely prove just as difficult since you'd be working with the same Permission APIs, and now you'd have 2 sources of truth: the System, and the `DataStore`.

To solve the permission problem, complex logic must be created client-side to attempt to infer what actually happened, and what the current state of the System is (is the permission permanently denied, did the User actually select "Don't Allow", or did they just dismiss the Dialog, etc.) and you can never really know for sure. I believe I may be able to come up with a fix for the above edge case, but for now I'm just leaving this as is. Much more could be said to explain exactly how to infer the state of the System, but I will cut this here.

### Preview Bug Workaround
There's a bug in Android Studio where `TextDefaults.fromHtml()` breaks compose previews. I use a similar method called `AnnotatedString.fromHtml()`. I'm experiencing a similar issue with the `AnnotatedString` version. Due to what I've read on `Google's IssueTracker`, it seems like it's the same bug. This bug was apparently fixed in Android Studio Koala, which I'm currently not using. Below is a link to the Android Studio bug, as well as another issue that leads me to believe that `AnnotatedString` has the same issue.
- https://issuetracker.google.com/issues/139326648#comment18
- https://issuetracker.google.com/issues/336161238