### PR TITLE
Feature | Alarm Table Naming Conventions

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
@@ -1,21 +1,28 @@
 package com.example.alarmscratch.alarm.data.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import java.time.LocalDateTime
 
-@Entity(tableName = "alarms")
+@Entity(tableName = "alarm")
 data class Alarm(
     // TODO: Do @ColumnInfo for custom column names
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val name: String = "",
     val enabled: Boolean = true,
+    @ColumnInfo(name = "date_time")
     val dateTime: LocalDateTime = LocalDateTimeUtil.nowTruncated(),
+    @ColumnInfo(name = "weekly_repeater")
     val weeklyRepeater: WeeklyRepeater = WeeklyRepeater(),
+    @ColumnInfo(name = "ringtone_uri_string")
     val ringtoneUriString: String,
+    @ColumnInfo(name = "is_vibration_enabled")
     val isVibrationEnabled: Boolean = false,
+    @ColumnInfo(name = "snooze_date_time")
     val snoozeDateTime: LocalDateTime? = null,
+    @ColumnInfo(name = "snooze_duration")
     val snoozeDuration: Int
 )

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/Alarm.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 
 @Entity(tableName = "alarm")
 data class Alarm(
-    // TODO: Do @ColumnInfo for custom column names
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val name: String = "",
@@ -17,8 +16,8 @@ data class Alarm(
     val dateTime: LocalDateTime = LocalDateTimeUtil.nowTruncated(),
     @ColumnInfo(name = "weekly_repeater")
     val weeklyRepeater: WeeklyRepeater = WeeklyRepeater(),
-    @ColumnInfo(name = "ringtone_uri_string")
-    val ringtoneUriString: String,
+    @ColumnInfo(name = "ringtone_uri")
+    val ringtoneUri: String,
     @ColumnInfo(name = "is_vibration_enabled")
     val isVibrationEnabled: Boolean = false,
     @ColumnInfo(name = "snooze_date_time")

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/model/AlarmDao.kt
@@ -31,19 +31,19 @@ interface AlarmDao {
     @Delete
     suspend fun delete(alarm: Alarm)
 
-    @Query("SELECT * FROM alarms WHERE id = :id")
+    @Query("SELECT * FROM alarm WHERE id = :id")
     suspend fun getAlarm(id: Int): Alarm
 
-    @Query("SELECT * FROM alarms")
+    @Query("SELECT * FROM alarm")
     suspend fun getAllAlarms(): List<Alarm>
 
     /*
      * Observable Read
      */
-    @Query("SELECT * FROM alarms WHERE id = :id")
+    @Query("SELECT * FROM alarm WHERE id = :id")
     fun getAlarmFlow(id: Int): Flow<Alarm>
 
-    @Query("SELECT * FROM alarms")
+    @Query("SELECT * FROM alarm")
     fun getAllAlarmsFlow(): Flow<List<Alarm>>
 
     /*
@@ -55,18 +55,18 @@ interface AlarmDao {
     /*
      * One-shot Read/Write
      */
-    @Query("SELECT * FROM alarms WHERE enabled = 1")
+    @Query("SELECT * FROM alarm WHERE enabled = 1")
     suspend fun getAllEnabledAlarms(): List<Alarm>
 
-    @Query("UPDATE alarms SET snoozeDateTime = :snoozeDateTime WHERE id = :id")
+    @Query("UPDATE alarm SET snooze_date_time = :snoozeDateTime WHERE id = :id")
     suspend fun updateSnooze(id: Int, snoozeDateTime: LocalDateTime)
 
-    @Query("UPDATE alarms SET snoozeDateTime = null WHERE id = :id")
+    @Query("UPDATE alarm SET snooze_date_time = null WHERE id = :id")
     suspend fun resetSnooze(id: Int)
 
-    @Query("UPDATE alarms SET enabled = 0, snoozeDateTime = null WHERE id = :id")
+    @Query("UPDATE alarm SET enabled = 0, snooze_date_time = null WHERE id = :id")
     suspend fun dismissAlarm(id: Int)
 
-    @Query("UPDATE alarms SET dateTime = :dateTime, snoozeDateTime = null WHERE id = :id")
+    @Query("UPDATE alarm SET date_time = :dateTime, snooze_date_time = null WHERE id = :id")
     suspend fun dismissAndRescheduleRepeating(id: Int, dateTime: LocalDateTime)
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/data/preview/AlarmPreviewData.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 
 const val tueWedThu: Int = 28
 const val everyDay: Int = 127
-private const val sampleRingtoneUriString = "content://settings/system/alarm_alert"
+private const val sampleRingtoneUri = "content://settings/system/alarm_alert"
 
 val repeatingAlarm =
     Alarm(
@@ -18,7 +18,7 @@ val repeatingAlarm =
         //  Alarm is going to go off based on the WeeklyRepeater
         dateTime = getTomorrowAtTime24Hr(hour = 8, minute = 30),
         weeklyRepeater = WeeklyRepeater(encodedRepeatingDays = tueWedThu),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = true,
         snoozeDuration = 5
     )
@@ -29,7 +29,7 @@ val todayAlarm =
         enabled = true,
         dateTime = getTodayAtTime24Hr(hour = 23, minute = 59),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = false,
         snoozeDuration = 10
     )
@@ -40,7 +40,7 @@ val tomorrowAlarm =
         enabled = false,
         dateTime = getTomorrowAtTime24Hr(hour = 14, minute = 0),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = true,
         snoozeDuration = 15
     )
@@ -51,7 +51,7 @@ val calendarAlarm =
         enabled = true,
         dateTime = getFutureTime(plusDays = 2),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = false,
         snoozeDuration = 20
     )
