### PR TITLE
Feature | Mod Full Screen Alarm Buttons

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -4,17 +4,22 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.graphics.Color
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.alarmexecution.AlarmActionReceiver
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.ui.theme.AndroidDefaultDarkScrim
 import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository
 import java.time.LocalDateTime
 
@@ -36,6 +41,12 @@ class FullScreenAlarmActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Enable edge to edge for dynamic Status Bar coloring
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(AndroidDefaultDarkScrim.toArgb())
+        )
 
         // Alarm data
         val dateTime = try {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -51,7 +51,6 @@ import java.time.LocalDateTime
 
 @Composable
 fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
-    // TODO: The Status Bar has a grey tint to it on the Lock Screen. Fix this.
     // Configure Status Bar
     StatusBarUtil.setLightStatusBar()
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -14,9 +15,14 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,9 +40,12 @@ import com.example.alarmscratch.core.extension.get24HourTime
 import com.example.alarmscratch.core.extension.getAmPm
 import com.example.alarmscratch.core.extension.getDayFull
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
-import com.example.alarmscratch.core.ui.theme.InCloudBlack
+import com.example.alarmscratch.core.ui.theme.BoatHull
+import com.example.alarmscratch.core.ui.theme.DarkGrey
+import com.example.alarmscratch.core.ui.theme.Grey
 import com.example.alarmscratch.core.ui.theme.SkyBlue
 import com.example.alarmscratch.core.ui.theme.TransparentBlack
+import com.example.alarmscratch.core.ui.theme.TransparentWetSand
 import com.example.alarmscratch.core.util.StatusBarUtil
 import java.time.LocalDateTime
 
@@ -55,6 +64,8 @@ fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
     )
 }
 
