### PR TITLE
Feature | Alarm List Notification Check

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -19,8 +19,8 @@ import com.example.alarmscratch.alarm.data.preview.alarmSampleDataHardCodedIds
 import com.example.alarmscratch.alarm.data.repository.AlarmListState
 import com.example.alarmscratch.alarm.ui.alarmlist.component.AlarmCard
 import com.example.alarmscratch.alarm.ui.alarmlist.component.NoAlarmsCard
-import com.example.alarmscratch.core.ui.notificationcheck.AppNotificationChannel
 import com.example.alarmscratch.core.ui.notificationcheck.NotificationChannelGateScreen
+import com.example.alarmscratch.core.ui.notificationcheck.NotificationPermission
 import com.example.alarmscratch.core.ui.permission.Permission
 import com.example.alarmscratch.core.ui.permission.PermissionGateScreen
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
@@ -40,7 +40,7 @@ fun AlarmListScreen(
     val notificationGatedAlarmList: @Composable () -> Unit = {
         // Gate Alarm List Screen behind Alarm Notification Channel
         NotificationChannelGateScreen(
-            appNotificationChannel = AppNotificationChannel.Alarm,
+            notificationPermission = NotificationPermission.Alarm,
             gatedScreen = {
                 if (alarmListState is AlarmListState.Success && generalSettingsState is GeneralSettingsState.Success) {
                     val alarmList = (alarmListState as AlarmListState.Success).alarmList

--- a/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/AppNotificationChannel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/AppNotificationChannel.kt
@@ -1,0 +1,20 @@
+package com.example.alarmscratch.core.ui.notificationcheck
+
+import android.app.NotificationManager
+import androidx.annotation.StringRes
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.ui.notification.AlarmNotification
+
+sealed class AppNotificationChannel(
+    val id: String,
+    @StringRes val name: Int,
+    val importance: Int,
+    @StringRes val description: Int
+) {
+    data object Alarm : AppNotificationChannel(
+        id = AlarmNotification.CHANNEL_ID_ALARM_NOTIFICATION,
+        name = R.string.permission_channel_alarm_name,
+        importance = NotificationManager.IMPORTANCE_HIGH,
+        description = R.string.permission_channel_alarm_desc
+    )
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateScreen.kt
@@ -1,0 +1,131 @@
+package com.example.alarmscratch.core.ui.notificationcheck
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun NotificationChannelGateScreen(
+    appNotificationChannel: AppNotificationChannel,
+    gatedScreen: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    notificationChannelGateViewModel: NotificationChannelGateViewModel = viewModel(factory = NotificationChannelGateViewModel.Factory)
+) {
+    // State
+    val disabledChannelList = notificationChannelGateViewModel.disabledChannelList
+
+    // Notification check
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val checkNotificationChannelStatus: () -> Unit = {
+        notificationChannelGateViewModel.checkNotificationChannelStatus(context, appNotificationChannel)
+    }
+
+    LaunchedEffect(key1 = context, key2 = lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            withContext(Dispatchers.Main.immediate) {
+                checkNotificationChannelStatus()
+            }
+        }
+    }
+
+    if (disabledChannelList.isNotEmpty()) {
+        NotificationChannelGateScreenContent(
+            openSettings = { notificationChannelGateViewModel.openNotificationSettings(context) },
+            modifier = modifier
+        )
+    } else {
+        gatedScreen()
+    }
+}
+
+@Composable
+fun NotificationChannelGateScreenContent(
+    openSettings: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = modifier.verticalScroll(rememberScrollState())
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Icon and Title
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = 14.dp, top = 14.dp, end = 14.dp)
+            ) {
+                // Icon
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+
+                // Title
+                Text(
+                    text = "Notifications Required",
+                    fontSize = 24.sp
+                )
+            }
+
+            // Body
+            Text(
+                text = "Alarm Notification required",
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(start = 24.dp, top = 12.dp, end = 24.dp)
+            )
+
+            // Request Button
+            Button(
+                onClick = openSettings,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 10.dp)
+            ) {
+                Text(text = "Open System Settings")
+            }
+        }
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview
+@Composable
+private fun NotificationChannelGateScreenPreview() {
+    AlarmScratchTheme {
+        NotificationChannelGateScreenContent(
+            openSettings = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateScreen.kt
@@ -54,7 +54,7 @@ fun NotificationChannelGateScreen(
     }
 
     LaunchedEffect(key1 = context, key2 = lifecycleOwner.lifecycle) {
-        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             withContext(Dispatchers.Main.immediate) {
                 checkNotificationChannelStatus()
             }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationChannelGateViewModel.kt
@@ -1,0 +1,56 @@
+package com.example.alarmscratch.core.ui.notificationcheck
+
+import android.app.Activity
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+
+class NotificationChannelGateViewModel : ViewModel() {
+
+    // Notification
+    val disabledChannelList = mutableStateListOf<AppNotificationChannel>()
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                NotificationChannelGateViewModel() as T
+        }
+    }
+
+    /*
+     * Check
+     */
+
+    fun checkNotificationChannelStatus(context: Context, appNotificationChannel: AppNotificationChannel) {
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        val channel = notificationManager.getNotificationChannel(appNotificationChannel.id)
+        val isChannelEnabled =
+            notificationManager.areNotificationsEnabled() && channel.importance != NotificationManager.IMPORTANCE_NONE
+
+        if (!isChannelEnabled) {
+            disabledChannelList.add(appNotificationChannel)
+        } else if (disabledChannelList.isNotEmpty()) {
+            // List can contain duplicates, remove all instances
+            disabledChannelList.removeAll { it == appNotificationChannel }
+        }
+    }
+
+    /*
+     * Navigation
+     */
+
+    fun openNotificationSettings(context: Context) {
+        val notificationSettingsIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        }
+
+        (context as? Activity)?.startActivity(notificationSettingsIntent)
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationPermission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/notificationcheck/NotificationPermission.kt
@@ -1,0 +1,14 @@
+package com.example.alarmscratch.core.ui.notificationcheck
+
+import androidx.annotation.StringRes
+import com.example.alarmscratch.R
+
+sealed class NotificationPermission(
+    val appNotificationChannel: AppNotificationChannel,
+    @StringRes val notificationDisabledBodyText: Int
+) {
+    data object Alarm : NotificationPermission(
+        appNotificationChannel = AppNotificationChannel.Alarm,
+        notificationDisabledBodyText = R.string.notification_missing_alarm_system_settings
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,4 +157,19 @@
         To do so, press the \"Open System Settings\" button below, then navigate to \"Permissions\"
         &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
         ensure that the \"Alarm\" Notification is also enabled.</string>
+
+    <!--
+        ***************************
+        ** Notification Settings **
+        ***************************
+    -->
+    <string name="notification_required">Notifications Required</string>
+    <string name="notification_open_notification_settings">Notification Settings</string>
+    <string name="notification_missing_alarm_system_settings">Alarm Notifications are required to
+        use Alarms. Without enabling them you will not be able to create or edit Alarms,
+        &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
+        &lt;br&gt;&lt;br&gt;
+        To use Alarms, you must manually enable Alarm Notifications in the System Settings.
+        To do so, press the \"Notification Settings\" button below, then toggle \"Alarm\"
+        Notifications on.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="permission_channel_alarm_desc">Used for Alarm notifications</string>
     <string name="permission_required">Permission Required</string>
     <string name="permission_request">Request</string>
-    <string name="permission_open_system_settings">Open System Settings</string>
+    <string name="permission_open_system_settings">System Settings</string>
     <string name="permission_missing_notifications_system_dialog">The Notification Permission is
         required to use Alarms. Without it you will not be able to create or edit Alarms,
         &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
@@ -154,7 +154,7 @@
         &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
         &lt;br&gt;&lt;br&gt;
         To use Alarms, you must manually accept the Permission in the System Settings.
-        To do so, press the \"Open System Settings\" button below, then navigate to \"Permissions\"
+        To do so, press the \"System Settings\" button below, then navigate to \"Permissions\"
         &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
         ensure that the \"Alarm\" Notification is also enabled.</string>
 


### PR DESCRIPTION
### Description
- Gate the `AlarmListScreen` behind a check to the Alarm Notification setting via `NotificationChannelGateScreen`
- Modify strings used in `PermissionGateScreen`

### Preview Bug Workaround
Same as in PR https://github.com/Joe-Beaulieu-Dev/maritime-alarm/pull/71. There's a bug in Android Studio where `TextDefaults.fromHtml()` breaks compose previews. I use a similar method called `AnnotatedString.fromHtml()`. I'm experiencing a similar issue with the `AnnotatedString` version. Due to what I've read on `Google's IssueTracker`, it seems like it's the same bug. This bug was apparently fixed in Android Studio Koala, which I'm currently not using. Below is a link to the Android Studio bug, as well as another issue that leads me to believe that `AnnotatedString` has the same issue.
- https://issuetracker.google.com/issues/139326648#comment18
- https://issuetracker.google.com/issues/336161238
