### PR TITLE
Feature | Permission Gate Alarm Create Edit

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -1,5 +1,12 @@
 package com.example.alarmscratch.alarm.ui.alarmcreate
 
+import android.os.Build
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -22,7 +29,10 @@ import com.example.alarmscratch.core.data.model.RingtoneData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getRingtone
 import com.example.alarmscratch.core.extension.getStringFromBackStack
+import com.example.alarmscratch.core.ui.permission.Permission
+import com.example.alarmscratch.core.ui.permission.PermissionGateScreen
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.util.StatusBarUtil
 import com.example.alarmscratch.settings.data.model.TimeDisplay
 import com.example.alarmscratch.settings.data.repository.GeneralSettingsState
 import kotlinx.coroutines.channels.Channel
@@ -44,45 +54,67 @@ fun AlarmCreationScreen(
     // Flow
     val snackbarFlow = alarmCreationViewModel.snackbarFlow
 
-    if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
-        // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
-        // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
-        // then the new Ringtone's URI will be saved here.
-        alarmCreationViewModel.updateRingtone(
-            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
-        )
+    val alarmCreateEditScreen: @Composable () -> Unit = {
+        if (alarmState is AlarmState.Success && generalSettingsState is GeneralSettingsState.Success) {
+            // Fetch updated Ringtone URI from this back stack entry's SavedStateHandle.
+            // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
+            // then the new Ringtone's URI will be saved here.
+            alarmCreationViewModel.updateRingtone(
+                navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+            )
 
-        val context = LocalContext.current
-        val alarm = (alarmState as AlarmState.Success).alarm
-        // This was extracted for previews, since previews can't actually "get a Ringtone"
-        // from anywhere, therefore they can't get a name to display in the preview.
-        val alarmRingtoneName = alarm.getRingtone(context).getTitle(context)
-        val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
+            val context = LocalContext.current
+            val alarm = (alarmState as AlarmState.Success).alarm
+            // This was extracted for previews, since previews can't actually "get a Ringtone"
+            // from anywhere, therefore they can't get a name to display in the preview.
+            val alarmRingtoneName = alarm.getRingtone(context).getTitle(context)
+            val generalSettings = (generalSettingsState as GeneralSettingsState.Success).generalSettings
 
-        AlarmCreateEditScreen(
-            navHostController = navHostController,
-            navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
-            titleRes = R.string.alarm_creation_screen_title,
-            alarm = alarm,
-            alarmRingtoneName = alarmRingtoneName,
-            timeDisplay = generalSettings.timeDisplay,
-            saveAndScheduleAlarm = alarmCreationViewModel::saveAndScheduleAlarm,
-            updateName = alarmCreationViewModel::updateName,
-            updateDate = alarmCreationViewModel::updateDateAndResetWeeklyRepeater,
-            updateTime = alarmCreationViewModel::updateTime,
-            addDay = alarmCreationViewModel::addDay,
-            removeDay = alarmCreationViewModel::removeDay,
-            toggleVibration = alarmCreationViewModel::toggleVibration,
-            updateSnoozeDuration = alarmCreationViewModel::updateSnoozeDuration,
-            isNameValid = isNameValid,
-            snackbarFlow = snackbarFlow,
-            tryNavigateUp = { alarmCreationViewModel.tryNavigateUp(navHostController) },
-            tryNavigateBack = { alarmCreationViewModel.tryNavigateBack(navHostController) },
-            showUnsavedChangesDialog = showUnsavedChangesDialog,
-            unsavedChangesLeave = { alarmCreationViewModel.unsavedChangesLeave(navHostController) },
-            unsavedChangesStay = alarmCreationViewModel::unsavedChangesStay,
-            modifier = modifier
-        )
+            AlarmCreateEditScreen(
+                navHostController = navHostController,
+                navigateToRingtonePickerScreen = navigateToRingtonePickerScreen,
+                titleRes = R.string.alarm_creation_screen_title,
+                alarm = alarm,
+                alarmRingtoneName = alarmRingtoneName,
+                timeDisplay = generalSettings.timeDisplay,
+                saveAndScheduleAlarm = alarmCreationViewModel::saveAndScheduleAlarm,
+                updateName = alarmCreationViewModel::updateName,
+                updateDate = alarmCreationViewModel::updateDateAndResetWeeklyRepeater,
+                updateTime = alarmCreationViewModel::updateTime,
+                addDay = alarmCreationViewModel::addDay,
+                removeDay = alarmCreationViewModel::removeDay,
+                toggleVibration = alarmCreationViewModel::toggleVibration,
+                updateSnoozeDuration = alarmCreationViewModel::updateSnoozeDuration,
+                isNameValid = isNameValid,
+                snackbarFlow = snackbarFlow,
+                tryNavigateUp = { alarmCreationViewModel.tryNavigateUp(navHostController) },
+                tryNavigateBack = { alarmCreationViewModel.tryNavigateBack(navHostController) },
+                showUnsavedChangesDialog = showUnsavedChangesDialog,
+                unsavedChangesLeave = { alarmCreationViewModel.unsavedChangesLeave(navHostController) },
+                unsavedChangesStay = alarmCreationViewModel::unsavedChangesStay,
+                modifier = modifier
+            )
+        }
+    }
+
+    // TODO: This permission gate is a stopgap. In the future I want to pop a Dialog when the save button
+    //  is pressed if a permission is missing, rather than replacing the entire screen like below.
+    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        // Configure Status Bar
+        StatusBarUtil.setDarkStatusBar()
+
+        Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+            PermissionGateScreen(
+                permission = Permission.PostNotifications,
+                gatedScreen = alarmCreateEditScreen,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.systemBars)
+            )
+        }
+    } else {
+        alarmCreateEditScreen()
     }
 }
 


### PR DESCRIPTION
### Description
- Gate `AlarmCreationScreen` and `AlarmEditScreen` behind `Manifest.permission.POST_NOTIFICATIONS` with `PermissionGateScreen`
  - There's already an indirect permission gate on these screens, by the fact that the `AlarmListScreen` and `LavaFloatingActionButton` both do not show up on the `CoreScreen` when the `Manifest.permission.POST_NOTIFICATIONS` is denied. However, it's possible that the User could open the `AlarmCreationScreen` or `AlarmEditScreens` with the permission granted, and then revoke the permission while still on those screens. This is pretty unlikely, but is and edge case that should still be covered.
    - As an unlikely edge case, this is receiving a stopgap solution. For now, the entire screen will be replaced with `PermissionGateScreen` to accelerate development since that screen already exists. In the future, I'd like to pop a `Dialog` that is similar to the `PermissionGateScreen` when the user presses the Save Button.