### PR TITLE
Feature | FAB Permission Gate

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -3,12 +3,6 @@ package com.example.alarmscratch.core.ui.core
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -136,10 +129,8 @@ fun CoreScreenContent(
     retrieveSnackbarFromPrevious: () -> Unit,
     internalScreen: @Composable () -> Unit
 ) {
-    // LavaFloatingActionButton specs
-    val fabHeight = 70.dp
+    // Specs
     val volcanoSpacerHeight = 6.dp
-    val fabAnimationHeight = with(LocalDensity.current) { (fabHeight + volcanoSpacerHeight).toPx().toInt() }
 
     // Snackbar
     val scope = rememberCoroutineScope()
@@ -198,22 +189,11 @@ fun CoreScreenContent(
             }
 
             // LavaFloatingActionButton with Slide In/Out Animation
-            AnimatedVisibility(
-                visible = selectedNavComponentDest == Destination.AlarmListScreen,
-                enter = slideInVertically(
-                    animationSpec = tween(durationMillis = 150, easing = LinearOutSlowInEasing),
-                    initialOffsetY = { fabAnimationHeight }
-                ),
-                exit = slideOutVertically(
-                    animationSpec = tween(durationMillis = 250, easing = FastOutLinearInEasing),
-                    targetOffsetY = { fabAnimationHeight }
-                )
-            ) {
-                LavaFloatingActionButton(
-                    enabled = selectedNavComponentDest == Destination.AlarmListScreen,
-                    onFabClicked = onFabClicked
-                )
-            }
+            LavaFloatingActionButton(
+                selectedNavComponentDest = selectedNavComponentDest,
+                onFabClicked = onFabClicked,
+                volcanoSpacerHeight = volcanoSpacerHeight
+            )
             Spacer(modifier = Modifier.height(volcanoSpacerHeight))
 
             // Volcano

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.core.ui.core.component
 
+import android.os.Build
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
@@ -31,6 +32,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.alarmscratch.core.navigation.Destination
+import com.example.alarmscratch.core.ui.permission.Permission
+import com.example.alarmscratch.core.ui.permission.SimplePermissionGate
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.AncientLavaOrange
 import com.example.alarmscratch.core.ui.theme.MaxBrightLavaOrange
@@ -46,23 +49,38 @@ fun LavaFloatingActionButton(
     val fabHeight = 70.dp
     val fabAnimationHeight = with(LocalDensity.current) { (fabHeight + volcanoSpacerHeight).toPx().toInt() }
 
-    // LavaFloatingActionButton with Slide In/Out Animation
-    AnimatedVisibility(
-        visible = selectedNavComponentDest == Destination.AlarmListScreen,
-        enter = slideInVertically(
-            animationSpec = tween(durationMillis = 150, easing = LinearOutSlowInEasing),
-            initialOffsetY = { fabAnimationHeight }
-        ),
-        exit = slideOutVertically(
-            animationSpec = tween(durationMillis = 250, easing = FastOutLinearInEasing),
-            targetOffsetY = { fabAnimationHeight }
+    val floatingActionButtonContent: @Composable () -> Unit = {
+        AnimatedVisibility(
+            visible = selectedNavComponentDest == Destination.AlarmListScreen,
+            enter = slideInVertically(
+                animationSpec = tween(durationMillis = 150, easing = LinearOutSlowInEasing),
+                initialOffsetY = { fabAnimationHeight }
+            ),
+            exit = slideOutVertically(
+                animationSpec = tween(durationMillis = 250, easing = FastOutLinearInEasing),
+                targetOffsetY = { fabAnimationHeight }
+            )
+        ) {
+            LavaFloatingActionButtonContent(
+                enabled = selectedNavComponentDest == Destination.AlarmListScreen,
+                onFabClicked = onFabClicked,
+                modifier = modifier
+            )
+        }
+    }
+
+    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        // TODO: We should also check to see if the Alarm Notification Channel is enabled because the User could
+        //  have accepted the General Notification Permission, and have the Alarm specific channel disabled.
+        //  Do the permission check first, then check the Alarm channel second.
+        SimplePermissionGate(
+            permission = Permission.PostNotifications,
+            gatedComposable = floatingActionButtonContent
         )
-    ) {
-        LavaFloatingActionButtonContent(
-            enabled = selectedNavComponentDest == Destination.AlarmListScreen,
-            onFabClicked = onFabClicked,
-            modifier = modifier
-        )
+    } else {
+        // TODO: Gate this with a check to see if the Alarm Notification Channel is enabled
+        floatingActionButtonContent()
     }
 }
 

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
@@ -1,5 +1,11 @@
 package com.example.alarmscratch.core.ui.core.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -20,16 +26,50 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.AncientLavaOrange
 import com.example.alarmscratch.core.ui.theme.MaxBrightLavaOrange
 
+@Composable
+fun LavaFloatingActionButton(
+    selectedNavComponentDest: Destination,
+    onFabClicked: () -> Unit,
+    volcanoSpacerHeight: Dp,
+    modifier: Modifier = Modifier
+) {
+    // LavaFloatingActionButton specs
+    val fabHeight = 70.dp
+    val fabAnimationHeight = with(LocalDensity.current) { (fabHeight + volcanoSpacerHeight).toPx().toInt() }
+
+    // LavaFloatingActionButton with Slide In/Out Animation
+    AnimatedVisibility(
+        visible = selectedNavComponentDest == Destination.AlarmListScreen,
+        enter = slideInVertically(
+            animationSpec = tween(durationMillis = 150, easing = LinearOutSlowInEasing),
+            initialOffsetY = { fabAnimationHeight }
+        ),
+        exit = slideOutVertically(
+            animationSpec = tween(durationMillis = 250, easing = FastOutLinearInEasing),
+            targetOffsetY = { fabAnimationHeight }
+        )
+    ) {
+        LavaFloatingActionButtonContent(
+            enabled = selectedNavComponentDest == Destination.AlarmListScreen,
+            onFabClicked = onFabClicked,
+            modifier = modifier
+        )
+    }
+}
+
 // ExperimentalMaterial3Api OptIn for LocalRippleConfiguration and RippleConfiguration
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LavaFloatingActionButton(
+fun LavaFloatingActionButtonContent(
     enabled: Boolean,
     onFabClicked: () -> Unit,
     modifier: Modifier = Modifier
@@ -115,7 +155,7 @@ fun LavaFloatingActionButton(
 @Composable
 private fun LavaFloatingActionButtonPreview() {
     AlarmScratchTheme {
-        LavaFloatingActionButton(
+        LavaFloatingActionButtonContent(
             enabled = true,
             onFabClicked = {},
             modifier = Modifier.padding(20.dp)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGate.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGate.kt
@@ -1,0 +1,46 @@
+package com.example.alarmscratch.core.ui.permission
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun SimplePermissionGate(
+    permission: Permission,
+    gatedComposable: @Composable () -> Unit,
+    simplePermissionGateViewModel: SimplePermissionGateViewModel = viewModel(factory = SimplePermissionGateViewModel.Factory)
+) {
+    // State
+    val isPermissionGranted by simplePermissionGateViewModel.isPermissionGranted.collectAsState()
+
+    // Permission check
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val checkForPermission: () -> Unit = {
+        simplePermissionGateViewModel.checkForPermission(context, permission.permissionString)
+    }
+
+    // Manually refresh the state every time the LifecycleOwner enters the RESUMED state to ensure
+    // that we're always up to date with the state of the permission. Since we're using RESUMED here,
+    // this will re-trigger when the System Permission Dialog is closed, if it was present.
+    LaunchedEffect(key1 = context, key2 = lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            withContext(Dispatchers.Main.immediate) {
+                checkForPermission()
+            }
+        }
+    }
+
+    // Show gated composable if permission is granted
+    if (isPermissionGranted) {
+        gatedComposable()
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGateViewModel.kt
@@ -1,0 +1,36 @@
+package com.example.alarmscratch.core.ui.permission
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SimplePermissionGateViewModel : ViewModel() {
+
+    // Permissions
+    private val _isPermissionGranted: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isPermissionGranted: StateFlow<Boolean> = _isPermissionGranted.asStateFlow()
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                SimplePermissionGateViewModel() as T
+        }
+    }
+
+    /*
+     * Check
+     */
+
+    fun checkForPermission(context: Context, permission: String) {
+        _isPermissionGranted.value =
+            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+}


### PR DESCRIPTION
### Description
- Gate the visibility of the `LavaFloatingActionButton` behind the `Manifest.permission.POST_NOTIFICATIONS` permission
  - In doing so, the `SimplePermissionGate` was created. This composable gates other composables behind permission checks, and does not prompt the User to accept any permission. It simply hides the element.
- Move the `LavaFloatingActionButton` animation logic from `CoreScreen` to inside `LavaFloatingActionButton`