### PR TITLE
Feature | Basic Splash Screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     // Preferences DataStore
     implementation(libs.androidx.preferences.datastore)
 
+    // Splash Screen
+    implementation(libs.androidx.core.splashscreen)
+
     testImplementation(libs.junit)
 
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,12 +40,12 @@
             ** Activities **
             ****************
         -->
-        <!-- Main Activity. Lands on the Alarm List Screen. -->
+        <!-- Main Activity. Initially displays a Splash Screen and then lands on the Alarm List Screen. -->
         <activity
             android:name=".core.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.AlarmScratch">
+            android:theme="@style/Theme.AlarmScratch.SplashScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/MainActivity.kt
@@ -7,12 +7,16 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.graphics.toArgb
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.example.alarmscratch.core.navigation.AlarmApp
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
 import com.example.alarmscratch.core.ui.theme.AndroidDefaultDarkScrim
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Create and display Splash Screen and auto switch from
+        // Splash Screen theme to general app theme afterwards
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         // Enable edge to edge for dynamic Status Bar coloring

--- a/app/src/main/res/drawable/ic_anchor_boat_sails_24dp.xml
+++ b/app/src/main/res/drawable/ic_anchor_boat_sails_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#F9F6E2"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,15l1.55,1.55c-0.96,1.69 -3.33,3.04 -5.55,3.37V11h3V9h-3V7.82C14.16,7.4 15,6.3 15,5c0,-1.65 -1.35,-3 -3,-3S9,3.35 9,5c0,1.3 0.84,2.4 2,2.82V9H8v2h3v8.92c-2.22,-0.33 -4.59,-1.68 -5.55,-3.37L7,15l-4,-3v3c0,3.88 4.92,7 9,7s9,-3.12 9,-7v-3L17,15zM12,4c0.55,0 1,0.45 1,1s-0.45,1 -1,1s-1,-0.45 -1,-1S11.45,4 12,4z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_splash_screen.xml
+++ b/app/src/main/res/drawable/ic_splash_screen.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_anchor_boat_sails_24dp"
+    android:insetLeft="24dp"
+    android:insetTop="24dp"
+    android:insetRight="24dp"
+    android:insetBottom="24dp" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- Splash Screen -->
+    <color name="dark_volcanic_rock">#FF232322</color>
+
+    <!-- Default -->
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
@@ -7,4 +12,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- General App Theme -->
     <style name="Theme.AlarmScratch" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <!-- Splash Screen Theme -->
+    <style name="Theme.AlarmScratch.SplashScreen" parent="Theme.SplashScreen">
+        <!-- UI -->
+        <item name="windowSplashScreenBackground">@color/dark_volcanic_rock</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_screen</item>
+
+        <!-- Post Splash Screen theme switching -->
+        <item name="postSplashScreenTheme">@style/Theme.AlarmScratch</item>
+    </style>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ activityCompose = "1.9.0"
 composeBom = "2024.09.02"
 materialIcons = "1.6.6"
 navigationCompose = "2.8.0-rc01"
+splashscreen = "1.0.1"
 serialization = "1.6.3"
 
 [libraries]
@@ -21,6 +22,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-preferences-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "preferencesDataStore" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }


### PR DESCRIPTION
### Description
- Create a basic placeholder Splash Screen
  - Dark grey background with an off-white anchor icon
  - The "real" version of the Splash Screen will replace the anchor icon with a version of the app's launcher icon, which has not yet been created
  - Add `androidx.core:core-splashscreen:1.0.1` dependency to `libs.versions.toml`, and the `:app` module's `build.gradle.kts` file
  - The customized Splash Screen seems to load about 25ms slower than the default one. I'm not sure why this is the case. I'm guessing it may have something to do with the fact that I'm using a basic 24dp icon which the System has to scale up for the Splash Screen, but I'm not sure if this is really even a factor since it's a vector drawable. Either way, there's not much you can do in terms of customizing the Splash Screen. You're really just modifying attributes in a theme file, and not actually "creating" the Splash Screen yourself, therefore there's not much control over it. I need to replace the default attributes either way so if this 25ms extra load time cannot be avoided then it will just have to be.