### PR TITLE
Feature | Screen Transition Time

### DIFF
--- a/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/AlarmApp.kt
@@ -1,5 +1,8 @@
 package com.example.alarmscratch.core.navigation
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,7 +22,13 @@ fun AlarmApp() {
     val navHostController = rememberNavController()
     NavHost(
         navController = navHostController,
-        startDestination = Destination.CoreScreen
+        startDestination = Destination.CoreScreen,
+        enterTransition = {
+            fadeIn(animationSpec = tween(durationMillis = 400))
+        },
+        exitTransition = {
+            fadeOut(animationSpec = tween(durationMillis = 400))
+        }
     ) {
         // Core Screen
         composable<Destination.CoreScreen> {

--- a/app/src/main/java/com/example/alarmscratch/core/navigation/CoreNavHost.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/navigation/CoreNavHost.kt
@@ -1,5 +1,8 @@
 package com.example.alarmscratch.core.navigation
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -18,6 +21,12 @@ fun CoreNavHost(
     NavHost(
         navController = coreNavHostController,
         startDestination = Destination.AlarmListScreen,
+        enterTransition = {
+            fadeIn(animationSpec = tween(durationMillis = 400))
+        },
+        exitTransition = {
+            fadeOut(animationSpec = tween(durationMillis = 400))
+        },
         modifier = modifier
     ) {
         // Alarm List Screen

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloud.kt
@@ -140,8 +140,8 @@ fun NextAlarmCloudContent(
         if (alarmCountdownState is AlarmCountdownState.Success) {
             AnimatedVisibility(
                 visibleState = visibleState,
-                enter = fadeIn(animationSpec = tween(durationMillis = 700)),
-                exit = fadeOut(animationSpec = tween(durationMillis = 700))
+                enter = fadeIn(animationSpec = tween(durationMillis = 400)),
+                exit = fadeOut(animationSpec = tween(durationMillis = 400))
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!-- General App Theme -->
-    <style name="Theme.AlarmScratch" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.AlarmScratch" parent="android:Theme.Material.NoActionBar" />
 
     <!-- Splash Screen Theme -->
     <style name="Theme.AlarmScratch.SplashScreen" parent="Theme.SplashScreen">


### PR DESCRIPTION
### Description
- Modify screen transition related animation times from `700ms` to `400ms` to provide a snappier feel to the app
  - This applies to `AlarmApp`, `CoreNavHost`, and `NextAlarmCloud`
  - `LavaFloatingActionButton` and `FullScreenAlarmNavHost` animation times remain unchanged
- Change main app theme to inherit from `android:Theme.Material.NoActionBar` instead of `android:Theme.Material.Light.NoActionBar`
  - This theme dictates the color of the background before composables are displayed. The Light variant was causing there to be a white flash during navigation between screens, which can be jarring. Switching to the dark version changes the default background to a darker color which is not jarring during navigation. Furthermore, my app's screens fit better with dark mode anyways.