### PR TITLE
Feature | Alarm Short Press Cancel

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -284,6 +284,12 @@ fun SnoozeAndDismissButtons(
         enabledButton = FullScreenAlarmButton.BOTH
     }
 
+    val onPressCancelled: () -> Unit = {
+        // Reset buttons and animate progress down towards 0f
+        enabledButton = FullScreenAlarmButton.BOTH
+        targetProgress = 0f
+    }
+
     // Snooze and Dismiss Buttons with Hold Indicator
     Column(
         verticalArrangement = Arrangement.Bottom,
@@ -331,6 +337,7 @@ fun SnoozeAndDismissButtons(
                 onShortPress = onShortPress,
                 onLongPress = { onLongPress(FullScreenAlarmButton.SNOOZE) },
                 onLongPressRelease = onLongPressRelease,
+                onPressCancelled = onPressCancelled,
                 enabled = isButtonEnabled(FullScreenAlarmButton.SNOOZE),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = TransparentWetSand,
@@ -355,6 +362,7 @@ fun SnoozeAndDismissButtons(
                 onShortPress = onShortPress,
                 onLongPress = { onLongPress(FullScreenAlarmButton.DISMISS) },
                 onLongPressRelease = onLongPressRelease,
+                onPressCancelled = onPressCancelled,
                 enabled = isButtonEnabled(FullScreenAlarmButton.DISMISS),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = TransparentWetSand,

--- a/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/shared/LongPressButton.kt
@@ -2,6 +2,7 @@ package com.example.alarmscratch.core.ui.shared
 
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,6 +18,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +40,7 @@ fun LongPressButton(
     onShortPress: (() -> Unit)? = null,
     onLongPress: () -> Unit,
     onLongPressRelease: (() -> Unit)? = null,
+    onPressCancelled: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     shape: Shape = ButtonDefaults.shape,
@@ -45,9 +48,19 @@ fun LongPressButton(
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     content: @Composable RowScope.() -> Unit
 ) {
+    // State
     val interactionSource = remember { MutableInteractionSource() }
     val containerColor = if (enabled) colors.containerColor else colors.disabledContainerColor
     val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
+
+    // Listen for press cancellations
+    LaunchedEffect(key1 = interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            if (interaction is PressInteraction.Cancel) {
+                onPressCancelled?.invoke()
+            }
+        }
+    }
 
     Surface(
         color = containerColor,


### PR DESCRIPTION
### Description
- Add cancellation logic for short presses on the Snooze and Dismiss buttons on `FullScreenAlarmScreen` via callback, `LongPressButton`, and `SingleTapGestureDetector`
  - Prior to this PR, if the User cancelled a short press on either of these buttons (press, hold less than long press timeout, and drag finger outside of button bounds before releasing) then the `Hold Indicator` would continue to fill up, when it should instead animate itself back to 0. This PR makes it so that a cancelled short press will both reset the Snooze and Dismiss enabled states, and animate the `Hold Indicator` down to 0.
  - Long press cancellations are still counted as `Releases` rather than `Cancellations`. This means that if the User presses Dismiss, holds past the long press timeout while inside the bounds of the button, then while still holding down drags their finger outside the button, a `Cancel` `PressInteraction` will not be sent when the held press goes out of bounds. Instead it will wait until the User releases, and then send a `Release` `PressInteraction`.