### PR TITLE
Feature | Disable App Cloud Backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 
     <application
         android:name=".core.AlarmApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
### Description
- Disable cloud backup and restore (and sometimes device-to-device backup and restore) by setting `android:allowBackup="false"` in `AndroidManifest.xml`
  - While this will always disable cloud backup and restore, it will only sometimes disable device-to-device (D2D) backup and restore. The difference in functionality is outlined below:
    - Any device running or targeting `API 30` or below: disables both cloud and D2D backup and restore
    - Any device running or targeting `API 31` or above: disables cloud backup and restore, and may or may not disable D2D backup and restore, as some device manufacturers do not disable D2D backup and restore when you set `android:allowBackup="false"`
      - https://developer.android.com/identity/data/autobackup#EnablingAutoBackup
      - https://developer.android.com/about/versions/12/behavior-changes-12#backup-restore