### PR TITLE
Feature | Handle Device Time Change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,6 +83,8 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.DATE_CHANGED" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,14 @@
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+        <!-- Handle Device Time Changes -->
+        <receiver
+            android:name=".core.receiver.TimeChangeReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.TIME_SET" />
+            </intent-filter>
+        </receiver>
 
         <!--
             **************

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
@@ -55,6 +55,9 @@ interface AlarmDao {
     /*
      * One-shot Read/Write
      */
+    @Query("SELECT * FROM alarms WHERE enabled = 1")
+    suspend fun getAllEnabledAlarms(): List<Alarm>
+
     @Query("UPDATE alarms SET snoozeDateTime = :snoozeDateTime WHERE id = :id")
     suspend fun updateSnooze(id: Int, snoozeDateTime: LocalDateTime)
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/repository/AlarmRepository.kt
@@ -42,6 +42,8 @@ class AlarmRepository(private val alarmDao: AlarmDao) {
     /*
      * One-shot Read/Write
      */
+    suspend fun getAllEnabledAlarms(): List<Alarm> = alarmDao.getAllEnabledAlarms()
+
     suspend fun updateSnooze(id: Int, snoozeDateTime: LocalDateTime) =
         alarmDao.updateSnooze(id = id, snoozeDateTime = snoozeDateTime)
 

--- a/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
@@ -3,6 +3,12 @@ package com.example.alarmscratch.core.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.example.alarmscratch.alarm.alarmexecution.AlarmScheduler
+import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
+import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.core.extension.alarmApplication
+import com.example.alarmscratch.core.extension.doAsync
+import kotlinx.coroutines.Dispatchers
 
 class TimeChangeReceiver : BroadcastReceiver() {
 
@@ -10,10 +16,15 @@ class TimeChangeReceiver : BroadcastReceiver() {
         if (context != null && intent != null) {
             when (intent.action) {
                 Intent.ACTION_TIME_CHANGED ->
-                    onTimeChanged()
+                    onTimeChanged(context)
             }
         }
     }
 
-    private fun onTimeChanged() {}
+    private fun onTimeChanged(context: Context) {
+        doAsync(context.alarmApplication.applicationScope, Dispatchers.Main) {
+            val alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(context.applicationContext).alarmDao())
+            AlarmScheduler.refreshAlarms(context, alarmRepository)
+        }
+    }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
@@ -15,7 +15,9 @@ class TimeChangeReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
             when (intent.action) {
-                Intent.ACTION_TIME_CHANGED ->
+                Intent.ACTION_TIME_CHANGED,
+                Intent.ACTION_DATE_CHANGED,
+                Intent.ACTION_TIMEZONE_CHANGED ->
                     onTimeChanged(context)
             }
         }

--- a/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/receiver/TimeChangeReceiver.kt
@@ -1,0 +1,19 @@
+package com.example.alarmscratch.core.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class TimeChangeReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context != null && intent != null) {
+            when (intent.action) {
+                Intent.ACTION_TIME_CHANGED ->
+                    onTimeChanged()
+            }
+        }
+    }
+
+    private fun onTimeChanged() {}
+}


### PR DESCRIPTION
### Description
- Handle the scenarios where the Device's time, date, or time zone change
  - This is a 2 pronged approach that takes place in 2 areas. When the device time etc. changes, you must 1) ensure that Alarms that are now in the past don't go off, and 2) clean up any Alarms with invalid states in the database. When I initially started working on this, I wanted to take care of everything in the `TimeChangeReciever`. When you move the time past an Alarm that's already scheduled with the `AlarmManager`, it will immediately execute the Alarm even though the Alarm is now technically in the past. I was originally cancelling the Alarm with the `AlarmManager`, and then doing the database cleanup. However, I found that cancelling the Alarm with the `AlarmManager` was inconsistent, and sometimes the Alarm would still go off. Through testing, I determined that this must be due to a race condition, because the `AlarmManager` isn't aware of, and therefore isn't waiting for the `TimeChangeReceiver` before cancelling the Alarm. This would lead to the `AlarmManger` sometimes still executing the Alarm. Because of this, I had to split the solution into 2 separate areas of the code, as described below:
    - `AlarmActionReceiver`
      - Don't start the `AlarmNotificationService` to to show the Alarm `Notification` if the Alarm time is in the past
    - `TimeChangeReceiver`
      - Clean up any enabled Alarms in the database that are in an invalid state after a time, date, or time zone change