### PR TITLE
Feature | Permission Gate Alarm Execution

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -154,29 +154,12 @@ class AlarmNotificationService : Service() {
             allNotifications.firstOrNull { notification -> notification.id == alarm.id } != null
         }
 
-        // If there's an Active Alarm, dismiss the Full Screen Notification and dismiss/reschedule the Alarm
+        // If there's an Active Alarm, dismiss the Full Screen Notification and disable/reschedule the Alarm
         if (notificationAlarm != null) {
             // Dismiss Full Screen Notification
             finishFullScreenAlarmActivity()
-
-            // Dismiss/reschedule Alarm
-            if (notificationAlarm.isRepeating()) {
-                // Calculate the next time the repeating Alarm should execute
-                val nextDateTime = AlarmUtil.nextRepeatingDateTime(
-                    notificationAlarm.dateTime,
-                    notificationAlarm.weeklyRepeater
-                )
-                // Dismiss Alarm and update with nextDateTime
-                alarmRepo.dismissAndRescheduleRepeating(notificationAlarm.id, nextDateTime)
-                // Reschedule Alarm with nextDateTime
-                AlarmScheduler.scheduleAlarm(
-                    applicationContext,
-                    notificationAlarm.toAlarmExecutionData().copy(executionDateTime = nextDateTime)
-                )
-            } else {
-                // Dismiss non-repeating Alarm
-                alarmRepo.dismissAlarm(notificationAlarm.id)
-            }
+            // Disable/reschedule Alarm
+            disableOrRescheduleAlarm(alarmRepo, notificationAlarm)
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
@@ -1,0 +1,15 @@
+package com.example.alarmscratch.core.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.example.alarmscratch.core.ui.permission.Permission
+
+object PermissionUtil {
+
+    fun isPermissionGranted(context: Context, permission: Permission): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            permission.permissionString
+        ) == PackageManager.PERMISSION_GRANTED
+}


### PR DESCRIPTION
### Description
- Gate the launch of the Alarm Execution Notification behind a check to `Manifest.permission.POST_NOTIFICATIONS`
- Create `PermissionUtil` because the permission check can be a little long. This just makes it slightly smaller on the line, and returns a `Boolean` instead of having to check an `Integer` constant.