### PR TITLE
Feature | Alarm Default DataStore Name

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
@@ -40,7 +40,7 @@ class AlarmDefaultsRepository(
 
     companion object {
         // Preferences name
-        const val ALARM_DEFAULTS_PREFERENCES_NAME = "alarm_defaults_preferences_name"
+        const val ALARM_DEFAULTS_PREFERENCES_NAME = "alarm_defaults"
 
         // Keys
         private val KEY_RINGTONE_URI = stringPreferencesKey("ringtone_uri")

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/AlarmDefaultsRepository.kt
@@ -78,7 +78,6 @@ class AlarmDefaultsRepository(
     val alarmDefaultsFlow: Flow<AlarmDefaults> = dataStore.data
         .catch { emit(emptyPreferences()) }
         .map { preferences ->
-            // TODO: Exception handling
             // Get Preferences
             val ringtoneUri = preferences[KEY_RINGTONE_URI] ?: SYSTEM_DEFAULT_RINGTONE_URI
             val isVibrationEnabled = preferences[KEY_IS_VIBRATION_ENABLED] ?: DEFAULT_IS_VIBRATION_ENABLED
@@ -93,7 +92,6 @@ class AlarmDefaultsRepository(
      */
 
     suspend fun updateAlarmDefaults(alarmDefaults: AlarmDefaults) {
-        // TODO: Exception handling
         dataStore.edit { preferences ->
             preferences[KEY_RINGTONE_URI] = alarmDefaults.ringtoneUri
             preferences[KEY_IS_VIBRATION_ENABLED] = alarmDefaults.isVibrationEnabled

--- a/app/src/main/java/com/example/alarmscratch/settings/data/repository/GeneralSettingsRepository.kt
+++ b/app/src/main/java/com/example/alarmscratch/settings/data/repository/GeneralSettingsRepository.kt
@@ -35,7 +35,6 @@ class GeneralSettingsRepository(private val dataStore: DataStore<Preferences>) {
     val generalSettingsFlow: Flow<GeneralSettings> = dataStore.data
         .catch { emit(emptyPreferences()) }
         .map { preferences ->
-            // TODO: Exception handling
             // Get Preferences
             val timeDisplay = TimeDisplay.fromString(preferences[KEY_TIME_DISPLAY]) ?: DEFAULT_TIME_DISPLAY
 
@@ -44,7 +43,6 @@ class GeneralSettingsRepository(private val dataStore: DataStore<Preferences>) {
         }
 
     suspend fun updateGeneralSettings(generalSettings: GeneralSettings) {
-        // TODO: Exception handling
         dataStore.edit { preferences ->
             preferences[KEY_TIME_DISPLAY] = generalSettings.timeDisplay.value
         }


### PR DESCRIPTION
### Description
- Change name of Alarm Defaults `DataStore` from `alarm_defaults_preferences_name` to `alarm_defaults`
- Remove unnecessary TODOs in `AlarmDefaultsRepository` and `GeneralSettingsRepository`