@@ -62,7 +62,7 @@ val consistentFutureAlarm =
         enabled = true,
         dateTime = getFutureTime(plusHours = 8, plusMinutes = 45),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = true,
         snoozeDuration = 25
     )
@@ -73,7 +73,7 @@ val snoozedAlarm =
         enabled = true,
         dateTime = LocalDateTimeUtil.nowTruncated(),
         weeklyRepeater = WeeklyRepeater(),
-        ringtoneUriString = sampleRingtoneUriString,
+        ringtoneUri = sampleRingtoneUri,
         isVibrationEnabled = true,
         snoozeDateTime = LocalDateTimeUtil.nowTruncated().plusMinutes(25),
         snoozeDuration = 25
@@ -87,7 +87,7 @@ val alarmSampleData: List<Alarm> = listOf(repeatingAlarm, todayAlarm, tomorrowAl
  */
 val alarmSampleDataHardCodedIds: List<Alarm> = alarmSampleData.mapIndexed { index, alarm -> alarm.copy(id = index) }
 
-val sampleRingtoneData = RingtoneData(id = 0, name = "Ringtone 1", baseUri = sampleRingtoneUriString)
+val sampleRingtoneData = RingtoneData(id = 0, name = "Ringtone 1", baseUri = sampleRingtoneUri)
 
 val ringtoneDataSampleList: List<RingtoneData> = listOf(
     sampleRingtoneData,

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -64,7 +64,7 @@ fun AlarmCreationScreen(
             // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
             // then the new Ringtone's URI will be saved here.
             alarmCreationViewModel.updateRingtone(
-                navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+                navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI)
             )
 
             val context = LocalContext.current
@@ -150,7 +150,7 @@ private fun AlarmCreationScreenPreview() {
             alarm = Alarm(
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu),
-                ringtoneUriString = sampleRingtoneData.fullUriString,
+                ringtoneUri = sampleRingtoneData.fullUri,
                 isVibrationEnabled = true,
                 snoozeDuration = 10
             ),

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -103,7 +103,7 @@ class AlarmCreationViewModel(
                         val alarmState = AlarmState.Success(
                             Alarm(
                                 dateTime = getInitialAlarmDateTime(),
-                                ringtoneUriString = alarmDefaults.ringtoneUri,
+                                ringtoneUri = alarmDefaults.ringtoneUri,
                                 isVibrationEnabled = alarmDefaults.isVibrationEnabled,
                                 snoozeDuration = alarmDefaults.snoozeDuration
                             )
@@ -271,14 +271,14 @@ class AlarmCreationViewModel(
         }
     }
 
-    fun updateRingtone(ringtoneUriString: String?) {
+    fun updateRingtone(ringtoneUri: String?) {
         if (
             _newAlarm.value is AlarmState.Success &&
-            ringtoneUriString != null &&
-            ringtoneUriString != RingtoneData.NO_RINGTONE_URI
+            ringtoneUri != null &&
+            ringtoneUri != RingtoneData.NO_RINGTONE_URI
         ) {
             val alarm = (_newAlarm.value as AlarmState.Success).alarm
-            _newAlarm.value = AlarmState.Success(alarm.copy(ringtoneUriString = ringtoneUriString))
+            _newAlarm.value = AlarmState.Success(alarm.copy(ringtoneUri = ringtoneUri))
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -251,7 +251,7 @@ fun AlarmCreateEditScreen(
 
             // Alert Settings
             AlertSettings(
-                navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(alarm.ringtoneUriString) },
+                navigateToRingtonePickerScreen = { navigateToRingtonePickerScreen(alarm.ringtoneUri) },
                 selectedRingtone = alarmRingtoneName,
                 isVibrationEnabled = alarm.isVibrationEnabled,
                 toggleVibration = toggleVibration,

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -64,7 +64,7 @@ fun AlarmEditScreen(
             // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
             // then the new Ringtone's URI will be saved here.
             alarmEditViewModel.updateRingtone(
-                navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+                navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI)
             )
 
             val context = LocalContext.current
@@ -151,7 +151,7 @@ private fun AlarmEditScreenPreview() {
                 name = "Meeting",
                 dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
                 weeklyRepeater = WeeklyRepeater(tueWedThu),
-                ringtoneUriString = sampleRingtoneData.fullUriString,
+                ringtoneUri = sampleRingtoneData.fullUri,
                 isVibrationEnabled = true,
                 snoozeDuration = 10
             ),

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -231,14 +231,14 @@ class AlarmEditViewModel(
         }
     }
 
-    fun updateRingtone(ringtoneUriString: String?) {
+    fun updateRingtone(ringtoneUri: String?) {
         if (
             _modifiedAlarm.value is AlarmState.Success &&
-            ringtoneUriString != null &&
-            ringtoneUriString != RingtoneData.NO_RINGTONE_URI
+            ringtoneUri != null &&
+            ringtoneUri != RingtoneData.NO_RINGTONE_URI
         ) {
             val alarm = (_modifiedAlarm.value as AlarmState.Success).alarm
-            _modifiedAlarm.value = AlarmState.Success(alarm.copy(ringtoneUriString = ringtoneUriString))
+            _modifiedAlarm.value = AlarmState.Success(alarm.copy(ringtoneUri = ringtoneUri))
         }
     }
 

--- a/app/src/main/java/com/example/alarmscratch/core/data/model/RingtoneData.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/data/model/RingtoneData.kt
@@ -7,10 +7,10 @@ class RingtoneData(
     baseUri: String
 ) {
 
-    val fullUriString = "$baseUri/$id"
+    val fullUri = "$baseUri/$id"
 
     companion object {
-        const val KEY_FULL_RINGTONE_URI_STRING = "key_full_ringtone_uri_string"
+        const val KEY_FULL_RINGTONE_URI = "key_full_ringtone_uri"
         const val NO_RINGTONE_URI = ""
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/data/model/RingtoneData.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/data/model/RingtoneData.kt
@@ -1,6 +1,5 @@
 package com.example.alarmscratch.core.data.model
 
-// TODO: Make actual Uri
 class RingtoneData(
     id: Int,
     val name: String,

--- a/app/src/main/java/com/example/alarmscratch/core/data/repository/RingtoneRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/data/repository/RingtoneRepository.kt
@@ -15,9 +15,9 @@ class RingtoneRepository(private val context: Context) {
         private const val SYSTEM_DEFAULT_RINGTONE_TITLE_SUFFIX = ")"
     }
 
-    fun getRingtone(uriString: String): Ringtone {
-        val ringtoneUri = Uri.parse(uriString)
-        var ringtone = RingtoneManager.getRingtone(context.applicationContext, ringtoneUri)
+    fun getRingtone(ringtoneUri: String): Ringtone {
+        val uri = Uri.parse(ringtoneUri)
+        var ringtone = RingtoneManager.getRingtone(context.applicationContext, uri)
 
         if (ringtone == null) {
             // TODO: This can return null, just check it out
@@ -77,7 +77,7 @@ class RingtoneRepository(private val context: Context) {
                 .removeSuffix(SYSTEM_DEFAULT_RINGTONE_TITLE_SUFFIX)
             val match: RingtoneData? = ringtoneList.firstOrNull { it.name == cleanRingtoneName }
 
-            match?.fullUriString ?: genericSystemDefaultUri.toString()
+            match?.fullUri ?: genericSystemDefaultUri.toString()
         } else {
             genericSystemDefaultUri.toString()
         }

--- a/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/extension/_Alarm.kt
@@ -19,7 +19,7 @@ fun Alarm.toAlarmExecutionData(): AlarmExecutionData =
         name = name,
         executionDateTime = snoozeDateTime ?: dateTime,
         encodedRepeatingDays = weeklyRepeater.toEncodedRepeatingDays(),
-        ringtoneUri = ringtoneUriString,
+        ringtoneUri = ringtoneUri,
         isVibrationEnabled = isVibrationEnabled,
         snoozeDuration = snoozeDuration
     )
@@ -77,7 +77,7 @@ fun Alarm.isDirty(): Boolean {
 }
 
 fun Alarm.getRingtone(context: Context): Ringtone =
-    RingtoneRepository(context).getRingtone(ringtoneUriString)
+    RingtoneRepository(context).getRingtone(ringtoneUri)
 
 /*
  * Formatting

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
@@ -34,8 +34,8 @@ fun AlarmApp() {
         composable<Destination.AlarmCreationScreen> {
             AlarmCreationScreen(
                 navHostController = navHostController,
-                navigateToRingtonePickerScreen = { ringtoneUriString ->
-                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUriString = ringtoneUriString))
+                navigateToRingtonePickerScreen = { ringtoneUri ->
+                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUri = ringtoneUri))
                 },
                 modifier = Modifier.fillMaxSize()
             )
@@ -45,8 +45,8 @@ fun AlarmApp() {
         composable<Destination.AlarmEditScreen> {
             AlarmEditScreen(
                 navHostController = navHostController,
-                navigateToRingtonePickerScreen = { ringtoneUriString ->
-                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUriString = ringtoneUriString))
+                navigateToRingtonePickerScreen = { ringtoneUri ->
+                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUri = ringtoneUri))
                 },
                 modifier = Modifier.fillMaxSize()
             )
@@ -73,7 +73,7 @@ fun AlarmApp() {
             AlarmDefaultsScreen(
                 navHostController = navHostController,
                 navigateToRingtonePickerScreen = { ringtoneUri ->
-                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUriString = ringtoneUri))
+                    navHostController.navigateSingleTop(Destination.RingtonePickerScreen(ringtoneUri = ringtoneUri))
                 },
                 modifier = Modifier.fillMaxSize()
             )

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/Destination.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/Destination.kt
@@ -29,7 +29,7 @@ sealed interface Destination {
     data class AlarmEditScreen(val alarmId: Int) : Destination
 
     @Serializable
-    data class RingtonePickerScreen(val ringtoneUriString: String) : Destination
+    data class RingtonePickerScreen(val ringtoneUri: String) : Destination
 
     @Serializable
     data object GeneralSettingsScreen : Destination

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayer.kt
@@ -13,7 +13,7 @@ class RingtonePlayer {
     private var audioFocusRequest: AudioFocusRequest? = null
     private var ringtone: Ringtone? = null
 
-    fun playRingtone(context: Context, ringtoneUriString: String) {
+    fun playRingtone(context: Context, ringtoneUri: String) {
         // Stop currently playing Ringtone if there is one
         stopRingtone()
 
@@ -30,7 +30,7 @@ class RingtonePlayer {
             .setAudioAttributes(audioAttributes)
             .build()
 
-        ringtone = getRingtone(context, ringtoneUriString)
+        ringtone = getRingtone(context, ringtoneUri)
 
         // Getting around smart cast mutability warnings
         audioManager?.let { manager ->

--- a/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayerManager.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ringtone/RingtonePlayerManager.kt
@@ -6,8 +6,8 @@ object RingtonePlayerManager {
 
     private var ringtonePlayer = RingtonePlayer()
 
-    fun startAlarmSound(context: Context, ringtoneUriString: String) {
-        ringtonePlayer.playRingtone(context.applicationContext, ringtoneUriString)
+    fun startAlarmSound(context: Context, ringtoneUri: String) {
+        ringtonePlayer.playRingtone(context.applicationContext, ringtoneUri)
     }
 
     fun stopAlarmSound() {

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerScreen.kt
@@ -156,18 +156,18 @@ fun RingtonePickerScreenContent(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { selectRingtone(context, ringtoneData.fullUriString) }
-                            .background(color = rowColor(ringtoneData.fullUriString))
+                            .clickable { selectRingtone(context, ringtoneData.fullUri) }
+                            .background(color = rowColor(ringtoneData.fullUri))
                             .padding(start = 32.dp, top = 12.dp, end = 32.dp, bottom = 12.dp)
                     ) {
                         // Ringtone Name
                         Text(text = ringtoneData.name)
 
                         // Ringtone playback and selection indicator Icons
-                        if (isRowSelected(ringtoneData.fullUriString)) {
+                        if (isRowSelected(ringtoneData.fullUri)) {
                             Row {
                                 // Ringtone playback indicator Icon
-                                if (isRowPlaying(ringtoneData.fullUriString)) {
+                                if (isRowPlaying(ringtoneData.fullUri)) {
                                     Icon(
                                         imageVector = Icons.AutoMirrored.Default.VolumeUp,
                                         contentDescription = null,
@@ -209,7 +209,7 @@ private fun RingtonePickerScreenPlayingPreview() {
     AlarmScratchTheme {
         RingtonePickerScreenContent(
             ringtoneDataList = ringtoneDataSampleList,
-            selectedRingtoneUri = sampleRingtoneData.fullUriString,
+            selectedRingtoneUri = sampleRingtoneData.fullUri,
             isRingtonePlaying = true,
             saveRingtone = {},
             selectRingtone = { _, _ -> },
@@ -229,7 +229,7 @@ private fun RingtonePickerScreenNotPlayingPreview() {
     AlarmScratchTheme {
         RingtonePickerScreenContent(
             ringtoneDataList = ringtoneDataSampleList,
-            selectedRingtoneUri = sampleRingtoneData.fullUriString,
+            selectedRingtoneUri = sampleRingtoneData.fullUri,
             isRingtonePlaying = false,
             saveRingtone = {},
             selectRingtone = { _, _ -> },

--- a/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/ringtonepicker/RingtonePickerViewModel.kt
@@ -28,7 +28,7 @@ class RingtonePickerViewModel(
 
     // Ringtone
     val ringtoneDataList = ringtoneRepository.getAllRingtoneData()
-    private val initialRingtoneUri: String = savedStateHandle.toRoute<Destination.RingtonePickerScreen>().ringtoneUriString
+    private val initialRingtoneUri: String = savedStateHandle.toRoute<Destination.RingtonePickerScreen>().ringtoneUri
     private val _selectedRingtoneUri: MutableStateFlow<String> = MutableStateFlow(initialRingtoneUri)
     val selectedRingtoneUri: StateFlow<String> = _selectedRingtoneUri.asStateFlow()
 
@@ -84,26 +84,26 @@ class RingtonePickerViewModel(
     fun saveRingtone(navHostController: NavHostController) {
         // Send Ringtone URI to previous screen
         navHostController.previousBackStackEntry?.savedStateHandle
-            ?.set(RingtoneData.KEY_FULL_RINGTONE_URI_STRING, _selectedRingtoneUri.value)
+            ?.set(RingtoneData.KEY_FULL_RINGTONE_URI, _selectedRingtoneUri.value)
 
         // Navigate back
         navHostController.popBackStack()
     }
 
-    fun selectRingtone(context: Context, ringtoneUriString: String) {
+    fun selectRingtone(context: Context, ringtoneUri: String) {
         // Play or Stop Ringtone
         if (_isRingtonePlaying.value) {
-            if (ringtoneUriString == _selectedRingtoneUri.value) {
+            if (ringtoneUri == _selectedRingtoneUri.value) {
                 stopRingtone()
             } else {
-                playRingtone(context, ringtoneUriString)
+                playRingtone(context, ringtoneUri)
             }
         } else {
-            playRingtone(context, ringtoneUriString)
+            playRingtone(context, ringtoneUri)
         }
 
         // Select Ringtone
-        _selectedRingtoneUri.value = ringtoneUriString
+        _selectedRingtoneUri.value = ringtoneUri
     }
 
     /*

--- a/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -86,7 +86,7 @@ fun AlarmDefaultsScreen(
         // If the User navigated to the RingtonePickerScreen and selected a new Ringtone,
         // then the new Ringtone's URI will be saved here.
         alarmDefaultsViewModel.updateRingtone(
-            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI_STRING)
+            navHostController.getStringFromBackStack(RingtoneData.KEY_FULL_RINGTONE_URI)
         )
 
         val context = LocalContext.current
@@ -345,7 +345,7 @@ private fun AlarmDefaultsScreenPreview() {
             navHostController = rememberNavController(),
             navigateToRingtonePickerScreen = {},
             ringtoneName = sampleRingtoneData.name,
-            ringtoneUri = sampleRingtoneData.fullUriString,
+            ringtoneUri = sampleRingtoneData.fullUri,
             isVibrationEnabled = true,
             snoozeDuration = 10,
             saveAlarmDefaults = {},


### PR DESCRIPTION
### Description
- Rename `alarms` table to `alarm`
- Rename various columns in `alarm` table via the `@ColumnInfo` annotation in `Alarm.kt`
  - Also renamed `Alarm.ringtoneUriString` to `Alarm.ringtoneUri`. This property is still a `String` however.
    - In accordance with this change, also renamed many function parameters and properties around the code from `ringtoneUriString` to `ringtoneUri` or something similar. These parameters and properties are still `Strings` however.
- Remove a TODO in `RingtoneData` about changing the `baseUri` parameter and `fullUri` property from `String` to `Uri`. I have decided to just leave them as `Strings`.