### PR TITLE
Feature | Finish Alarm Activity Screen Off

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -14,6 +14,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -131,6 +132,25 @@ class FullScreenAlarmActivity : ComponentActivity() {
         }
 
         turnScreenOn()
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        // If onStart() is called while we're currently on PostAlarmConfirmationScreen then
+        // that means the User has already Snoozed or Dismissed the Alarm, and they have already
+        // visited this screen before. This means that the PostAlarmConfirmationScreen was previously
+        // displayed, then navigated away from (screen turned off), then displayed a second time.
+        // PostAlarmConfirmationScreen should not be displayed a second time if the User turned the
+        // screen off the first time around, so just finish the Activity.
+        val onPostAlarmConfirmationScreen: Boolean? = if (::navHostController.isInitialized) {
+            navHostController.currentDestination?.hasRoute<Destination.PostAlarmConfirmationScreen>()
+        } else {
+            null
+        }
+        if (onPostAlarmConfirmationScreen == true) {
+            finish()
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
@@ -100,14 +103,17 @@ fun BasicCountdown(
     timeSeconds: Int,
     onCountdownFinished: () -> Unit,
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
     var timeLeft by rememberSaveable { mutableIntStateOf(timeSeconds) }
 
-    LaunchedEffect(key1 = timeLeft) {
-        if (timeLeft > 0) {
-            delay(1000L)
-            timeLeft--
-        } else {
-            onCountdownFinished()
+    LaunchedEffect(key1 = lifecycleOwner.lifecycle, key2 = timeLeft) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            if (timeLeft > 0) {
+                delay(1000L)
+                timeLeft--
+            } else {
+                onCountdownFinished()
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
- Finish `FullScreenAlarmActivity` if it has been started more than once while on `PostAlarmConfirmationScreen`
  - This can happen when the User Snoozes/Dismisses an Alarm on `FullScreenAlarmScreen`, which navigates to `PostAlarmConfirmationScreen`, and the User then turns the screen off before the `PostAlarmConfirmationScreen` timeout finishes, which would normally finish the `FullScreenAlarmActivity`. However, if the User turns the screen off here before that happens, then the `FullScreenAlarmActivity` remains. In this scenario the `FullScreenAlarmActivity` must be destroyed so the User doesn't see the `PostAlarmConfirmationScreen` the next time they turn the screen on.