### PR TITLE
Feature | Next Alarm Cloud Animation Consistency

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/CoreScreen.kt
@@ -3,6 +3,7 @@ package com.example.alarmscratch.core.ui.core
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -104,7 +105,12 @@ fun CoreScreen(
         modifier = modifier,
         currentCoreDestination = currentCoreDestination,
         previousCoreDestination = previousCoreDestination,
-        header = { SkylineHeader(selectedNavComponentDest = currentCoreDestination) },
+        header = {
+            SkylineHeader(
+                currentCoreDestination = currentCoreDestination,
+                previousCoreDestination = previousCoreDestination
+            )
+        },
         onFabClicked = navigateToAlarmCreationScreen,
         navigationBar = {
             VolcanoNavigationBar(
@@ -236,11 +242,12 @@ private fun CoreScreenAlarmListPreview() {
                 SkylineHeaderContent(
                     nextAlarmIndicator = {
                         NextAlarmCloudContent(
-                            selectedNavComponentDest = currentCoreDestination,
+                            currentCoreDestination = currentCoreDestination,
                             alarmCountdownState = AlarmCountdownState.Success(
                                 icon = Icons.Default.Alarm,
                                 countdownText = alarmListState.alarmList.first().toCountdownString(LocalContext.current)
                             ),
+                            visibleState = MutableTransitionState(true),
                             timeChangeReceiver = object : BroadcastReceiver() {
                                 override fun onReceive(context: Context?, intent: Intent?) {}
                             }
@@ -284,11 +291,12 @@ private fun CoreScreenAlarmListNoAlarmsPreview() {
                 SkylineHeaderContent(
                     nextAlarmIndicator = {
                         NextAlarmCloudContent(
-                            selectedNavComponentDest = currentCoreDestination,
+                            currentCoreDestination = currentCoreDestination,
                             alarmCountdownState = AlarmCountdownState.Success(
                                 icon = Icons.Default.AlarmOff,
                                 countdownText = stringResource(id = R.string.no_active_alarms)
                             ),
+                            visibleState = MutableTransitionState(true),
                             timeChangeReceiver = object : BroadcastReceiver() {
                                 override fun onReceive(context: Context?, intent: Intent?) {}
                             }
@@ -332,11 +340,12 @@ private fun CoreScreenSettingsPreview() {
                 SkylineHeaderContent(
                     nextAlarmIndicator = {
                         NextAlarmCloudContent(
-                            selectedNavComponentDest = currentCoreDestination,
+                            currentCoreDestination = currentCoreDestination,
                             alarmCountdownState = AlarmCountdownState.Success(
                                 icon = Icons.Default.Alarm,
                                 countdownText = alarmSampleDataHardCodedIds.first().toCountdownString(LocalContext.current)
                             ),
+                            visibleState = MutableTransitionState(false),
                             timeChangeReceiver = object : BroadcastReceiver() {
                                 override fun onReceive(context: Context?, intent: Intent?) {}
                             }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
@@ -55,8 +55,8 @@ fun LavaFloatingActionButton(
     val fabAnimationHeight = with(LocalDensity.current) { (fabHeight + volcanoSpacerHeight).toPx().toInt() }
 
     // Visibility state
-    val onScreenWithFab = currentCoreDestination == Destination.AlarmListScreen
-    val comingFromScreenWithFab = previousCoreDestination == Destination.AlarmListScreen
+    val onScreenWithFab = currentCoreDestination is Destination.AlarmListScreen
+    val comingFromScreenWithFab = previousCoreDestination is Destination.AlarmListScreen
     val visibleState = remember(key1 = currentCoreDestination, key2 = previousCoreDestination) {
         // True == FAB up
         // False == FAB down

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/SkylineHeader.kt
@@ -3,6 +3,7 @@ package com.example.alarmscratch.core.ui.core.component
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,11 +39,17 @@ import com.example.alarmscratch.core.ui.theme.SkyBlue
 
 @Composable
 fun SkylineHeader(
-    selectedNavComponentDest: Destination,
+    currentCoreDestination: Destination,
+    previousCoreDestination: Destination,
     modifier: Modifier = Modifier
 ) {
     SkylineHeaderContent(
-        nextAlarmIndicator = { NextAlarmCloud(selectedNavComponentDest = selectedNavComponentDest) },
+        nextAlarmIndicator = {
+            NextAlarmCloud(
+                currentCoreDestination = currentCoreDestination,
+                previousCoreDestination = previousCoreDestination
+            )
+        },
         modifier = modifier
     )
 }
@@ -149,11 +156,12 @@ private fun SkylineHeaderOneLineAlarmPreview() {
         SkylineHeaderContent(
             nextAlarmIndicator = {
                 NextAlarmCloudContent(
-                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    currentCoreDestination = Destination.AlarmListScreen,
                     alarmCountdownState = AlarmCountdownState.Success(
                         icon = Icons.Default.Alarm,
                         countdownText = consistentFutureAlarm.toCountdownString(LocalContext.current)
                     ),
+                    visibleState = MutableTransitionState(true),
                     timeChangeReceiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {}
                     }
@@ -174,11 +182,12 @@ private fun SkylineHeaderTwoLineAlarmPreview() {
         SkylineHeaderContent(
             nextAlarmIndicator = {
                 NextAlarmCloudContent(
-                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    currentCoreDestination = Destination.AlarmListScreen,
                     alarmCountdownState = AlarmCountdownState.Success(
                         icon = Icons.Default.Alarm,
                         countdownText = alarm.toCountdownString(LocalContext.current)
                     ),
+                    visibleState = MutableTransitionState(true),
                     timeChangeReceiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {}
                     }
@@ -195,11 +204,12 @@ private fun SkylineHeaderSnoozedAlarmPreview() {
         SkylineHeaderContent(
             nextAlarmIndicator = {
                 NextAlarmCloudContent(
-                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    currentCoreDestination = Destination.AlarmListScreen,
                     alarmCountdownState = AlarmCountdownState.Success(
                         icon = Icons.Default.Snooze,
                         countdownText = snoozedAlarm.toCountdownString(LocalContext.current)
                     ),
+                    visibleState = MutableTransitionState(true),
                     timeChangeReceiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {}
                     }
@@ -216,11 +226,12 @@ private fun SkylineHeaderNoAlarmsPreview() {
         SkylineHeaderContent(
             nextAlarmIndicator = {
                 NextAlarmCloudContent(
-                    selectedNavComponentDest = Destination.AlarmListScreen,
+                    currentCoreDestination = Destination.AlarmListScreen,
                     alarmCountdownState = AlarmCountdownState.Success(
                         icon = Icons.Default.AlarmOff,
                         countdownText = stringResource(id = R.string.no_active_alarms)
                     ),
+                    visibleState = MutableTransitionState(true),
                     timeChangeReceiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {}
                     }
@@ -237,11 +248,12 @@ private fun SkylineHeaderSettingsScreenPreview() {
         SkylineHeaderContent(
             nextAlarmIndicator = {
                 NextAlarmCloudContent(
-                    selectedNavComponentDest = Destination.SettingsScreen,
+                    currentCoreDestination = Destination.SettingsScreen,
                     alarmCountdownState = AlarmCountdownState.Success(
                         icon = Icons.Default.Alarm,
                         countdownText = consistentFutureAlarm.toCountdownString(LocalContext.current)
                     ),
+                    visibleState = MutableTransitionState(false),
                     timeChangeReceiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {}
                     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ androidxLifecycle = "2.8.0"
 activityCompose = "1.9.0"
 composeBom = "2024.09.02"
 materialIcons = "1.6.6"
-navigationCompose = "2.8.0-rc01"
+navigationCompose = "2.8.8"
 splashscreen = "1.0.1"
 serialization = "1.6.3"
 


### PR DESCRIPTION
### Description
- Make it so the `NextAlarmCloud` text does not reanimate itself (via `AnimatedVisibility`) unnecessarily
  - Previously, if the User was on the `SettingsScreen` in `CoreScreen`, where the `NextAlarmCloud` text should not be displayed, and the User navigated to a secondary screen such as `AlarmDefaultsScreen`, then the `NextAlarmCloud` text's exit animation would replay when the User backs out back to `SettingsScreen`. This behavior is not desired because the User has already seen the `NextAlarmCloud` text's exit animation, and was "already" on `SettingsScreen`.
  - Additional tracking for this was added to back presses. Previously, back presses did not result in proper animation management.
- Update `androidx.navigation:navigation-compose` from `2.8.0-rc01` to `2.8.8`
- Change some `LavaFloatingActionButton` comparison logic from `==` to `is`