### PR TITLE
Feature | Change Alarm Scheduling Method

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
@@ -8,24 +8,30 @@ import android.content.Intent
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.alarm.util.AlarmUtil
+import com.example.alarmscratch.core.MainActivity
 import com.example.alarmscratch.core.extension.toAlarmExecutionData
 import com.example.alarmscratch.core.extension.zonedEpochMillis
 
 object AlarmScheduler {
 
     fun scheduleAlarm(context: Context, alarmExecutionData: AlarmExecutionData) {
+        // Create AlarmClockInfo that launches the application
+        val alarmClockInfo = AlarmClockInfo(
+            alarmExecutionData.executionDateTime.zonedEpochMillis(),
+            PendingIntent.getActivity(
+                context,
+                0,
+                Intent(context, MainActivity::class.java),
+                PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+
         // Create PendingIntent to execute Alarm
         val alarmPendingIntent = PendingIntent.getBroadcast(
             context,
             alarmExecutionData.id,
             AlarmIntentBuilder.executeAlarmIntent(context, alarmExecutionData),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // Create AlarmClockInfo
-        val alarmClockInfo = AlarmClockInfo(
-            alarmExecutionData.executionDateTime.zonedEpochMillis(),
-            alarmPendingIntent
         )
 
         // Schedule Alarm
@@ -69,16 +75,24 @@ object AlarmScheduler {
         // Reschedule Alarms
         val alarmManager = getAlarmManager(context)
         cleanAlarmExecutionData.forEach { alarm ->
+            // Create PendingIntent to execute Alarm
             val alarmPendingIntent = PendingIntent.getBroadcast(
                 context,
                 alarm.id,
                 AlarmIntentBuilder.executeAlarmIntent(context, alarm),
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
+
+            // Schedule Alarm
             alarmManager.setAlarmClock(
                 AlarmClockInfo(
                     alarm.executionDateTime.zonedEpochMillis(),
-                    alarmPendingIntent
+                    PendingIntent.getActivity(
+                        context,
+                        0,
+                        Intent(context, MainActivity::class.java),
+                        PendingIntent.FLAG_IMMUTABLE
+                    )
                 ),
                 alarmPendingIntent
             )

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
@@ -1,6 +1,7 @@
 package com.example.alarmscratch.alarm.alarmexecution
 
 import android.app.AlarmManager
+import android.app.AlarmManager.AlarmClockInfo
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -21,10 +22,15 @@ object AlarmScheduler {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        // Schedule Alarm
-        getAlarmManager(context).setExactAndAllowWhileIdle(
-            AlarmManager.RTC_WAKEUP,
+        // Create AlarmClockInfo
+        val alarmClockInfo = AlarmClockInfo(
             alarmExecutionData.executionDateTime.zonedEpochMillis(),
+            alarmPendingIntent
+        )
+
+        // Schedule Alarm
+        getAlarmManager(context).setAlarmClock(
+            alarmClockInfo,
             alarmPendingIntent
         )
     }
@@ -63,15 +69,18 @@ object AlarmScheduler {
         // Reschedule Alarms
         val alarmManager = getAlarmManager(context)
         cleanAlarmExecutionData.forEach { alarm ->
-            alarmManager.setExactAndAllowWhileIdle(
-                AlarmManager.RTC_WAKEUP,
-                alarm.executionDateTime.zonedEpochMillis(),
-                PendingIntent.getBroadcast(
-                    context,
-                    alarm.id,
-                    AlarmIntentBuilder.executeAlarmIntent(context, alarm),
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
+            val alarmPendingIntent = PendingIntent.getBroadcast(
+                context,
+                alarm.id,
+                AlarmIntentBuilder.executeAlarmIntent(context, alarm),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            alarmManager.setAlarmClock(
+                AlarmClockInfo(
+                    alarm.executionDateTime.zonedEpochMillis(),
+                    alarmPendingIntent
+                ),
+                alarmPendingIntent
             )
         }
     }


### PR DESCRIPTION
### Description
- Change Alarms from being set with `AlarmManager.setExactAndAllowWhileIdle()` to `AlarmManager.setAlarmClock()`
  - Using `AlarmManager.setAlarmClock()` has the added effect of the Status Bar's `Alarm Tile` being populated with information from the upcoming Alarm
    - The implementation of `AlarmManager.setAlarmClock()` will have the Status Bar's `Alarm Tile` open the Alarm application when pressed