+// ExperimentalMaterial3Api OptIn for LocalRippleConfiguration and RippleConfiguration
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullScreenAlarmScreenContent(
     alarmName: String,
@@ -92,7 +103,7 @@ fun FullScreenAlarmScreenContent(
                     // Name
                     Text(
                         text = alarmName,
-                        color = InCloudBlack,
+                        color = DarkGrey,
                         fontSize = 42.sp,
                         fontWeight = FontWeight.Bold
                     )
@@ -100,7 +111,7 @@ fun FullScreenAlarmScreenContent(
                     // Day
                     Text(
                         text = alarmExecutionDateTime.getDayFull(),
-                        color = InCloudBlack,
+                        color = DarkGrey,
                         fontSize = 32.sp,
                         fontWeight = FontWeight.SemiBold
                     )
@@ -114,7 +125,7 @@ fun FullScreenAlarmScreenContent(
                             } else {
                                 alarmExecutionDateTime.get12HourTime()
                             },
-                            color = InCloudBlack,
+                            color = DarkGrey,
                             fontSize = 64.sp,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.alignByBaseline()
@@ -124,7 +135,7 @@ fun FullScreenAlarmScreenContent(
                         if (!is24Hour) {
                             Text(
                                 text = alarmExecutionDateTime.getAmPm(context),
-                                color = InCloudBlack,
+                                color = DarkGrey,
                                 fontSize = 42.sp,
                                 fontWeight = FontWeight.SemiBold,
                                 modifier = Modifier.alignByBaseline()
@@ -140,17 +151,42 @@ fun FullScreenAlarmScreenContent(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.weight(0.75f)
             ) {
-                // Snooze Button
-                Button(onClick = { snoozeAlarm(context) }) {
-                    Text(text = stringResource(id = R.string.snooze_alarm), fontSize = 42.sp)
-                }
-                Spacer(modifier = Modifier.height(48.dp))
+                // Replace default Ripple
+                CompositionLocalProvider(value = LocalRippleConfiguration provides RippleConfiguration(color = Grey)) {
+                    // Snooze Button
+                    Button(
+                        onClick = { snoozeAlarm(context) },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = TransparentWetSand,
+                            contentColor = Grey
+                        ),
+                        contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.snooze_alarm),
+                            fontSize = 48.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(32.dp))
 
-                // Dismiss Button
-                Button(onClick = { dismissAlarm(context) }) {
-                    Text(text = stringResource(id = R.string.dismiss_alarm), fontSize = 42.sp)
+                    // Dismiss Button
+                    Button(
+                        onClick = { dismissAlarm(context) },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = TransparentWetSand,
+                            contentColor = BoatHull
+                        ),
+                        contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.dismiss_alarm),
+                            fontSize = 48.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(48.dp))
                 }
-                Spacer(modifier = Modifier.height(48.dp))
             }
         }
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -23,6 +23,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,10 +43,12 @@ import com.example.alarmscratch.core.extension.get12HourTime
 import com.example.alarmscratch.core.extension.get24HourTime
 import com.example.alarmscratch.core.extension.getAmPm
 import com.example.alarmscratch.core.extension.getDayFull
+import com.example.alarmscratch.core.ui.shared.LongPressButton
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.BoatHull
 import com.example.alarmscratch.core.ui.theme.DarkGrey
 import com.example.alarmscratch.core.ui.theme.Grey
+import com.example.alarmscratch.core.ui.theme.MediumGrey
 import com.example.alarmscratch.core.ui.theme.SkyBlue
 import com.example.alarmscratch.core.ui.theme.TransparentBlack
 import com.example.alarmscratch.core.ui.theme.TransparentWetSand
@@ -73,7 +79,10 @@ fun FullScreenAlarmScreenContent(
     snoozeAlarm: (Context) -> Unit,
     dismissAlarm: (Context) -> Unit
 ) {
+    // State
     val context = LocalContext.current
+    var showHoldButtonText by remember { mutableStateOf(false) }
+    val toggleHoldButtonText: () -> Unit = { showHoldButtonText = !showHoldButtonText }
 
     Surface(
         modifier = Modifier
@@ -150,10 +159,21 @@ fun FullScreenAlarmScreenContent(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.weight(0.75f)
             ) {
+                // Hold Button Text
+                if (showHoldButtonText) {
+                    Text(
+                        text = "Hold to dismiss",
+                        color = MediumGrey,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(bottom = 18.dp)
+                    )
+                }
+
                 // Replace default Ripple
                 CompositionLocalProvider(value = LocalRippleConfiguration provides RippleConfiguration(color = Grey)) {
                     // Snooze Button
-                    Button(
+                    LongPressButton(
                         onClick = { snoozeAlarm(context) },
                         colors = ButtonDefaults.buttonColors(
                             containerColor = TransparentWetSand,

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -1,6 +1,7 @@
 package com.example.alarmscratch.alarm.ui.fullscreenalert
 
 import android.content.Context
+import androidx.annotation.StringRes
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -34,6 +35,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -66,6 +68,12 @@ import com.example.alarmscratch.core.ui.theme.TransparentWetSand
 import com.example.alarmscratch.core.util.StatusBarUtil
 import java.time.LocalDateTime
 
+enum class FullScreenAlarmButton(@StringRes val stringRes: Int){
+    SNOOZE(R.string.hold_to_snooze),
+    DISMISS(R.string.hold_to_dismiss),
+    BOTH(R.string.hold_to_dismiss)
+}
+
 @Composable
 fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
     // Configure Status Bar
@@ -80,8 +88,6 @@ fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
     )
 }
 
-// ExperimentalMaterial3Api OptIn for LocalRippleConfiguration and RippleConfiguration
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullScreenAlarmScreenContent(
     alarmName: String,
@@ -90,49 +96,6 @@ fun FullScreenAlarmScreenContent(
     snoozeAlarm: (Context) -> Unit,
     dismissAlarm: (Context) -> Unit
 ) {
-    // Hold text state
-    val context = LocalContext.current
-    var holdText by remember { mutableStateOf("") }
-    var showHoldIndicator by remember { mutableStateOf(false) }
-    val holdToSnoozeText = stringResource(id = R.string.hold_to_snooze)
-    val holdToDismissText = stringResource(id = R.string.hold_to_dismiss)
-
-    // Progress state
-    val longPressThreshold = 1500
-    var start by remember { mutableStateOf(false) }
-    var currentProgress by remember { mutableFloatStateOf(0f) }
-    val currentPercentage by animateFloatAsState(
-        targetValue = currentProgress,
-        animationSpec = tween(durationMillis = longPressThreshold, easing = LinearEasing),
-        label = "progress",
-        finishedListener = { endProgress ->
-            if (endProgress == 1f) {
-                start = false
-            } else {
-                showHoldIndicator = false
-            }
-        }
-    )
-
-    // Progress functions
-    val onPressStart: () -> Unit = {
-        // Start progress animation and show hold text
-        start = true
-        showHoldIndicator = true
-    }
-    val onShortPress: () -> Unit = {
-        start = false
-        // Reset progress animation
-        currentProgress = 0f
-    }
-
-    // Start progress animation
-    if (start) {
-        LaunchedEffect(key1 = Unit) {
-            currentProgress = 1f
-        }
-    }
-
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -142,151 +105,248 @@ fun FullScreenAlarmScreenContent(
         // Screen background
         BeachBackdrop()
 
-        // Alarm Data and Buttons
+        // Alarm Data and Snooze and Dismiss Buttons with Hold Indicator
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             // Alarm Data
-            Column(
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
+            AlarmData(
+                alarmName = alarmName,
+                alarmExecutionDateTime = alarmExecutionDateTime,
+                is24Hour = is24Hour,
                 modifier = Modifier.weight(0.25f)
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(18.dp))
-                        .background(color = TransparentBlack)
-                        .padding(12.dp)
-                ) {
-                    // Name
+            )
+
+            // Snooze and Dismiss Buttons with Hold Indicator
+            SnoozeAndDismissButtons(
+                snoozeAlarm = snoozeAlarm,
+                dismissAlarm = dismissAlarm,
+                modifier = Modifier.weight(0.75f)
+            )
+        }
+    }
+}
+
+@Composable
+fun AlarmData(
+    alarmName: String,
+    alarmExecutionDateTime: LocalDateTime,
+    is24Hour: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+    ) {
+        // Alarm Name, Day, and Time
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .clip(RoundedCornerShape(18.dp))
+                .background(color = TransparentBlack)
+                .padding(12.dp)
+        ) {
+            // Name
+            Text(
+                text = alarmName,
+                color = DarkGrey,
+                fontSize = 42.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            // Day
+            Text(
+                text = alarmExecutionDateTime.getDayFull(),
+                color = DarkGrey,
+                fontSize = 32.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            // Time
+            Row {
+                // Hour and Minute
+                Text(
+                    text = if (is24Hour) {
+                        alarmExecutionDateTime.get24HourTime()
+                    } else {
+                        alarmExecutionDateTime.get12HourTime()
+                    },
+                    color = DarkGrey,
+                    fontSize = 64.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.alignByBaseline()
+                )
+
+                // AM/PM
+                if (!is24Hour) {
                     Text(
-                        text = alarmName,
+                        text = alarmExecutionDateTime.getAmPm(LocalContext.current),
                         color = DarkGrey,
                         fontSize = 42.sp,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.alignByBaseline()
                     )
-
-                    // Day
-                    Text(
-                        text = alarmExecutionDateTime.getDayFull(),
-                        color = DarkGrey,
-                        fontSize = 32.sp,
-                        fontWeight = FontWeight.SemiBold
-                    )
-
-                    // Time
-                    Row {
-                        // Hour and Minute
-                        Text(
-                            text = if (is24Hour) {
-                                alarmExecutionDateTime.get24HourTime()
-                            } else {
-                                alarmExecutionDateTime.get12HourTime()
-                            },
-                            color = DarkGrey,
-                            fontSize = 64.sp,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.alignByBaseline()
-                        )
-
-                        // AM/PM
-                        if (!is24Hour) {
-                            Text(
-                                text = alarmExecutionDateTime.getAmPm(context),
-                                color = DarkGrey,
-                                fontSize = 42.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                modifier = Modifier.alignByBaseline()
-                            )
-                        }
-                    }
                 }
             }
+        }
+    }
+}
 
-            // Snooze and Dismiss Buttons, and Hold Indicator
-            Column(
-                verticalArrangement = Arrangement.Bottom,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.weight(0.75f)
+// ExperimentalMaterial3Api OptIn for LocalRippleConfiguration and RippleConfiguration
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SnoozeAndDismissButtons(
+    snoozeAlarm: (Context) -> Unit,
+    dismissAlarm: (Context) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Hold indicator text state
+    val context = LocalContext.current
+    var showHoldIndicator by remember { mutableStateOf(false) }
+    var holdIndicatorTextRes by remember { mutableIntStateOf(FullScreenAlarmButton.BOTH.stringRes) }
+
+    // Hold indicator progress state
+    val longPressTimeout = 1500
+    var startProgressAnimation by remember { mutableStateOf(false) }
+    var currentProgress by remember { mutableFloatStateOf(0f) }
+    val currentPercentage by animateFloatAsState(
+        targetValue = currentProgress,
+        animationSpec = tween(durationMillis = longPressTimeout, easing = LinearEasing),
+        label = "progress",
+        finishedListener = { endProgress ->
+            if (endProgress == 1f) {
+                startProgressAnimation = false
+            } else {
+                showHoldIndicator = false
+            }
+        }
+    )
+
+    // Snooze and Dismiss button state
+    var enabledButton by remember { mutableStateOf(FullScreenAlarmButton.BOTH) }
+    val isButtonEnabled: (FullScreenAlarmButton) -> Boolean = { it == enabledButton || enabledButton == FullScreenAlarmButton.BOTH }
+
+    // Snooze and Dismiss button functions
+    val onPressStart: (FullScreenAlarmButton) -> Unit = { button ->
+        // Disable inactive button and configure hold progress indicator
+        enabledButton = button
+        holdIndicatorTextRes = button.stringRes
+
+        // Show hold progress indicator and start animation
+        showHoldIndicator = true
+        startProgressAnimation = true
+    }
+    val onShortPress: () -> Unit = {
+        // Enable both buttons
+        enabledButton = FullScreenAlarmButton.BOTH
+
+        startProgressAnimation = false
+        // Animate progress towards 0
+        currentProgress = 0f
+    }
+    val onLongPress: (FullScreenAlarmButton) -> Unit = { button ->
+        // Enable both buttons
+        enabledButton = FullScreenAlarmButton.BOTH
+
+        // Perform appropriate long press action given the button pressed
+        when (button) {
+            FullScreenAlarmButton.SNOOZE ->
+                snoozeAlarm(context)
+            FullScreenAlarmButton.DISMISS ->
+                dismissAlarm(context)
+            FullScreenAlarmButton.BOTH ->
+                Unit
+        }
+    }
+
+    // Start progress animation
+    if (startProgressAnimation) {
+        LaunchedEffect(key1 = Unit) {
+            currentProgress = 1f
+        }
+    }
+
+    // Snooze and Dismiss Buttons with Hold Indicator
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+    ) {
+        // Hold Indicator
+        if (showHoldIndicator) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .width(IntrinsicSize.Min)
+                    .height(IntrinsicSize.Min)
+                    .padding(bottom = 14.dp)
             ) {
-                // Hold Indicator
-                if (showHoldIndicator) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .width(IntrinsicSize.Min)
-                            .height(IntrinsicSize.Min)
-                            .padding(bottom = 14.dp)
-                    ) {
-                        Text(
-                            text = holdText,
-                            color = MediumGrey,
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
-                        )
+                // Hold Text
+                Text(
+                    text = stringResource(id = holdIndicatorTextRes),
+                    color = MediumGrey,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
+                )
 
-                        LinearProgressIndicator(
-                            progress = { currentPercentage },
-                            color = TransparentBlack,
-                            trackColor = Color.Transparent,
-                            drawStopIndicator = {},
-                            modifier = Modifier
-                                .fillMaxWidth(fraction = 0.65f)
-                                .fillMaxHeight()
-                                .clip(RoundedCornerShape(12.dp))
-                        )
-                    }
-                }
-
-                // Replace default Ripple
-                CompositionLocalProvider(value = LocalRippleConfiguration provides RippleConfiguration(color = Grey)) {
-                    // Snooze Button
-                    LongPressButton(
-                        longPressThreshold = longPressThreshold,
-                        onPressStart = {
-                            holdText = holdToSnoozeText
-                            onPressStart()
-                        },
-                        onLongPress = { snoozeAlarm(context) },
-                        onShortPress = onShortPress,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = TransparentWetSand,
-                            contentColor = Grey
-                        ),
-                        contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.snooze_alarm),
-                            fontSize = 48.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(32.dp))
-
-                    // Dismiss Button
-                    LongPressButton(
-                        longPressThreshold = longPressThreshold,
-                        onPressStart = {
-                            holdText = holdToDismissText
-                            onPressStart()
-                        },
-                        onLongPress = { dismissAlarm(context) },
-                        onShortPress = onShortPress,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = TransparentWetSand,
-                            contentColor = BoatHull
-                        ),
-                        contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.dismiss_alarm),
-                            fontSize = 48.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(48.dp))
-                }
+                // Hold Progress Indicator
+                LinearProgressIndicator(
+                    progress = { currentPercentage },
+                    color = TransparentBlack,
+                    trackColor = Color.Transparent,
+                    drawStopIndicator = {},
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.65f)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(12.dp))
+                )
             }
