### PR TITLE
Feature | Lava FAB Animation Consistency

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
@@ -24,7 +24,7 @@ fun AlarmApp() {
         // Core Screen
         composable<Destination.CoreScreen> {
             CoreScreen(
-                rootNavHostController = navHostController,
+                secondaryNavHostController = navHostController,
                 navigateToAlarmCreationScreen = { navHostController.navigateSingleTop(Destination.AlarmCreationScreen) },
                 modifier = Modifier.fillMaxSize()
             )

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/CoreNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/CoreNavHost.kt
@@ -10,13 +10,13 @@ import com.example.alarmscratch.core.extension.navigateSingleTop
 import com.example.alarmscratch.settings.SettingsScreen
 
 @Composable
-fun AlarmNavHost(
-    localNavHostController: NavHostController,
-    rootNavHostController: NavHostController,
+fun CoreNavHost(
+    coreNavHostController: NavHostController,
+    secondaryNavHostController: NavHostController,
     modifier: Modifier = Modifier
 ) {
     NavHost(
-        navController = localNavHostController,
+        navController = coreNavHostController,
         startDestination = Destination.AlarmListScreen,
         modifier = modifier
     ) {
@@ -24,7 +24,7 @@ fun AlarmNavHost(
         composable<Destination.AlarmListScreen> {
             AlarmListScreen(
                 navigateToAlarmEditScreen = { alarmId ->
-                    rootNavHostController.navigateSingleTop(Destination.AlarmEditScreen(alarmId = alarmId))
+                    secondaryNavHostController.navigateSingleTop(Destination.AlarmEditScreen(alarmId = alarmId))
                 }
             )
         }
@@ -32,8 +32,8 @@ fun AlarmNavHost(
         // Settings Screen
         composable<Destination.SettingsScreen> {
             SettingsScreen(
-                navigateToGeneralSettingsScreen = { rootNavHostController.navigateSingleTop(Destination.GeneralSettingsScreen) },
-                navigateToAlarmDefaultsScreen = { rootNavHostController.navigateSingleTop(Destination.AlarmDefaultsScreen) }
+                navigateToGeneralSettingsScreen = { secondaryNavHostController.navigateSingleTop(Destination.GeneralSettingsScreen) },
+                navigateToAlarmDefaultsScreen = { secondaryNavHostController.navigateSingleTop(Destination.AlarmDefaultsScreen) }
             )
         }
     }

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/NavComponent.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/NavComponent.kt
@@ -5,6 +5,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination.Companion.hasRoute
 import com.example.alarmscratch.R
 
 enum class NavComponent(
@@ -21,5 +23,13 @@ enum class NavComponent(
         navNameRes = R.string.nav_settings,
         navIcon = Icons.Default.Settings,
         destination = Destination.SettingsScreen
-    )
+    );
+
+    companion object {
+
+        fun fromNavBackStackEntry(navBackStackEntry: NavBackStackEntry?): Destination =
+            entries.find { navComponent ->
+                navBackStackEntry?.destination?.hasRoute(navComponent.destination::class) ?: false
+            }?.destination ?: ALARM_LIST.destination
+    }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/VolcanoNavigationBar.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/VolcanoNavigationBar.kt
@@ -43,7 +43,7 @@ import com.example.alarmscratch.core.ui.theme.NavTextInactive
 
 @Composable
 fun VolcanoNavigationBar(
-    selectedNavComponentDest: Destination,
+    currentCoreDestination: Destination,
     onDestinationChange: (Destination) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -61,7 +61,7 @@ fun VolcanoNavigationBar(
     ) {
         NavComponent.entries.forEach { navComponent ->
             NavigationBarItem(
-                selected = selectedNavComponentDest == navComponent.destination,
+                selected = currentCoreDestination == navComponent.destination,
                 onClick = { onDestinationChange(navComponent.destination) },
                 icon = { Icon(imageVector = navComponent.navIcon, contentDescription = null) },
                 label = { Text(text = stringResource(id = navComponent.navNameRes)) },
@@ -291,7 +291,7 @@ fun Volcano(modifier: Modifier = Modifier) {
 private fun VolcanoNavigationBarPreview() {
     AlarmScratchTheme {
         VolcanoNavigationBar(
-            selectedNavComponentDest = Destination.AlarmListScreen,
+            currentCoreDestination = Destination.AlarmListScreen,
             onDestinationChange = {},
             modifier = Modifier.padding(top = 20.dp)
         )


### PR DESCRIPTION
### Description
- Make it so `LavaFloatingActionButton` does not reanimate itself (via `AnimatedVisibility`) unnecessarily
  - Previously, if the User was on the `SettingsScreen` in `CoreScreen`, where `LavaFloatingActionButton` should not be displayed, and the User navigated to a secondary screen such as `AlarmDefaultsScreen`, then `LavaFloatingActionButton's` exit animation would replay when the User backs out back to `SettingsScreen`. This behavior is not desired because the User has already seen `LavaFloatingActionButton's` exit animation, and was "already" on `SettingsScreen`.
- Create `NavComponent.fromNavBackStackEntry()` convenience function. This function's logic was extracted from `CoreScreen`.
- Rename `AlarmNavHost` to `CoreNavHost`
  - Even though the composable was called `AlarmNavHost`, the file was still `CoreNavHost`, so renaming it brings it in alignment with the file. That said, I like `CoreNavHost` better anyways because it's used in `CoreScreen`.
- Rename navigation related parameters and properties across modified files in order to clarify which `NavHost` they're associated with