### PR TITLE
Feature | Package In Intent Strings

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmActionReceiver.kt
@@ -10,6 +10,8 @@ import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmButton
 import com.example.alarmscratch.alarm.util.AlarmUtil
+import com.example.alarmscratch.core.constant.actionPackageName
+import com.example.alarmscratch.core.constant.extraPackageName
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.alarmApplication
 import com.example.alarmscratch.core.extension.doAsync
@@ -23,21 +25,21 @@ class AlarmActionReceiver : BroadcastReceiver() {
 
     companion object {
         // Actions
-        const val ACTION_EXECUTE_ALARM = "action_execute_alarm"
-        const val ACTION_SNOOZE_AND_RESCHEDULE_ALARM = "action_snooze_and_reschedule_alarm"
-        const val ACTION_DISMISS_ALARM = "action_dismiss_alarm"
+        const val ACTION_EXECUTE_ALARM = "${actionPackageName}EXECUTE_ALARM"
+        const val ACTION_SNOOZE_AND_RESCHEDULE_ALARM = "${actionPackageName}SNOOZE_AND_RESCHEDULE_ALARM"
+        const val ACTION_DISMISS_ALARM = "${actionPackageName}DISMISS_ALARM"
 
         // Extras
-        const val EXTRA_ALARM_ID = "extra_alarm_id"
-        const val EXTRA_ALARM_NAME = "extra_alarm_name"
-        const val EXTRA_ALARM_EXECUTION_DATE_TIME = "extra_alarm_execution_date_time"
-        const val EXTRA_REPEATING_DAYS = "extra_repeating_days"
-        const val EXTRA_RINGTONE_URI = "extra_ringtone_uri"
-        const val EXTRA_IS_VIBRATION_ENABLED = "extra_is_vibration_enabled"
-        const val EXTRA_ALARM_SNOOZE_DURATION = "extra_alarm_snooze_duration"
-        const val EXTRA_IS_24_HOUR = "extra_is_24_hour"
-        const val EXTRA_ALARM_ACTION_ORIGIN = "extra_alarm_action_origin"
-        const val EXTRA_FULL_SCREEN_ALARM_BUTTON = "extra_full_screen_alarm_button"
+        const val EXTRA_ALARM_ID = "${extraPackageName}ALARM_ID"
+        const val EXTRA_ALARM_NAME = "${extraPackageName}ALARM_NAME"
+        const val EXTRA_ALARM_EXECUTION_DATE_TIME = "${extraPackageName}ALARM_EXECUTION_DATE_TIME"
+        const val EXTRA_REPEATING_DAYS = "${extraPackageName}REPEATING_DAYS"
+        const val EXTRA_RINGTONE_URI = "${extraPackageName}RINGTONE_URI"
+        const val EXTRA_IS_VIBRATION_ENABLED = "${extraPackageName}IS_VIBRATION_ENABLED"
+        const val EXTRA_ALARM_SNOOZE_DURATION = "${extraPackageName}ALARM_SNOOZE_DURATION"
+        const val EXTRA_IS_24_HOUR = "${extraPackageName}IS_24_HOUR"
+        const val EXTRA_ALARM_ACTION_ORIGIN = "${extraPackageName}ALARM_ACTION_ORIGIN"
+        const val EXTRA_FULL_SCREEN_ALARM_BUTTON = "${extraPackageName}FULL_SCREEN_ALARM_BUTTON"
 
         // Other
         const val ALARM_NO_ID = -1
@@ -82,7 +84,7 @@ class AlarmActionReceiver : BroadcastReceiver() {
             // Display Alarm Notification
             intent.extras?.let { extrasBundle ->
                 val displayNotificationIntent = Intent(context.applicationContext, AlarmNotificationService::class.java).apply {
-                    action = AlarmNotificationService.DISPLAY_ALARM_NOTIFICATION
+                    action = AlarmNotificationService.ACTION_DISPLAY_ALARM_NOTIFICATION
                     putExtras(extrasBundle)
                 }
                 context.applicationContext.startService(displayNotificationIntent)
@@ -176,7 +178,7 @@ class AlarmActionReceiver : BroadcastReceiver() {
         // Dismiss Alarm Notification
         val dismissNotificationIntent = Intent(context.applicationContext, AlarmNotificationService::class.java).apply {
             // Action
-            action = AlarmNotificationService.DISMISS_ALARM_NOTIFICATION
+            action = AlarmNotificationService.ACTION_DISMISS_ALARM_NOTIFICATION
             // Extras
             putExtra(EXTRA_ALARM_ACTION_ORIGIN, alarmActionOrigin)
             putExtra(EXTRA_FULL_SCREEN_ALARM_BUTTON, fullScreenAlarmButton)

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmNotificationService.kt
@@ -14,6 +14,7 @@ import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmActivity
 import com.example.alarmscratch.alarm.ui.fullscreenalert.FullScreenAlarmButton
 import com.example.alarmscratch.alarm.ui.notification.AlarmNotification
 import com.example.alarmscratch.alarm.util.AlarmUtil
+import com.example.alarmscratch.core.constant.actionPackageName
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getSerializableExtraSafe
 import com.example.alarmscratch.core.extension.isRepeating
@@ -42,17 +43,17 @@ class AlarmNotificationService : Service() {
 
     companion object {
         // Actions
-        const val DISPLAY_ALARM_NOTIFICATION = "display_alarm_notification"
-        const val DISMISS_ALARM_NOTIFICATION = "dismiss_alarm_notification"
+        const val ACTION_DISPLAY_ALARM_NOTIFICATION = "${actionPackageName}DISPLAY_ALARM_NOTIFICATION"
+        const val ACTION_DISMISS_ALARM_NOTIFICATION = "${actionPackageName}DISMISS_ALARM_NOTIFICATION"
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            DISPLAY_ALARM_NOTIFICATION ->
+            ACTION_DISPLAY_ALARM_NOTIFICATION ->
                 displayAlarmNotification(intent)
-            DISMISS_ALARM_NOTIFICATION ->
+            ACTION_DISMISS_ALARM_NOTIFICATION ->
                 dismissAlarmNotification(intent)
         }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -21,6 +21,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.alarmscratch.R
 import com.example.alarmscratch.alarm.alarmexecution.AlarmActionReceiver
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
+import com.example.alarmscratch.core.constant.actionPackageName
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.getSerializableExtraSafe
 import com.example.alarmscratch.core.navigation.Destination
@@ -76,8 +77,8 @@ class FullScreenAlarmActivity : ComponentActivity() {
 
     companion object {
         // BroadcastReceiver constants
-        const val ACTION_SHOW_POST_ALARM_CONFIRMATION = "action_show_post_alarm_confirmation"
-        const val ACTION_FINISH_FULL_SCREEN_ALARM_FLOW = "action_finish_full_screen_alarm_flow"
+        const val ACTION_SHOW_POST_ALARM_CONFIRMATION = "${actionPackageName}SHOW_POST_ALARM_CONFIRMATION"
+        const val ACTION_FINISH_FULL_SCREEN_ALARM_FLOW = "${actionPackageName}FINISH_FULL_SCREEN_ALARM_FLOW"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/alarmscratch/core/constant/AppConstant.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/constant/AppConstant.kt
@@ -1,0 +1,20 @@
+package com.example.alarmscratch.core.constant
+
+/**
+ * Package name for the app
+ */
+const val appPackageName = "com.example.alarmscratch"
+
+/**
+ * Package name for the app with ".action." appended
+ *
+ * @see appPackageName
+ */
+const val actionPackageName = "$appPackageName.action."
+
+/**
+ * Package name for the app with ".extra." appended
+ *
+ * @see appPackageName
+ */
+const val extraPackageName = "$appPackageName.extra."


### PR DESCRIPTION
### Description
- Prefix all action and extra constants which are passed to `Intents` with the app's package name
  - Furthermore, actions and extras are prepended with `<package name>.action.` and `<package name>.extra.`, respectively
    - Ex: `ACTION_EXECUTE_ALARM` evaluates to `com.example.alarmscratch.action.EXECUTE_ALARM`, while `EXTRA_ALARM_ID` evaluates to `com.example.alarmscratch.extra.ALARM_ID`
- Create `AppConstant.kt` with constants `appPackageName`, `actionPackageName`, and `extraPackageName` for use in prepending action and extra `Intent` constants