+        }
+
+        // Snooze and Dismiss buttons
+        // Replace default Ripple
+        CompositionLocalProvider(value = LocalRippleConfiguration provides RippleConfiguration(color = Grey)) {
+            // Snooze Button
+            LongPressButton(
+                longPressThreshold = longPressTimeout.toLong(),
+                onPressStart = { onPressStart(FullScreenAlarmButton.SNOOZE) },
+                onShortPress = onShortPress,
+                onLongPress = { onLongPress(FullScreenAlarmButton.SNOOZE) },
+                enabled = isButtonEnabled(FullScreenAlarmButton.SNOOZE),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = TransparentWetSand,
+                    contentColor = Grey
+                ),
+                contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.snooze_alarm),
+                    fontSize = 48.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Dismiss Button
+            LongPressButton(
+                longPressThreshold = longPressTimeout.toLong(),
+                onPressStart = { onPressStart(FullScreenAlarmButton.DISMISS) },
+                onShortPress = onShortPress,
+                onLongPress = { onLongPress(FullScreenAlarmButton.DISMISS) },
+                enabled = isButtonEnabled(FullScreenAlarmButton.DISMISS),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = TransparentWetSand,
+                    contentColor = BoatHull
+                ),
+                contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.dismiss_alarm),
+                    fontSize = 48.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Spacer(modifier = Modifier.height(48.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -324,7 +324,6 @@ fun SnoozeAndDismissButtons(
                     modifier = Modifier
                         .fillMaxWidth(fraction = 0.65f)
                         .fillMaxHeight()
-                        .clip(RoundedCornerShape(12.dp))
                 )
             }
         }
