### PR TITLE
Feature | Test AlarmListScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,8 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Required to clear permissions between instrumented tests
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -44,6 +46,9 @@ android {
     }
     room {
         schemaDirectory("$projectDir/schemas")
+    }
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
     packaging {
         resources {
@@ -105,7 +110,9 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.androidx.test.uiautomator)
     androidTestImplementation(libs.mockk.android)
+    androidTestUtil(libs.androidx.test.orchestrator)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreenTest.kt
+++ b/app/src/androidTest/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreenTest.kt
@@ -1,0 +1,141 @@
+package com.example.alarmscratch.alarm.ui.alarmlist
+
+import android.Manifest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.alarmscratch.R
+import com.example.alarmscratch.alarm.data.model.Alarm
+import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
+import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import com.example.alarmscratch.core.ui.notificationcheck.AppNotificationChannel
+import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.testutil.NotificationChannelUtil
+import com.example.alarmscratch.testutil.PermissionUtil
+import io.mockk.every
+import io.mockk.mockkConstructor
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+
+class AlarmListScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // Alarm
+    private val tueWedThu: Int = 28
+    private val baseAlarmNonRepeating = Alarm(
+        id = 1,
+        name = "Non-Repeating Alarm",
+        enabled = true,
+        dateTime = LocalDateTimeUtil.nowTruncated().plusHours(1),
+        weeklyRepeater = WeeklyRepeater(),
+        ringtoneUri = "ringtoneUri",
+        isVibrationEnabled = false,
+        snoozeDateTime = null,
+        snoozeDuration = 10
+    )
+    private val baseAlarmRepeating = baseAlarmNonRepeating.copy(
+        id = 2,
+        name = "Repeating Alarm",
+        dateTime = baseAlarmNonRepeating.dateTime.plusHours(1),
+        weeklyRepeater = WeeklyRepeater(tueWedThu)
+    )
+    private val alarmList = listOf(baseAlarmNonRepeating, baseAlarmRepeating)
+
+    /*
+     * AlarmListScreen - Alarm List
+     */
+
+    @Test
+    fun alarmListScreen_DisplaysNoAlarmsCard_WhenNoAlarms_AndPermissionsAlreadyGranted() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val noAlarmsCardString = instrumentation.targetContext.getString(R.string.no_alarms)
+
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
+        mockkConstructor(AlarmRepository::class) {
+            every { anyConstructed<AlarmRepository>().getAllAlarmsFlow() } returns flowOf(emptyList())
+            composeTestRule.setContent {
+                AlarmScratchTheme {
+                    AlarmListScreen(navigateToAlarmEditScreen = {})
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText(noAlarmsCardString).assertIsDisplayed()
+    }
+
+    @Test
+    fun alarmListScreen_DisplaysAlarmCards_WhenThereAreAlarms_AndPermissionsAlreadyGranted() {
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
+        mockkConstructor(AlarmRepository::class) {
+            every { anyConstructed<AlarmRepository>().getAllAlarmsFlow() } returns flowOf(alarmList)
+            composeTestRule.setContent {
+                AlarmScratchTheme {
+                    AlarmListScreen(navigateToAlarmEditScreen = {})
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText(baseAlarmNonRepeating.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(baseAlarmRepeating.name).assertIsDisplayed()
+    }
+
+    @Test
+    fun alarmListScreen_DisplaysAlarmCards_WhenThereAreAlarms_AfterGrantingPermissionViaSystemDialog() {
+        mockkConstructor(AlarmRepository::class) {
+            every { anyConstructed<AlarmRepository>().getAllAlarmsFlow() } returns flowOf(alarmList)
+            composeTestRule.setContent {
+                AlarmScratchTheme {
+                    AlarmListScreen(navigateToAlarmEditScreen = {})
+                }
+            }
+            PermissionUtil.grantPermissionDialog()
+        }
+
+        composeTestRule.onNodeWithText(baseAlarmNonRepeating.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(baseAlarmRepeating.name).assertIsDisplayed()
+    }
+
+    /*
+     * AlarmListScreen - Permission Gate
+     */
+
+    @Test
+    fun alarmListScreen_ShowsPermissionGateScreen_WhenNotificationPermissionDenied() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val permissionGateString = context.getString(R.string.permission_required)
+
+        composeTestRule.setContent {
+            AlarmScratchTheme {
+                AlarmListScreen(navigateToAlarmEditScreen = {})
+            }
+        }
+        PermissionUtil.denyPermissionDialog()
+
+        composeTestRule.onNodeWithText(permissionGateString).assertIsDisplayed()
+    }
+
+    /*
+     * AlarmListScreen - NotificationChannel Gate
+     */
+
+    @Test
+    fun alarmListScreen_ShowsNotificationChannelGateScreen_WhenAlarmNotificationChannelIsDisabled() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val notificationGateString = context.getString(R.string.notification_required)
+
+        NotificationChannelUtil.disableNotificationChannel(context, AppNotificationChannel.Alarm)
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
+        composeTestRule.setContent {
+            AlarmScratchTheme {
+                AlarmListScreen(navigateToAlarmEditScreen = {})
+            }
+        }
+
+        composeTestRule.onNodeWithText(notificationGateString).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/example/alarmscratch/testutil/NotificationChannelUtil.kt
+++ b/app/src/androidTest/java/com/example/alarmscratch/testutil/NotificationChannelUtil.kt
@@ -1,0 +1,27 @@
+package com.example.alarmscratch.testutil
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import com.example.alarmscratch.core.ui.notificationcheck.AppNotificationChannel
+
+object NotificationChannelUtil {
+
+    fun disableNotificationChannel(context: Context, appNotificationChannel: AppNotificationChannel) {
+        // Keep original channel configuration, except decrease importance level to IMPORTANCE_NONE.
+        // NotificationChannels with IMPORTANCE_NONE are considered disabled.
+        val channel = NotificationChannel(
+            appNotificationChannel.id,
+            context.getString(appNotificationChannel.name),
+            NotificationManager.IMPORTANCE_NONE
+        )
+        channel.description = context.getString(appNotificationChannel.description)
+        appNotificationChannel.soundAttributes?.let {
+            channel.setSound(it.sound, it.audioAttributes)
+        }
+
+        // Update channel
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/androidTest/java/com/example/alarmscratch/testutil/PermissionUtil.kt
+++ b/app/src/androidTest/java/com/example/alarmscratch/testutil/PermissionUtil.kt
@@ -1,0 +1,51 @@
+package com.example.alarmscratch.testutil
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+
+object PermissionUtil {
+
+    private const val SYSTEM_DIALOG_ALLOW = "Allow"
+    // Text uses smart apostrophe
+    private const val SYSTEM_DIALOG_DENY = "Don\u2019t allow"
+
+    /*
+     * With System Permission Dialog
+     */
+
+    /**
+     * Grants whatever permission is currently being requested via the System Permission Dialog
+     */
+    fun grantPermissionDialog() {
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .findObject(By.text(SYSTEM_DIALOG_ALLOW))
+            .click()
+    }
+
+    /**
+     * Denies whatever permission is currently being requested via the System Permission Dialog
+     */
+    fun denyPermissionDialog() {
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .findObject(By.text(SYSTEM_DIALOG_DENY))
+            .click()
+    }
+
+    /*
+     * Without System Permission Dialog
+     */
+
+    /**
+     * Grants a specific permission without having to go through the System Permission Dialog
+     *
+     * @param permission permission string
+     */
+    fun grantPermissionAuto(permission: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.uiAutomation.grantRuntimePermission(
+            instrumentation.targetContext.packageName,
+            permission
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ junit = "4.13.2"
 kotlinxCoroutinesTest = "1.9.0"
 mockk = "1.13.17"
 # Instrumented Tests
+orchestrator = "1.5.1"
+uiAutomator = "2.3.0"
 mockkAndroid = "1.13.17"
 
 [libraries]
@@ -53,6 +55,8 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 # Instrumented Tests
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "orchestrator" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiAutomator" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockkAndroid" }
 
 [plugins]


### PR DESCRIPTION
### Description
- Write instrumented tests for `AlarmListScreen`
- Create `NotificationChannelUtil` and `PermissionUtil` in `androidTest` directory
- Add dependencies for `Android Test Orchestrator` and `UI Automator`
  - Setting `testInstrumentationRunnerArguments["clearPackageData"] = "true"` in `app/build.gradle.kts` was required in order to reset runtime permissions between instrumented tests. Without this, permission settings would persist between tests in `AlarmListScreenTest`, causing some tests to fail. Not using `Android Test Orchestrator` and manually revoking permissions between tests was not an option as it would cause the test process to terminate, preventing subsequent tests from executing when running all tests at once.