### PR TITLE
Feature | Post Alarm Confirmation Screen

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionOrigin.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionOrigin.kt
@@ -1,0 +1,6 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+enum class AlarmActionOrigin {
+    NOTIFICATION,
+    FULL_SCREEN
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmIntentBuilder.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmIntentBuilder.kt
@@ -7,6 +7,10 @@ import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 
 object AlarmIntentBuilder {
 
+    /*
+     * Execute
+     */
+
     /**
      * Creates an Intent for executing Alarms. This Intent contains all the properties of AlarmExecutionData.
      *
@@ -32,20 +36,43 @@ object AlarmIntentBuilder {
         }
     }
 
+    /*
+     * Snooze
+     */
+
+    /**
+     * Creates an Intent for snoozing Alarms via the Alarm Notification.
+     * This Intent does not contain all the properties of AlarmExecutionData.
+     *
+     * @param context used for Intent creation
+     * @param alarmExecutionData execution data for the Alarm
+     *
+     * @return Intent for snoozing Alarms via the Alarm Notification
+     */
     fun snoozeAlarmFromNotification(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
         snoozeAlarmIntent(context, AlarmActionOrigin.NOTIFICATION, alarmExecutionData)
 
+    /**
+     * Creates an Intent for snoozing Alarms via the Full Screen Alarm.
+     * This Intent does not contain all the properties of AlarmExecutionData.
+     *
+     * @param context used for Intent creation
+     * @param alarmExecutionData execution data for the Alarm
+     *
+     * @return Intent for snoozing Alarms via the Full Screen Alarm
+     */
     fun snoozeAlarmFromFullScreen(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
         snoozeAlarmIntent(context, AlarmActionOrigin.FULL_SCREEN, alarmExecutionData)
 
     /**
-     * Creates an Intent for snoozing Alarms. This Intent does not contain all the properties of AlarmExecutionData.
+     * Creates an Intent for snoozing Alarms from either the Alarm Notification or the Full Screen Alarm,
+     * depending on the [alarmActionOrigin]. This Intent does not contain all the properties of AlarmExecutionData.
      *
      * @param context used for Intent creation
      * @param alarmActionOrigin the origin of the snooze action (ex: Notification, Full Screen Alarm)
      * @param alarmExecutionData execution data for the Alarm
      *
-     * @return Intent for snoozing Alarms
+     * @return Intent for snoozing Alarms from either the Alarm Notification or the Full Screen Alarm
      */
     private fun snoozeAlarmIntent(
         context: Context,
@@ -68,20 +95,43 @@ object AlarmIntentBuilder {
         }
     }
 
+    /*
+     * Dismiss
+     */
+
+    /**
+     * Creates an Intent for dismissing Alarms via the Alarm Notification.
+     * This Intent does not contain all the properties of AlarmExecutionData.
+     *
+     * @param context used for Intent creation
+     * @param alarmExecutionData execution data for the Alarm
+     *
+     * @return Intent for dismissing Alarms via the Alarm Notification
+     */
     fun dismissAlarmFromNotification(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
         dismissAlarmIntent(context, AlarmActionOrigin.NOTIFICATION, alarmExecutionData)
 
+    /**
+     * Creates an Intent for dismissing Alarms via the Full Screen Alarm.
+     * This Intent does not contain all the properties of AlarmExecutionData.
+     *
+     * @param context used for Intent creation
+     * @param alarmExecutionData execution data for the Alarm
+     *
+     * @return Intent for dismissing Alarms via the Full Screen Alarm
+     */
     fun dismissAlarmFromFullScreen(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
         dismissAlarmIntent(context, AlarmActionOrigin.FULL_SCREEN, alarmExecutionData)
 
     /**
-     * Creates an Intent for dismissing Alarms. This Intent does not contain all the properties of AlarmExecutionData.
+     * Creates an Intent for dismissing Alarms from either the Alarm Notification or the Full Screen Alarm,
+     * depending on the [alarmActionOrigin]. This Intent does not contain all the properties of AlarmExecutionData.
      *
      * @param context used for Intent creation
      * @param alarmActionOrigin the origin of the dismiss action (ex: Notification, Full Screen Alarm)
      * @param alarmExecutionData execution data for the Alarm
      *
-     * @return Intent for dismissing Alarms
+     * @return Intent for dismissing Alarms from either the Alarm Notification or the Full Screen Alarm
      */
     private fun dismissAlarmIntent(
         context: Context,

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmIntentBuilder.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmIntentBuilder.kt
@@ -32,15 +32,26 @@ object AlarmIntentBuilder {
         }
     }
 
+    fun snoozeAlarmFromNotification(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
+        snoozeAlarmIntent(context, AlarmActionOrigin.NOTIFICATION, alarmExecutionData)
+
+    fun snoozeAlarmFromFullScreen(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
+        snoozeAlarmIntent(context, AlarmActionOrigin.FULL_SCREEN, alarmExecutionData)
+
     /**
      * Creates an Intent for snoozing Alarms. This Intent does not contain all the properties of AlarmExecutionData.
      *
      * @param context used for Intent creation
+     * @param alarmActionOrigin the origin of the snooze action (ex: Notification, Full Screen Alarm)
      * @param alarmExecutionData execution data for the Alarm
      *
      * @return Intent for snoozing Alarms
      */
-    fun snoozeAlarmIntent(context: Context, alarmExecutionData: AlarmExecutionData): Intent {
+    private fun snoozeAlarmIntent(
+        context: Context,
+        alarmActionOrigin: AlarmActionOrigin,
+        alarmExecutionData: AlarmExecutionData
+    ): Intent {
         val name = alarmExecutionData.name.ifBlank { context.getString(R.string.default_alarm_name) }
 
         return Intent(context, AlarmActionReceiver::class.java).apply {
@@ -53,23 +64,36 @@ object AlarmIntentBuilder {
             putExtra(AlarmActionReceiver.EXTRA_RINGTONE_URI, alarmExecutionData.ringtoneUri)
             putExtra(AlarmActionReceiver.EXTRA_IS_VIBRATION_ENABLED, alarmExecutionData.isVibrationEnabled)
             putExtra(AlarmActionReceiver.EXTRA_ALARM_SNOOZE_DURATION, alarmExecutionData.snoozeDuration)
+            putExtra(AlarmActionReceiver.EXTRA_ALARM_ACTION_ORIGIN, alarmActionOrigin)
         }
     }
+
+    fun dismissAlarmFromNotification(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
+        dismissAlarmIntent(context, AlarmActionOrigin.NOTIFICATION, alarmExecutionData)
+
+    fun dismissAlarmFromFullScreen(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
+        dismissAlarmIntent(context, AlarmActionOrigin.FULL_SCREEN, alarmExecutionData)
 
     /**
      * Creates an Intent for dismissing Alarms. This Intent does not contain all the properties of AlarmExecutionData.
      *
      * @param context used for Intent creation
+     * @param alarmActionOrigin the origin of the dismiss action (ex: Notification, Full Screen Alarm)
      * @param alarmExecutionData execution data for the Alarm
      *
      * @return Intent for dismissing Alarms
      */
-    fun dismissAlarmIntent(context: Context, alarmExecutionData: AlarmExecutionData): Intent =
+    private fun dismissAlarmIntent(
+        context: Context,
+        alarmActionOrigin: AlarmActionOrigin,
+        alarmExecutionData: AlarmExecutionData
+    ): Intent =
         Intent(context, AlarmActionReceiver::class.java).apply {
             // Action
             action = AlarmActionReceiver.ACTION_DISMISS_ALARM
             // Extras
             putExtra(AlarmActionReceiver.EXTRA_ALARM_ID, alarmExecutionData.id)
             putExtra(AlarmActionReceiver.EXTRA_REPEATING_DAYS, alarmExecutionData.encodedRepeatingDays)
+            putExtra(AlarmActionReceiver.EXTRA_ALARM_ACTION_ORIGIN, alarmActionOrigin)
         }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -247,7 +247,7 @@ class AlarmNotificationService : Service() {
         )
 
         // Create Intent and send Broadcast
-        val dismissFullScreenAlertIntent = Intent().apply {
+        val showPostAlarmConfirmationIntent = Intent().apply {
             // Action
             action = FullScreenAlarmActivity.ACTION_SHOW_POST_ALARM_CONFIRMATION
             // Extras
@@ -258,17 +258,17 @@ class AlarmNotificationService : Service() {
             // that are not exported, and are to be used by an application's internal components.
             setPackage(this@AlarmNotificationService.packageName)
         }
-        applicationContext.sendBroadcast(dismissFullScreenAlertIntent)
+        applicationContext.sendBroadcast(showPostAlarmConfirmationIntent)
     }
 
     private fun finishFullScreenAlarmFlow() {
-        val dismissFullScreenAlertIntent = Intent().apply {
+        val finishFullScreenAlarmFlowIntent = Intent().apply {
             action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_FLOW
             // On devices running API 34+, it is required to call setPackage() on implicit Intents
             // that are not exported, and are to be used by an application's internal components.
             setPackage(this@AlarmNotificationService.packageName)
         }
-        applicationContext.sendBroadcast(dismissFullScreenAlertIntent)
+        applicationContext.sendBroadcast(finishFullScreenAlarmFlowIntent)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -176,7 +176,7 @@ class AlarmNotificationService : Service() {
         // If there's an Active Alarm, dismiss the Full Screen Notification and disable/reschedule the Alarm
         if (notificationAlarm != null) {
             // Dismiss Full Screen Notification
-            finishFullScreenAlarmActivityNoConfirm()
+            finishFullScreenAlarmFlow()
             // Disable/reschedule Alarm
             disableOrRescheduleAlarm(alarmRepo, notificationAlarm)
         }
@@ -216,9 +216,9 @@ class AlarmNotificationService : Service() {
 
         // Dismiss Full Screen Notification
         if (alarmActionOrigin == AlarmActionOrigin.NOTIFICATION) {
-            finishFullScreenAlarmActivityNoConfirm()
+            finishFullScreenAlarmFlow()
         } else {
-            finishFullScreenAlarmActivityNatural(intent)
+            showPostAlarmConfirmation(intent)
         }
 
         // Stop Ringtone
@@ -234,7 +234,7 @@ class AlarmNotificationService : Service() {
         stopSelf()
     }
 
-    private fun finishFullScreenAlarmActivityNatural(intent: Intent) {
+    private fun showPostAlarmConfirmation(intent: Intent) {
         // TODO: Come up with a better default than just FullScreenAlarmButton.BOTH
         // Post Alarm confirmation data
         val fullScreenAlarmButton = intent.getSerializableExtraSafe(
@@ -249,7 +249,7 @@ class AlarmNotificationService : Service() {
         // Create Intent and send Broadcast
         val dismissFullScreenAlertIntent = Intent().apply {
             // Action
-            action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL
+            action = FullScreenAlarmActivity.ACTION_SHOW_POST_ALARM_CONFIRMATION
             // Extras
             putExtra(AlarmActionReceiver.EXTRA_FULL_SCREEN_ALARM_BUTTON, fullScreenAlarmButton)
             putExtra(AlarmActionReceiver.EXTRA_ALARM_SNOOZE_DURATION, snoozeDuration)
@@ -261,9 +261,9 @@ class AlarmNotificationService : Service() {
         applicationContext.sendBroadcast(dismissFullScreenAlertIntent)
     }
 
-    private fun finishFullScreenAlarmActivityNoConfirm() {
+    private fun finishFullScreenAlarmFlow() {
         val dismissFullScreenAlertIntent = Intent().apply {
-            action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM
+            action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_FLOW
             // On devices running API 34+, it is required to call setPackage() on implicit Intents
             // that are not exported, and are to be used by an application's internal components.
             setPackage(this@AlarmNotificationService.packageName)

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -64,10 +64,7 @@ class FullScreenAlarmActivity : ComponentActivity() {
                 // Do so in such a way that the User cannot navigate back to the FullScreenAlarmScreen
                 // Navigating back will simply exit the full screen Alarm flow
                 navHostController.navigate(Destination.PostAlarmConfirmationScreen(fullScreenAlarmButton, snoozeDuration)) {
-                    popUpTo(navHostController.graph.findStartDestination().id) {
-                        saveState = false
-                        inclusive = true
-                    }
+                    popUpTo(navHostController.graph.findStartDestination().id) { inclusive = true }
                 }
             }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -40,9 +40,9 @@ class FullScreenAlarmActivity : ComponentActivity() {
             override fun onReceive(context: Context?, intent: Intent?) {
                 if (context != null && intent != null) {
                     when (intent.action) {
-                        ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL ->
+                        ACTION_SHOW_POST_ALARM_CONFIRMATION ->
                             navigateToConfirmationScreen(intent)
-                        ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM ->
+                        ACTION_FINISH_FULL_SCREEN_ALARM_FLOW ->
                             finishActivity()
                     }
                 }
@@ -72,8 +72,8 @@ class FullScreenAlarmActivity : ComponentActivity() {
 
     companion object {
         // BroadcastReceiver constants
-        const val ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL = "action_finish_full_screen_alarm_activity_natural"
-        const val ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM = "action_finish_full_screen_alarm_activity_no_confirm"
+        const val ACTION_SHOW_POST_ALARM_CONFIRMATION = "action_show_post_alarm_confirmation"
+        const val ACTION_FINISH_FULL_SCREEN_ALARM_FLOW = "action_finish_full_screen_alarm_flow"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -136,8 +136,8 @@ class FullScreenAlarmActivity : ComponentActivity() {
         // Register BroadcastReceiver
         if (!receiverRegistered) {
             val intentFilter = IntentFilter().apply {
-                addAction(ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL)
-                addAction(ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM)
+                addAction(ACTION_SHOW_POST_ALARM_CONFIRMATION)
+                addAction(ACTION_FINISH_FULL_SCREEN_ALARM_FLOW)
             }
             ContextCompat.registerReceiver(this, fullScreenAlarmReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
             receiverRegistered = true

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -21,6 +20,7 @@ import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.alarmexecution.AlarmActionReceiver
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import com.example.alarmscratch.core.extension.getSerializableExtraSafe
 import com.example.alarmscratch.core.extension.navigateSingleTop
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.navigation.FullScreenAlarmNavHost
@@ -52,14 +52,10 @@ class FullScreenAlarmActivity : ComponentActivity() {
             private fun navigateToConfirmationScreen(intent: Intent) {
                 // TODO: Come up with a better default than just FullScreenAlarmButton.BOTH
                 // Post Alarm confirmation data
-                val fullScreenAlarmButton = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    intent.getSerializableExtra(
-                        AlarmActionReceiver.EXTRA_FULL_SCREEN_ALARM_BUTTON,
-                        FullScreenAlarmButton::class.java
-                    )
-                } else {
-                    intent.getSerializableExtra(AlarmActionReceiver.EXTRA_FULL_SCREEN_ALARM_BUTTON) as? FullScreenAlarmButton
-                } ?: FullScreenAlarmButton.BOTH
+                val fullScreenAlarmButton = intent.getSerializableExtraSafe(
+                    AlarmActionReceiver.EXTRA_FULL_SCREEN_ALARM_BUTTON,
+                    FullScreenAlarmButton::class.java
+                ) ?: FullScreenAlarmButton.BOTH
                 val snoozeDuration = intent.getIntExtra(
                     AlarmActionReceiver.EXTRA_ALARM_SNOOZE_DURATION,
                     AlarmDefaultsRepository.DEFAULT_SNOOZE_DURATION
@@ -140,7 +136,10 @@ class FullScreenAlarmActivity : ComponentActivity() {
 
         // Register BroadcastReceiver
         if (!receiverRegistered) {
-            val intentFilter = IntentFilter(ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL)
+            val intentFilter = IntentFilter().apply {
+                addAction(ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NATURAL)
+                addAction(ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM)
+            }
             ContextCompat.registerReceiver(this, fullScreenAlarmReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
             receiverRegistered = true
         }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -23,7 +23,6 @@ import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getSerializableExtraSafe
 import com.example.alarmscratch.core.extension.navigateSingleTop
 import com.example.alarmscratch.core.navigation.Destination
-import com.example.alarmscratch.core.navigation.FullScreenAlarmNavHost
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.AndroidDefaultDarkScrim
 import com.example.alarmscratch.settings.data.repository.AlarmDefaultsRepository

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -14,6 +14,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.R
@@ -21,7 +22,6 @@ import com.example.alarmscratch.alarm.alarmexecution.AlarmActionReceiver
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getSerializableExtraSafe
-import com.example.alarmscratch.core.extension.navigateSingleTop
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.AndroidDefaultDarkScrim
@@ -60,9 +60,15 @@ class FullScreenAlarmActivity : ComponentActivity() {
                     AlarmDefaultsRepository.DEFAULT_SNOOZE_DURATION
                 )
 
-                // TODO: Do navigation that disables back press
                 // Navigate to PostAlarmConfirmationScreen
-                navHostController.navigateSingleTop(Destination.PostAlarmConfirmationScreen(fullScreenAlarmButton, snoozeDuration))
+                // Do so in such a way that the User cannot navigate back to the FullScreenAlarmScreen
+                // Navigating back will simply exit the full screen Alarm flow
+                navHostController.navigate(Destination.PostAlarmConfirmationScreen(fullScreenAlarmButton, snoozeDuration)) {
+                    popUpTo(navHostController.graph.findStartDestination().id) {
+                        saveState = false
+                        inclusive = true
+                    }
+                }
             }
 
             private fun finishActivity() {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmButton.kt
@@ -1,0 +1,30 @@
+package com.example.alarmscratch.alarm.ui.fullscreenalert
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AlarmOff
+import androidx.compose.material.icons.filled.Snooze
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.alarmscratch.R
+
+enum class FullScreenAlarmButton(
+    @StringRes val fullScreenStringRes: Int,
+    @StringRes val confirmationStringRes: Int,
+    val confirmationIcon: ImageVector
+) {
+    SNOOZE(
+        fullScreenStringRes = R.string.hold_to_snooze,
+        confirmationStringRes = R.string.post_alarm_confirmation_snooze,
+        confirmationIcon = Icons.Default.Snooze
+    ),
+    DISMISS(
+        fullScreenStringRes = R.string.hold_to_dismiss,
+        confirmationStringRes = R.string.post_alarm_confirmation_dismiss,
+        confirmationIcon = Icons.Default.AlarmOff
+    ),
+    BOTH(
+        fullScreenStringRes = R.string.hold_to_dismiss,
+        confirmationStringRes = R.string.post_alarm_confirmation_dismiss,
+        confirmationIcon = Icons.Default.AlarmOff
+    )
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
@@ -1,13 +1,14 @@
-package com.example.alarmscratch.core.navigation
+package com.example.alarmscratch.alarm.ui.fullscreenalert
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmScreen
-import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmViewModel
-import com.example.alarmscratch.alarm.ui.fullscreenalert.PostAlarmConfirmationScreen
+import com.example.alarmscratch.core.navigation.Destination
 
 @Composable
 fun FullScreenAlarmNavHost(
@@ -16,7 +17,13 @@ fun FullScreenAlarmNavHost(
 ) {
     NavHost(
         navController = navHostController,
-        startDestination = Destination.FullScreenAlarmScreen
+        startDestination = Destination.FullScreenAlarmScreen,
+        enterTransition = {
+            fadeIn(animationSpec = tween(durationMillis = 300))
+        },
+        exitTransition = {
+            fadeOut(animationSpec = tween(durationMillis = 300))
+        }
     ) {
         // Full Screen Alarm Screen
         composable<Destination.FullScreenAlarmScreen> {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -1,7 +1,6 @@
 package com.example.alarmscratch.alarm.ui.fullscreenalert
 
 import android.content.Context
-import androidx.annotation.StringRes
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.animation.core.animateFloatAsState
@@ -67,12 +66,6 @@ import com.example.alarmscratch.core.ui.theme.TransparentBlack
 import com.example.alarmscratch.core.ui.theme.TransparentWetSand
 import com.example.alarmscratch.core.util.StatusBarUtil
 import java.time.LocalDateTime
-
-enum class FullScreenAlarmButton(@StringRes val stringRes: Int){
-    SNOOZE(R.string.hold_to_snooze),
-    DISMISS(R.string.hold_to_dismiss),
-    BOTH(R.string.hold_to_dismiss)
-}
 
 @Composable
 fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
@@ -208,7 +201,7 @@ fun SnoozeAndDismissButtons(
 
     // Hold Indicator text state
     var showHoldIndicator by remember { mutableStateOf(false) }
-    var holdIndicatorTextRes by remember { mutableIntStateOf(FullScreenAlarmButton.BOTH.stringRes) }
+    var holdIndicatorTextRes by remember { mutableIntStateOf(FullScreenAlarmButton.BOTH.fullScreenStringRes) }
 
     // Hold Indicator progress state
     val longPressTimeout = 1500
@@ -263,7 +256,7 @@ fun SnoozeAndDismissButtons(
         // Set button as enabled
         enabledButton = button
         // Configure and show Hold Indicator
-        holdIndicatorTextRes = button.stringRes
+        holdIndicatorTextRes = button.fullScreenStringRes
         hardResetHoldIndicatorProgress()
         showHoldIndicator = true
     }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmViewModel.kt
@@ -26,13 +26,13 @@ class FullScreenAlarmViewModel(
 
     fun snoozeAlarm(context: Context) {
         context.sendBroadcast(
-            AlarmIntentBuilder.snoozeAlarmIntent(context.applicationContext, alarmExecutionData)
+            AlarmIntentBuilder.snoozeAlarmFromFullScreen(context.applicationContext, alarmExecutionData)
         )
     }
 
     fun dismissAlarm(context: Context) {
         context.sendBroadcast(
-            AlarmIntentBuilder.dismissAlarmIntent(context.applicationContext, alarmExecutionData)
+            AlarmIntentBuilder.dismissAlarmFromFullScreen(context.applicationContext, alarmExecutionData)
         )
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -69,7 +69,7 @@ fun PostAlarmConfirmationScreen(
                 Text(
                     text = stringResource(id = fullScreenAlarmButton.confirmationStringRes),
                     fontSize = 42.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Bold,
                     lineHeight = 44.sp
                 )
 
@@ -77,7 +77,8 @@ fun PostAlarmConfirmationScreen(
                 if (fullScreenAlarmButton == FullScreenAlarmButton.SNOOZE) {
                     Text(
                         text = "${snoozeDuration}${stringResource(id = R.string.post_alarm_confirmation_min)}",
-                        fontSize = 54.sp
+                        fontSize = 54.sp,
+                        fontWeight = FontWeight.SemiBold
                     )
                 }
             }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -13,26 +13,41 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
 import com.example.alarmscratch.core.util.StatusBarUtil
+import kotlinx.coroutines.delay
 
 @Composable
 fun PostAlarmConfirmationScreen(
     fullScreenAlarmButton: FullScreenAlarmButton,
     snoozeDuration: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    postAlarmConfirmationViewModel: PostAlarmConfirmationViewModel = viewModel(factory = PostAlarmConfirmationViewModel.Factory)
 ) {
     // Configure Status Bar
     StatusBarUtil.setDarkStatusBar()
+
+    // Countdown timer to finish the Alarm execution flow
+    val context = LocalContext.current
+    BasicCountdown(timeSeconds = 2) {
+        postAlarmConfirmationViewModel.finishAlarmExecutionFlow(context)
+    }
 
     Surface(
         modifier = modifier
@@ -75,6 +90,23 @@ fun PostAlarmConfirmationScreen(
                     modifier = Modifier.size(90.dp)
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun BasicCountdown(
+    timeSeconds: Int,
+    onCountdownFinished: () -> Unit,
+) {
+    var timeLeft by rememberSaveable { mutableIntStateOf(timeSeconds) }
+
+    LaunchedEffect(key1 = timeLeft) {
+        if (timeLeft > 0) {
+            delay(1000L)
+            timeLeft--
+        } else {
+            onCountdownFinished()
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.alarm.ui.fullscreenalert
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.ui.theme.DarkVolcanicRock
+import com.example.alarmscratch.core.util.StatusBarUtil
 
 @Composable
 fun PostAlarmConfirmationScreen(
@@ -28,9 +31,13 @@ fun PostAlarmConfirmationScreen(
     snoozeDuration: Int,
     modifier: Modifier = Modifier
 ) {
+    // Configure Status Bar
+    StatusBarUtil.setDarkStatusBar()
+
     Surface(
         modifier = modifier
             .fillMaxSize()
+            .background(color = DarkVolcanicRock)
             .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -46,7 +46,7 @@ fun PostAlarmConfirmationScreen(
     // Countdown timer to finish the Alarm execution flow
     val context = LocalContext.current
     BasicCountdown(timeSeconds = 2) {
-        postAlarmConfirmationViewModel.finishAlarmExecutionFlow(context)
+        postAlarmConfirmationViewModel.finishFullScreenAlarmFlow(context)
     }
 
     Surface(

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -1,0 +1,99 @@
+package com.example.alarmscratch.alarm.ui.fullscreenalert
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.alarmscratch.R
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+
+@Composable
+fun PostAlarmConfirmationScreen(
+    fullScreenAlarmButton: FullScreenAlarmButton,
+    snoozeDuration: Int,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Confirmation Text and optional Snooze Time
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.weight(0.60f)
+            ) {
+                // Confirmation Text
+                Text(
+                    text = stringResource(id = fullScreenAlarmButton.confirmationStringRes),
+                    fontSize = 42.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    lineHeight = 44.sp
+                )
+
+                // Snooze Duration
+                if (fullScreenAlarmButton == FullScreenAlarmButton.SNOOZE) {
+                    Text(
+                        text = "${snoozeDuration}${stringResource(id = R.string.post_alarm_confirmation_min)}",
+                        fontSize = 54.sp
+                    )
+                }
+            }
+
+            // Confirmation Icon
+            Box(modifier = Modifier.weight(0.40f)) {
+                Icon(
+                    imageVector = fullScreenAlarmButton.confirmationIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(90.dp)
+                )
+            }
+        }
+    }
+}
+
+/*
+ * Preview
+ */
+
+@Preview
+@Composable
+private fun PostAlarmConfirmationScreenSnoozePreview() {
+    AlarmScratchTheme {
+        PostAlarmConfirmationScreen(
+            fullScreenAlarmButton = FullScreenAlarmButton.SNOOZE,
+            snoozeDuration = 10
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PostAlarmConfirmationScreenDismissPreview() {
+    AlarmScratchTheme {
+        PostAlarmConfirmationScreen(
+            fullScreenAlarmButton = FullScreenAlarmButton.DISMISS,
+            snoozeDuration = 10
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.alarmscratch.alarm.ui.fullscreenalert
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+
+class PostAlarmConfirmationViewModel : ViewModel() {
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                PostAlarmConfirmationViewModel() as T
+        }
+    }
+
+    fun finishAlarmExecutionFlow(context: Context) {
+        context.sendBroadcast(
+            Intent().apply {
+                action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM
+                // On devices running API 34+, it is required to call setPackage() on implicit Intents
+                // that are not exported, and are to be used by an application's internal components.
+                setPackage(context.packageName)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
@@ -17,10 +17,10 @@ class PostAlarmConfirmationViewModel : ViewModel() {
         }
     }
 
-    fun finishAlarmExecutionFlow(context: Context) {
+    fun finishFullScreenAlarmFlow(context: Context) {
         context.sendBroadcast(
             Intent().apply {
-                action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY_NO_CONFIRM
+                action = FullScreenAlarmActivity.ACTION_FINISH_FULL_SCREEN_ALARM_FLOW
                 // On devices running API 34+, it is required to call setPackage() on implicit Intents
                 // that are not exported, and are to be used by an application's internal components.
                 setPackage(context.packageName)

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotification.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/notification/AlarmNotification.kt
@@ -49,7 +49,7 @@ object AlarmNotification {
         val snoozeAlarmPendingIntent = PendingIntent.getBroadcast(
             context,
             alarmExecutionData.id,
-            AlarmIntentBuilder.snoozeAlarmIntent(context, alarmExecutionData),
+            AlarmIntentBuilder.snoozeAlarmFromNotification(context, alarmExecutionData),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
@@ -71,7 +71,7 @@ object AlarmNotification {
         PendingIntent.getBroadcast(
             context,
             alarmExecutionData.id,
-            AlarmIntentBuilder.dismissAlarmIntent(context, alarmExecutionData),
+            AlarmIntentBuilder.dismissAlarmFromNotification(context, alarmExecutionData),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Intent.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Intent.kt
@@ -1,0 +1,12 @@
+package com.example.alarmscratch.core.extension
+
+import android.content.Intent
+import android.os.Build
+import java.io.Serializable
+
+inline fun <reified T : Serializable> Intent.getSerializableExtraSafe(name: String, clazz: Class<T>): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(name, clazz)
+    } else {
+        getSerializableExtra(name) as? T
+    }

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/Destination.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/Destination.kt
@@ -1,13 +1,26 @@
 package com.example.alarmscratch.core.navigation
 
+import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmButton
 import kotlinx.serialization.Serializable
 
 sealed interface Destination {
+
+    /*
+     * Main Screens
+     */
+
     @Serializable
     data object CoreScreen : Destination
 
     @Serializable
     data object AlarmListScreen : Destination
+
+    @Serializable
+    data object SettingsScreen : Destination
+
+    /*
+     * Secondary Screens
+     */
 
     @Serializable
     data object AlarmCreationScreen : Destination
@@ -19,11 +32,21 @@ sealed interface Destination {
     data class RingtonePickerScreen(val ringtoneUriString: String) : Destination
 
     @Serializable
-    data object SettingsScreen : Destination
-
-    @Serializable
     data object GeneralSettingsScreen : Destination
 
     @Serializable
     data object AlarmDefaultsScreen : Destination
+
+    /*
+     * Alarm Execution Screens
+     */
+
+    @Serializable
+    data object FullScreenAlarmScreen : Destination
+
+    @Serializable
+    data class PostAlarmConfirmationScreen(
+        val fullScreenAlarmButton: FullScreenAlarmButton,
+        val snoozeDuration: Int
+    ) : Destination
 }

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/FullScreenAlarmNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/FullScreenAlarmNavHost.kt
@@ -1,0 +1,38 @@
+package com.example.alarmscratch.core.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmScreen
+import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmViewModel
+import com.example.alarmscratch.alarm.ui.fullscreenalert.PostAlarmConfirmationScreen
+
+@Composable
+fun FullScreenAlarmNavHost(
+    navHostController: NavHostController,
+    fullScreenAlarmViewModel: FullScreenAlarmViewModel
+) {
+    NavHost(
+        navController = navHostController,
+        startDestination = Destination.FullScreenAlarmScreen
+    ) {
+        // Full Screen Alarm Screen
+        composable<Destination.FullScreenAlarmScreen> {
+            FullScreenAlarmScreen(fullScreenAlarmViewModel = fullScreenAlarmViewModel)
+        }
+
+        // Post Alarm Confirmation Screen
+        composable<Destination.PostAlarmConfirmationScreen> {
+            val route = it.toRoute<Destination.PostAlarmConfirmationScreen>()
+            val fullScreenAlarmButton = route.fullScreenAlarmButton
+            val snoozeDuration = route.snoozeDuration
+
+            PostAlarmConfirmationScreen(
+                fullScreenAlarmButton = fullScreenAlarmButton,
+                snoozeDuration = snoozeDuration
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,15 @@
     <string name="default_alarm_time">Now</string>
 
     <!--
+        *****************************
+        ** Post Alarm Confirmation **
+        *****************************
+    -->
+    <string name="post_alarm_confirmation_snooze">Alarm Snoozed</string>
+    <string name="post_alarm_confirmation_dismiss">Alarm Dismissed</string>
+    <string name="post_alarm_confirmation_min">min</string>
+
+    <!--
         **********************
         ** DaysHoursMinutes **
         **********************


### PR DESCRIPTION
### Description
- Create `PostAlarmConfirmationScreen` to confirm to the User that they had Snoozed or Dismissed the Alarm on the `FullScreenAlarmScreen`
  - If the User Snoozes or Dismisses the Alarm via the `FullScreenAlarmScreen`, the `PostAlarmConfirmationScreen` will show for 2 seconds, confirming which decision they made
  - The `PostAlarmConfirmationScreen` will not show when Snoozing or Dismissing the Alarm from the Notification, even if the `FullScreenAlarmScreen` is visible to the User
- Rename existing Intent Action constant for the `FullScreenAlarmActivity` `BroadcastReceiver` from `ACTION_FINISH_FULL_SCREEN_ALARM_ACTIVITY` to `ACTION_FINISH_FULL_SCREEN_ALARM_FLOW`