@@ -342,7 +341,9 @@ fun SnoozeAndDismissButtons(
                 enabled = isButtonEnabled(FullScreenAlarmButton.SNOOZE),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = TransparentWetSand,
-                    contentColor = Grey
+                    contentColor = Grey,
+                    disabledContainerColor = TransparentWetSand,
+                    disabledContentColor = Grey
                 ),
                 contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
             ) {
@@ -364,7 +365,9 @@ fun SnoozeAndDismissButtons(
                 enabled = isButtonEnabled(FullScreenAlarmButton.DISMISS),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = TransparentWetSand,
-                    contentColor = BoatHull
+                    contentColor = BoatHull,
+                    disabledContainerColor = TransparentWetSand,
+                    disabledContentColor = BoatHull
                 ),
                 contentPadding = PaddingValues(start = 28.dp, top = 10.dp, end = 28.dp, bottom = 10.dp)
             ) {

--- a/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
@@ -15,6 +15,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Enable edge to edge for dynamic Status Bar coloring
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
             navigationBarStyle = SystemBarStyle.dark(AndroidDefaultDarkScrim.toArgb())

--- a/app/src/main/java/com/example/alarmscratch/core/gesture/SingleTapGestureDetector.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/gesture/SingleTapGestureDetector.kt
@@ -1,0 +1,85 @@
+package com.example.alarmscratch.core.gesture
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Detect and react to single tap gestures. Gestures include: [onPressStart], [onShortPress], and [onLongPress].
+ * [onPressStart] is immediately invoked after the first down event, and either [onShortPress] or [onLongPress]
+ * are subsequently invoked depending on if the [longPressTimeout] was exceeded before the first up event was received.
+ *
+ * Although [onLongPress] is invoked immediately after [longPressTimeout] has been exceeded, all press events
+ * continue to be consumed until the first up event is received.
+ *
+ * Ex: [longPressTimeout] is set to 1.5 seconds. The User holds the Button down for 2 seconds. [onLongPress] will be
+ * invoked at the 1.5 second mark, but we will still continue to consume the last 0.5 seconds of the "hold" since the
+ * entire 2 seconds of the User's press in considered to be a single intention.
+ *
+ * This function does not perform any special behavior specific to double taps. A double tap will simply result in
+ * 2 calls to [onPressStart] and [onShortPress].
+ *
+ * @param longPressTimeout how long to wait after a down event for the press to be considered a long press
+ * @param onPressStart invoked immediately after the first down event
+ * @param onShortPress invoked after the first up event if the duration of the press did not exceed [longPressTimeout]
+ * @param onLongPress invoked immediately once the duration of the press exceeds [longPressTimeout]
+ */
+suspend fun PointerInputScope.detectSingleTapGestures(
+    longPressTimeout: Long,
+    onPressStart: (() -> Unit)? = null,
+    onShortPress: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null
+) = coroutineScope {
+    awaitEachGesture {
+        // Consume the initial down event and invoke onPressStart()
+        val down = awaitFirstDown()
+        down.consume()
+        onPressStart?.invoke()
+
+        // Wait for the next up event and consume it. If it takes longer than longPressTimeout
+        // then a PointerEventTimeoutCancellationException is thrown and caught, onLongPress() is immediately
+        // invoked, and all subsequent press events are consumed until the first up event is received.
+        var upOrCancel: PointerInputChange? = null
+        try {
+            // Wait for up event or cancellation. If the pointer is held down longer than
+            // longPressTimeout then throw a PointerEventTimeoutCancellationException.
+            upOrCancel = withTimeout(longPressTimeout) {
+                waitForUpOrCancellation()
+            }
+
+            // The up event was not cancelled, so consume it
+            upOrCancel?.consume()
+        } catch (e: PointerEventTimeoutCancellationException) {
+            // Invoke onLongPress() immediately. However, since the User could still be holding
+            // the pointer down, we must consume all press events until the pointer is lifted,
+            // even though we've already invoked onLongPress(). This is because the entirety of
+            // this window of press events is to be interpreted as a single User intention.
+            onLongPress?.invoke()
+            consumeUntilUp()
+        }
+
+        // The up event was successful and not cancelled, and the
+        // longPressTimeout was not exceeded. Invoke onShortPress().
+        if (upOrCancel != null) {
+            onShortPress?.invoke()
+        }
+    }
+}
+
+/**
+ * Consume all pointer events until nothing is pressed,
+ * assuming that something is currently pressed.
+ */
+private suspend fun AwaitPointerEventScope.consumeUntilUp() {
+    do {
+        val event = awaitPointerEvent()
+        event.changes.fastForEach { it.consume() }
+    } while (event.changes.fastAny { it.pressed })
+}

--- a/app/src/main/java/com/example/alarmscratch/core/gesture/SingleTapGestureDetector.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/gesture/SingleTapGestureDetector.kt
@@ -3,6 +3,8 @@ package com.example.alarmscratch.core.gesture
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
 import androidx.compose.ui.input.pointer.PointerInputChange
@@ -10,6 +12,7 @@ import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Detect and react to single tap gestures. Gestures include: [onPressStart], [onShortPress], and [onLongPress].
@@ -35,13 +38,20 @@ suspend fun PointerInputScope.detectSingleTapGestures(
     longPressTimeout: Long,
     onPressStart: (() -> Unit)? = null,
     onShortPress: (() -> Unit)? = null,
-    onLongPress: (() -> Unit)? = null
+    onLongPress: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource
 ) = coroutineScope {
     awaitEachGesture {
         // Consume the initial down event and invoke onPressStart()
         val down = awaitFirstDown()
         down.consume()
         onPressStart?.invoke()
+
+        // Start Ripple from the down event position
+        val ripplePress = PressInteraction.Press(down.position)
+        launch {
+            interactionSource.emit(ripplePress)
+        }
 
         // Wait for the next up event and consume it. If it takes longer than longPressTimeout
         // then a PointerEventTimeoutCancellationException is thrown and caught, onLongPress() is immediately
@@ -70,6 +80,11 @@ suspend fun PointerInputScope.detectSingleTapGestures(
         if (upOrCancel != null) {
             onShortPress?.invoke()
         }
+
+        // Release Ripple
+        launch {
+            releaseOrCancel(interactionSource, ripplePress, upOrCancel)
+        }
     }
 }
 
@@ -82,4 +97,25 @@ private suspend fun AwaitPointerEventScope.consumeUntilUp() {
         val event = awaitPointerEvent()
         event.changes.fastForEach { it.consume() }
     } while (event.changes.fastAny { it.pressed })
+}
+
+/**
+ * Emit either PressInteraction.Cancel or PressInteraction.Release from the given [interactionSource]
+ * based on whether [upOrCancel] is null or non-null, respectively.
+ *
+ * @param interactionSource MutableInteractionSource to emit the PressInteraction from
+ * @param downPress the source Press interaction that is being either released or cancelled
+ * @param upOrCancel PointerInputChange being used to determine if the Press is being released or cancelled
+ */
+private suspend fun releaseOrCancel(
+    interactionSource: MutableInteractionSource,
+    downPress: PressInteraction.Press,
+    upOrCancel: PointerInputChange?
+) {
+    when (upOrCancel) {
+        null ->
+            interactionSource.emit(PressInteraction.Cancel(downPress))
+        else ->
+            interactionSource.emit(PressInteraction.Release(downPress))
+    }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -47,7 +47,7 @@ import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.toCountdownString
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
-import com.example.alarmscratch.core.ui.theme.InCloudBlack
+import com.example.alarmscratch.core.ui.theme.DarkGrey
 
 @Composable
 fun NextAlarmCloud(
@@ -73,10 +73,10 @@ fun NextAlarmCloudContent(
     timeChangeReceiver: BroadcastReceiver,
     modifier: Modifier = Modifier
 ) {
-    val localContext = LocalContext.current
+    val context = LocalContext.current
 
     // Manage the BroadcastReceiver for keeping the Alarm Countdown Text up to date
-    DisposableEffect(key1 = localContext, key2 = selectedNavComponentDest) {
+    DisposableEffect(key1 = context, key2 = selectedNavComponentDest) {
         // Register BroadcastReceiver
         if (selectedNavComponentDest is Destination.AlarmListScreen) {
             val intentFilter = IntentFilter().apply {
@@ -86,7 +86,7 @@ fun NextAlarmCloudContent(
                 addAction(Intent.ACTION_TIMEZONE_CHANGED)
             }
             ContextCompat.registerReceiver(
-                localContext,
+                context,
                 timeChangeReceiver,
                 intentFilter,
                 ContextCompat.RECEIVER_NOT_EXPORTED
@@ -96,7 +96,7 @@ fun NextAlarmCloudContent(
         // Unregister BroadcastReceiver
         onDispose {
             try {
-                localContext.unregisterReceiver(timeChangeReceiver)
+                context.unregisterReceiver(timeChangeReceiver)
             } catch (e: Exception) {
                 // Receiver was never registered in the first place. Nothing to do here. Just don't crash.
             }
@@ -126,14 +126,14 @@ fun NextAlarmCloudContent(
                 Icon(
                     imageVector = (alarmCountdownState as AlarmCountdownState.Success).icon,
                     contentDescription = null,
-                    tint = InCloudBlack,
+                    tint = DarkGrey,
                     modifier = Modifier.padding(end = 4.dp, bottom = 2.dp)
                 )
 
                 // Countdown Text
                 Text(
                     text = alarmCountdownState.countdownText,
-                    color = InCloudBlack,
+                    color = DarkGrey,
                     fontSize = getCountdownTextFontSize(alarmCountdownState.countdownText),
                     fontWeight = FontWeight.SemiBold,
                     lineHeight = getCountdownTextLineHeight(alarmCountdownState.countdownText)

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -34,9 +34,10 @@ import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 @Composable
 fun LongPressButton(
     longPressTimeout: Long,
-    onPressStart: () -> Unit,
-    onShortPress: () -> Unit,
+    onPressStart: (() -> Unit)? = null,
+    onShortPress: (() -> Unit)? = null,
     onLongPress: () -> Unit,
+    onLongPressRelease: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     shape: Shape = ButtonDefaults.shape,
@@ -44,9 +45,9 @@ fun LongPressButton(
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     content: @Composable RowScope.() -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     val containerColor = if (enabled) colors.containerColor else colors.disabledContainerColor
     val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
-    val interactionSource = remember { MutableInteractionSource() }
 
     Surface(
         color = containerColor,
@@ -61,6 +62,7 @@ fun LongPressButton(
                         onPressStart = onPressStart,
                         onShortPress = onShortPress,
                         onLongPress = onLongPress,
+                        onLongPressRelease = onLongPressRelease,
                         interactionSource = interactionSource
                     )
                 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -28,7 +28,7 @@ import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 
 @Composable
 fun LongPressButton(
-    longPressThreshold: Long,
+    longPressTimeout: Long,
     onPressStart: () -> Unit,
     onShortPress: () -> Unit,
     onLongPress: () -> Unit,
@@ -51,7 +51,7 @@ fun LongPressButton(
             .pointerInput(enabled) {
                 if (enabled) {
                     detectSingleTapGestures(
-                        longPressTimeout = longPressThreshold,
+                        longPressTimeout = longPressTimeout,
                         onPressStart = onPressStart,
                         onShortPress = onShortPress,
                         onLongPress = onLongPress
@@ -91,7 +91,7 @@ private fun LongPressButtonPreview() {
                 .height(200.dp)
         ) {
             LongPressButton(
-                longPressThreshold = 3000,
+                longPressTimeout = 3000,
                 onPressStart = {},
                 onShortPress = {},
                 onLongPress = {}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -1,0 +1,84 @@
+package com.example.alarmscratch.core.ui.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+@Composable
+fun LongPressButton(
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    shape: Shape = ButtonDefaults.shape,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    val containerColor = if (enabled) colors.containerColor else colors.disabledContainerColor
+    val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
+
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = shape,
+        color = containerColor,
+        contentColor = contentColor,
+        modifier = modifier.semantics { role = Role.Button }
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .defaultMinSize(
+                    minWidth = ButtonDefaults.MinWidth,
+                    minHeight = ButtonDefaults.MinHeight
+                )
+                .padding(contentPadding),
+            content = content
+        )
+    }
+}
+
+/*
+ * Previews
+ */
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF373736
+)
+@Composable
+private fun LongPressButtonPreview() {
+    AlarmScratchTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .width(200.dp)
+                .height(200.dp)
+        ) {
+            LongPressButton(onClick = {}) {
+                Text(text = "Confirm")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -1,5 +1,7 @@
 package com.example.alarmscratch.core.ui.shared
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,16 +19,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import kotlinx.coroutines.coroutineScope
 
 @Composable
 fun LongPressButton(
-    onClick: () -> Unit,
+    longPressThreshold: Int,
+    onPressStart: () -> Unit,
+    onShortPress: () -> Unit,
+    onLongPress: () -> Unit,
     enabled: Boolean = true,
     shape: Shape = ButtonDefaults.shape,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
@@ -38,12 +47,19 @@ fun LongPressButton(
     val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
 
     Surface(
-        onClick = onClick,
-        enabled = enabled,
         shape = shape,
         color = containerColor,
         contentColor = contentColor,
-        modifier = modifier.semantics { role = Role.Button }
+        modifier = modifier
+            .semantics { role = Role.Button }
+            .pointerInput(Unit) {
+                detectPressGestures(
+                    longPressThreshold = longPressThreshold.toLong(),
+                    onPressStart = onPressStart,
+                    onLongPress = onLongPress,
+                    onShortPress = onShortPress
+                )
+            }
     ) {
         Row(
             horizontalArrangement = Arrangement.Center,
@@ -56,6 +72,45 @@ fun LongPressButton(
                 .padding(contentPadding),
             content = content
         )
+    }
+}
+
+suspend fun PointerInputScope.detectPressGestures(
+    longPressThreshold: Long,
+    onPressStart: (() -> Unit)? = null,
+    onShortPress: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null
+) = coroutineScope {
+    awaitEachGesture {
+        // Consume the initial press event
+        val down = awaitFirstDown()
+        down.consume()
+
+        // Record time of initial press, and invoke onPressStart()
+        val downTime = System.currentTimeMillis()
+        onPressStart?.invoke()
+
+        var longPressThresholdPassed = false
+
+        // Grab initial PointerEvent and loop until the User releases
+        do {
+            val event: PointerEvent = awaitPointerEvent()
+            val currentTime = System.currentTimeMillis()
+
+            // First time long press threshold is passed. Invoke onLongPress().
+            if (!longPressThresholdPassed && currentTime - downTime >= longPressThreshold) {
+                onLongPress?.invoke()
+                longPressThresholdPassed = true
+            }
+
+            // Consume press events since they're being handled here
+            event.changes.forEach { it.consume() }
+        } while (event.changes.any { it.pressed })
+
+        // Invoke onShortPress() if long press threshold was not reached
+        if (!longPressThresholdPassed) {
+            onShortPress?.invoke()
+        }
     }
 }
 
@@ -76,7 +131,12 @@ private fun LongPressButtonPreview() {
                 .width(200.dp)
                 .height(200.dp)
         ) {
-            LongPressButton(onClick = {}) {
+            LongPressButton(
+                longPressThreshold = 3000,
+                onPressStart = {},
+                onShortPress = {},
+                onLongPress = {}
+            ) {
                 Text(text = "Confirm")
             }
         }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -1,5 +1,7 @@
 package com.example.alarmscratch.core.ui.shared
 
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,9 +15,12 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.Role
@@ -32,32 +37,35 @@ fun LongPressButton(
     onPressStart: () -> Unit,
     onShortPress: () -> Unit,
     onLongPress: () -> Unit,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     shape: Shape = ButtonDefaults.shape,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit
 ) {
     val containerColor = if (enabled) colors.containerColor else colors.disabledContainerColor
     val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
+    val interactionSource = remember { MutableInteractionSource() }
 
     Surface(
-        shape = shape,
         color = containerColor,
         contentColor = contentColor,
         modifier = modifier
             .semantics { role = Role.Button }
+            .clip(shape)
             .pointerInput(enabled) {
                 if (enabled) {
                     detectSingleTapGestures(
                         longPressTimeout = longPressTimeout,
                         onPressStart = onPressStart,
                         onShortPress = onShortPress,
-                        onLongPress = onLongPress
+                        onLongPress = onLongPress,
+                        interactionSource = interactionSource
                     )
                 }
             }
+            .indication(interactionSource, ripple())
     ) {
         Row(
             horizontalArrangement = Arrangement.Center,
@@ -91,7 +99,7 @@ private fun LongPressButtonPreview() {
                 .height(200.dp)
         ) {
             LongPressButton(
-                longPressTimeout = 3000,
+                longPressTimeout = 3000L,
                 onPressStart = {},
                 onShortPress = {},
                 onLongPress = {}

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
@@ -3,7 +3,6 @@ package com.example.alarmscratch.core.ui.theme
 import androidx.compose.ui.graphics.Color
 
 // SkylineHeader
-val InCloudBlack = Color(0xFF404040)// 25% Lighter Black
 val SkyBlue = Color(0xFFc2e0ff) // 80% Lighter TopOceanBlue
 
 // Sail Boat
@@ -21,6 +20,7 @@ val BeachOcean = Color(0xFF66b2ff)
 val WetSand = Color(0xFFffe3a0)
 val DrySand = Color(0xFFfff5be)
 val TransparentBlack = Color(0x10000000)
+val TransparentWetSand = Color(0x80ffe3a0)
 
 // Starfish
 val StarfishBasePink = Color(0xFFba7999)
@@ -42,6 +42,8 @@ val MediumLavaRed = Color(0xFFa60d1a) // 20% Darker BrightLavaRed
 val DarkLavaRed = Color(0xFF660f00) // 60% Darker #ff2500
 
 // General
+val Grey = Color(0xFF595959) // 35% Lighter Black
+val DarkGrey = Color(0xFF404040) // 25% Lighter Black
 val SelectedGreen = Color(0xFF00b300)
 
 // Navigation

--- a/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/theme/Color.kt
@@ -43,6 +43,7 @@ val DarkLavaRed = Color(0xFF660f00) // 60% Darker #ff2500
 
 // General
 val Grey = Color(0xFF595959) // 35% Lighter Black
+val MediumGrey = Color(0xFF4d4d4d) // 30% Lighter Black
 val DarkGrey = Color(0xFF404040) // 25% Lighter Black
 val SelectedGreen = Color(0xFF00b300)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,8 @@
     -->
     <string name="snooze_alarm">Snooze</string>
     <string name="dismiss_alarm">Dismiss</string>
+    <string name="hold_to_snooze">Hold to Snooze</string>
+    <string name="hold_to_dismiss">Hold to Dismiss</string>
     <string name="default_alarm_name">Alarm</string>
     <string name="default_alarm_date">Today</string>
     <string name="default_alarm_time">Now</string>


### PR DESCRIPTION
### Description
- Add long press functionality to the Snooze and Dismiss buttons on `FullScreenAlarmScreen`. Functionality added via the creation of `LongPressButton`, which utilized the newly created `SingleTapGestureDetector.detectTapGestures()`. When the User presses either Snooze or Dismiss, a Hold Indicator will appear above the two buttons. It will say either "Hold to Snooze" or "Hold to Dismiss" and will show a `LinearProgressIndicator` that fills as the User is holding the button. The Hold Indicator is synchronized with the timeout of the long press from the `LongPressButton`.
  - `LongPressButton` is complete with a `Ripple` effect
  - `FullScreenAlarmScreen` manages the Snooze and Dismiss buttons in such a way that only one can be pressed at a time
    - There is an exception to this. Since the screen still allows for multitouch in general, if the User presses both buttons at the "same time" (single digit milliseconds apart) they will both appear active to the User by simultaneously showing a Ripple effect. This is strictly a visual glitch. `FullScreenAlarmScreen` will still pick up on the fact that one was pressed after the other, quickly enable and then disable the first pressed button, and only the second pressed button will remain active under the hood, and the appropriate action (Snooze or Dismiss) will be displayed to the User and activated on the long press.
      - I decided to leave this as-is since it's inconsequential to the actual underlying functionality. In this scenario, if the UI says "Hold to Snooze" it will still snooze, and vice versa. Cleaning this up at a later date, however, would provide a slightly cleaner UX in this edge case.
- Enable Edge-to-Edge on `FullScreenAlarmActivity` to allow for the Status Bar's color to be changed in accordance with the skyline on `BeachBackdrop`
- Restructure the `Color` file, and rename some `Colors`