### PR TITLE
Feature | Lock App to Portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,7 @@
             android:name=".alarm.ui.fullscreenalert.FullScreenAlarmActivity"
             android:directBootAware="true"
             android:excludeFromRecents="true"
+            android:exported="false"
             android:screenOrientation="portrait"
             android:showOnLockScreen="true"
             android:showWhenLocked="true"
@@ -69,7 +70,9 @@
             ************************
         -->
         <!-- Receive Alarm Actions -->
-        <receiver android:name=".alarm.alarmexecution.AlarmActionReceiver" />
+        <receiver
+            android:name=".alarm.alarmexecution.AlarmActionReceiver"
+            android:exported="false" />
         <!-- Reschedule Alarms on Device boot -->
         <receiver
             android:name=".alarm.alarmexecution.BootCompletedReceiver"
@@ -105,6 +108,7 @@
         -->
         <service
             android:name=".alarm.alarmexecution.AlarmNotificationService"
+            android:exported="false"
             android:foregroundServiceType="systemExempted" />
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
             android:name=".core.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.AlarmScratch.SplashScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -57,6 +58,7 @@
             android:name=".alarm.ui.fullscreenalert.FullScreenAlarmActivity"
             android:directBootAware="true"
             android:excludeFromRecents="true"
+            android:screenOrientation="portrait"
             android:showOnLockScreen="true"
             android:showWhenLocked="true"
             android:taskAffinity="" />


### PR DESCRIPTION
### Description
- Temporarily lock all `Activities` in app to portrait orientation until landscape-specific screens are created
- Set `android:exoprted="false"` explicitly on all components inside `AndroidManifest.xml` that were not previously set. Now all components besides `MainActivity` have `android:exoprted="false"`.
  - Note: There are 2 `BroadcastReceivers` that are not registered in the `Manifest`. They live inside `FullScreenAlarmActivity` and `NextAlarmViewModel`. Currently, they are registered at runtime with `ContextCompat.RECEIVER_NOT_EXPORTED`, which is equivalent to `android:exoprted="false"`.