### PR TITLE
Feature | Lower API Level Fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.alarmscratch"
-        minSdk = 27
+        minSdk = 31
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/androidTest/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloudTest.kt
+++ b/app/src/androidTest/java/com/example/alarmscratch/core/ui/core/component/NextAlarmCloudTest.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.core.ui.core.component
 
+import android.Manifest
 import android.content.BroadcastReceiver
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.material.icons.Icons
@@ -13,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.navigation.Destination
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.testutil.PermissionUtil
 import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
@@ -27,10 +29,11 @@ class NextAlarmCloudTest {
      */
 
     @Test
-    fun nextAlarmCloudContent_DisplaysAlarmCountdownText_WhenOnAlarmListScreen_AndHasActiveAlarm() {
+    fun nextAlarmCloudContent_DisplaysAlarmCountdownText_WhenOnAlarmListScreen_AndHasActiveAlarm_AndPermissionsAlreadyGranted() {
         val countdownText = "countdownText"
         val alarmCountdownState = AlarmCountdownState.Success(Icons.Default.Alarm, countdownText)
 
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
         composeTestRule.setContent {
             AlarmScratchTheme {
                 NextAlarmCloudContent(
@@ -46,11 +49,12 @@ class NextAlarmCloudTest {
     }
 
     @Test
-    fun nextAlarmCloudContent_DisplaysNoActiveAlarmsText_WhenOnAlarmListScreen_AndHasNoActiveAlarms() {
+    fun nextAlarmCloudContent_DisplaysNoActiveAlarmsText_WhenOnAlarmListScreen_AndHasNoActiveAlarms_AndPermissionsAlreadyGranted() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val countdownText = context.getString(R.string.no_active_alarms)
         val alarmCountdownState = AlarmCountdownState.Success(Icons.Default.AlarmOff, countdownText)
 
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
         composeTestRule.setContent {
             AlarmScratchTheme {
                 NextAlarmCloudContent(
@@ -66,10 +70,30 @@ class NextAlarmCloudTest {
     }
 
     @Test
-    fun nextAlarmCloudContent_DisplaysNothing_WhenNotOnAlarmListScreen() {
+    fun nextAlarmCloudContent_DisplaysNothing_WhenOnAlarmListScreen_AndHasActiveAlarm_WhenNotificationPermissionDenied() {
         val countdownText = "countdownText"
         val alarmCountdownState = AlarmCountdownState.Success(Icons.Default.Alarm, countdownText)
 
+        composeTestRule.setContent {
+            AlarmScratchTheme {
+                NextAlarmCloudContent(
+                    currentCoreDestination = Destination.AlarmListScreen,
+                    alarmCountdownState = alarmCountdownState,
+                    visibleState = MutableTransitionState(initialState = true),
+                    timeChangeReceiver = mockk<BroadcastReceiver>(relaxed = true)
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(countdownText).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun nextAlarmCloudContent_DisplaysNothing_WhenNotOnAlarmListScreen_AndPermissionsAlreadyGranted() {
+        val countdownText = "countdownText"
+        val alarmCountdownState = AlarmCountdownState.Success(Icons.Default.Alarm, countdownText)
+
+        PermissionUtil.grantPermissionAuto(Manifest.permission.POST_NOTIFICATIONS)
         composeTestRule.setContent {
             AlarmScratchTheme {
                 NextAlarmCloudContent(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,6 +94,14 @@
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
             </intent-filter>
         </receiver>
+        <!-- SCHEDULE_EXACT_ALARM Permission Granted -->
+        <receiver
+            android:name=".alarm.alarmexecution.ScheduleExactAlarmPermissionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
+            </intent-filter>
+        </receiver>
 
         <!--
             **************

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Required for setting exact Alarms -->
+    <uses-permission
+        android:name="android.permission.SCHEDULE_EXACT_ALARM"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
@@ -32,8 +35,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AlarmScratch"
-        tools:targetApi="31">
+        android:theme="@style/Theme.AlarmScratch">
 
         <!--
             ****************

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/AlarmScheduler.kt
@@ -5,14 +5,23 @@ import android.app.AlarmManager.AlarmClockInfo
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.AlarmExecutionData
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.alarm.util.AlarmUtil
 import com.example.alarmscratch.core.MainActivity
+import com.example.alarmscratch.core.extension.LocalDateTimeUtil
+import com.example.alarmscratch.core.extension.isDirty
+import com.example.alarmscratch.core.extension.isRepeating
+import com.example.alarmscratch.core.extension.isSnoozed
 import com.example.alarmscratch.core.extension.toAlarmExecutionData
 import com.example.alarmscratch.core.extension.zonedEpochMillis
 
 object AlarmScheduler {
+
+    /*
+     * Scheduling
+     */
 
     fun scheduleAlarm(context: Context, alarmExecutionData: AlarmExecutionData) {
         // Create AlarmClockInfo that launches the application
@@ -62,12 +71,66 @@ object AlarmScheduler {
         )
     }
 
+    /*
+     * Rescheduling
+     */
+
+    suspend fun snoozeAndRescheduleAlarm(context: Context, alarmRepository: AlarmRepository, alarm: Alarm) {
+        // Update Alarm in database
+        val snoozeDateTime = LocalDateTimeUtil.nowTruncated().plusMinutes(alarm.snoozeDuration.toLong())
+        alarmRepository.updateSnooze(alarm.id, snoozeDateTime)
+        // Reschedule Alarm
+        scheduleAlarm(
+            context,
+            alarm.toAlarmExecutionData().copy(executionDateTime = snoozeDateTime)
+        )
+    }
+
+    suspend fun disableOrRescheduleAlarm(context: Context, alarmRepository: AlarmRepository, alarm: Alarm) {
+        // Dismiss/reschedule Alarm
+        if (alarm.isRepeating()) {
+            // Calculate the next time the repeating Alarm should execute
+            val nextDateTime = AlarmUtil.nextRepeatingDateTime(
+                alarm.dateTime,
+                alarm.weeklyRepeater
+            )
+            // Dismiss Alarm and update with nextDateTime
+            alarmRepository.dismissAndRescheduleRepeating(alarm.id, nextDateTime)
+            // Reschedule Alarm with nextDateTime
+            scheduleAlarm(
+                context,
+                alarm.toAlarmExecutionData().copy(executionDateTime = nextDateTime)
+            )
+        } else {
+            // Dismiss non-repeating Alarm
+            alarmRepository.dismissAlarm(alarm.id)
+        }
+    }
+
+    /**
+     * Cleans all dirty Alarms in the database, then reschedules any Alarms
+     * that are still enabled in the database after cleaning.
+     *
+     * @param context Context to be used for scheduling Alarms
+     * @param alarmRepository repository for getting all Alarms
+     *
+     * @see cleanAlarm
+     */
+    suspend fun cleanAndRescheduleAlarms(context: Context, alarmRepository: AlarmRepository) {
+        // Clean Alarms
+        alarmRepository.getAllAlarms().forEach { cleanAlarm(it, alarmRepository) }
+
+        // Reschedule Alarms
+        // Re-query the database to get up to date Alarm data after cleaning the Alarms
+        rescheduleEligibleAlarms(context, alarmRepository.getAllAlarms())
+    }
+
     suspend fun refreshAlarms(context: Context, alarmRepository: AlarmRepository) {
         // Get all enabled Alarms
         val enabledAlarms = alarmRepository.getAllEnabledAlarms()
 
         // Clean Alarms
-        enabledAlarms.forEach { AlarmUtil.cleanAlarm(it, alarmRepository) }
+        enabledAlarms.forEach { cleanAlarm(it, alarmRepository) }
 
         // Get all enabled Alarms post cleaning, as AlarmExecutionData
         val cleanAlarmExecutionData = alarmRepository.getAllEnabledAlarms().map { it.toAlarmExecutionData() }
@@ -97,6 +160,66 @@ object AlarmScheduler {
                 alarmPendingIntent
             )
         }
+    }
+
+    /*
+     * Utility
+     */
+
+    /**
+     * Cleans dirty Alarms as determined by Alarm.isDirty().
+     * Alarms that are already clean are a no-op.
+     *
+     * This function only modifies Alarms in the database, and does not
+     * do anything with scheduling or cancelling Alarms with AlarmManager.
+     *
+     * To clean an Alarm is to:
+     * - Reset snooze
+     * - If Alarm is repeating -> set to next repeating date/time
+     * - If Alarm is not repeating -> disable Alarm
+     *
+     * @param alarm Alarm candidate for cleaning
+     * @param alarmRepository repository in which cleaned Alarms are updated
+     */
+    private suspend fun cleanAlarm(alarm: Alarm, alarmRepository: AlarmRepository) {
+        if (alarm.isDirty()) {
+            // Clean Alarm
+            val cleanAlarm = alarm.run {
+                if (isRepeating()) {
+                    copy(
+                        dateTime = AlarmUtil.nextRepeatingDateTime(alarm.dateTime, alarm.weeklyRepeater),
+                        snoozeDateTime = null
+                    )
+                } else {
+                    copy(enabled = false, snoozeDateTime = null)
+                }
+            }
+
+            // Update database
+            alarmRepository.updateAlarm(cleanAlarm)
+        }
+    }
+
+    /**
+     * Reschedule Alarms if they meet the following criteria:
+     * 1) Are enabled
+     * 2) Are configured to execute in the future
+     *
+     * @param context Context to be used for scheduling Alarms
+     * @param alarmList List of Alarms to potentially reschedule
+     */
+    private fun rescheduleEligibleAlarms(context: Context, alarmList: List<Alarm>) {
+        val now = LocalDateTimeUtil.nowTruncated()
+        alarmList
+            .filter { alarm ->
+                alarm.enabled &&
+                        if (alarm.isSnoozed()) {
+                            alarm.snoozeDateTime?.isAfter(now) == true
+                        } else {
+                            alarm.dateTime.isAfter(now)
+                        }
+            }
+            .forEach { scheduleAlarm(context, it.toAlarmExecutionData()) }
     }
 
     private fun getAlarmManager(context: Context): AlarmManager =

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/BootCompletedReceiver.kt
@@ -1,19 +1,14 @@
 package com.example.alarmscratch.alarm.alarmexecution
 
+import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.example.alarmscratch.alarm.data.model.Alarm
+import android.os.Build
 import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
 import com.example.alarmscratch.alarm.data.repository.AlarmRepository
-import com.example.alarmscratch.alarm.util.AlarmUtil
-import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.alarmApplication
 import com.example.alarmscratch.core.extension.doAsync
-import com.example.alarmscratch.core.extension.isDirty
-import com.example.alarmscratch.core.extension.isRepeating
-import com.example.alarmscratch.core.extension.isSnoozed
-import com.example.alarmscratch.core.extension.toAlarmExecutionData
 import kotlinx.coroutines.Dispatchers
 
 class BootCompletedReceiver : BroadcastReceiver() {
@@ -22,82 +17,41 @@ class BootCompletedReceiver : BroadcastReceiver() {
         if (context != null && intent != null) {
             when (intent.action) {
                 Intent.ACTION_LOCKED_BOOT_COMPLETED ->
-                    cleanAndRescheduleAlarms(context)
+                    cleanAndRescheduleAlarmsIfPossible(context)
             }
-        }
-    }
-
-    private fun cleanAndRescheduleAlarms(context: Context) {
-        val alarmRepository = AlarmRepository(
-            AlarmDatabase
-                .getDatabase(context.createDeviceProtectedStorageContext())
-                .alarmDao()
-        )
-
-        doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
-            // Clean Alarms
-            cleanAllAlarms(alarmRepository)
-
-            // Reschedule Alarms
-            // Re-query the database to get up to date Alarm data after cleaning the Alarms
-            rescheduleEligibleAlarms(context, alarmRepository.getAllAlarms())
-        }
-    }
-
-    private suspend fun cleanAllAlarms(alarmRepository: AlarmRepository) {
-        alarmRepository.getAllAlarms().forEach { cleanAlarm(it, alarmRepository) }
-    }
-
-    /**
-     * Cleans dirty Alarms as determined by Alarm.isDirty().
-     * Alarms that are already clean are a no-op.
-     *
-     * To clean an Alarm is to:
-     * - Reset snooze
-     * - If Alarm is repeating -> set to next repeating date/time
-     * - If Alarm is not repeating -> disable Alarm
-     *
-     * @param alarm Alarm candidate for cleaning
-     * @param alarmRepository repository in which cleaned Alarms are updated
-     */
-    private suspend fun cleanAlarm(alarm: Alarm, alarmRepository: AlarmRepository) {
-        if (alarm.isDirty()) {
-            // Clean Alarm
-            val cleanAlarm = alarm.run {
-                if (isRepeating()) {
-                    copy(
-                        dateTime = AlarmUtil.nextRepeatingDateTime(alarm.dateTime, alarm.weeklyRepeater),
-                        snoozeDateTime = null
-                    )
-                } else {
-                    copy(enabled = false, snoozeDateTime = null)
-                }
-            }
-
-            // Update database
-            alarmRepository.updateAlarm(cleanAlarm)
         }
     }
 
     /**
-     * Reschedule Alarms if they meet the following criteria:
-     * 1) Are enabled
-     * 2) Are configured to execute in the future
+     * Clean and reschedule Alarms as long as one of the two following conditions are met:
+     *   1) The Device is running an API >= 33
+     *   2) The Device is running an API < 33, and has the SCHEDULE_EXACT_ALARM permission granted
      *
-     * @param context Context to be used for scheduling Alarms
-     * @param alarmList List of Alarms to potentially reschedule
+     * If neither of the above two conditions are met, then this method is a no-op.
+     *
+     * @param context Context used to perform various functions related to the System
      */
-    private fun rescheduleEligibleAlarms(context: Context, alarmList: List<Alarm>) {
-        val now = LocalDateTimeUtil.nowTruncated()
-        alarmList
-            .filter { alarm ->
-                alarm.enabled &&
-                        if (alarm.isSnoozed()) {
-                            alarm.snoozeDateTime?.isAfter(now) == true
-                        } else {
-                            alarm.dateTime.isAfter(now)
-                        }
+    private fun cleanAndRescheduleAlarmsIfPossible(context: Context) {
+        val canRescheduleAlarms =
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                val alarmManager = context.getSystemService(AlarmManager::class.java)
+                alarmManager.canScheduleExactAlarms()
+            } else {
+                // This app declares the USE_EXACT_ALARM permission on APIs 33+, which is auto-granted
+                // and cannot be revoked. Therefore, we can always schedule Alarms on APIs 33+.
+                true
             }
-            .forEach { AlarmScheduler.scheduleAlarm(context, it.toAlarmExecutionData()) }
+
+        if (canRescheduleAlarms) {
+            val alarmRepository = AlarmRepository(
+                AlarmDatabase
+                    .getDatabase(context.createDeviceProtectedStorageContext())
+                    .alarmDao()
+            )
+
+            doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
+                AlarmScheduler.cleanAndRescheduleAlarms(context, alarmRepository)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
@@ -30,17 +30,18 @@ class ScheduleExactAlarmPermissionReceiver : BroadcastReceiver() {
                 // In spite of what the name may suggest, this action is only sent
                 // by the system when the permission changes from denied to granted
                 AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED ->
-                    cleanAndRescheduleAlarms(context)
+                    cleanAndRescheduleAlarmsIfPossible(context)
             }
         }
     }
 
     /**
-     * Clean and reschedule Alarms as long as the Device has the SCHEDULE_EXACT_ALARM permission granted
+     * Clean and reschedule Alarms as long as the Device has the SCHEDULE_EXACT_ALARM permission granted.
+     * If the Device does not have the SCHEDULE_EXACT_ALARM permission granted, then this method is a no-op.
      *
      * @param context Context used to perform various functions related to the System
      */
-    private fun cleanAndRescheduleAlarms(context: Context) {
+    private fun cleanAndRescheduleAlarmsIfPossible(context: Context) {
         val alarmManager = context.getSystemService(AlarmManager::class.java)
         if (alarmManager.canScheduleExactAlarms()) {
             val alarmRepository = AlarmRepository(

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
@@ -1,0 +1,57 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import android.app.AlarmManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.example.alarmscratch.alarm.data.repository.AlarmDatabase
+import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.core.extension.alarmApplication
+import com.example.alarmscratch.core.extension.doAsync
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Reschedule Alarms, if possible, when the SCHEDULE_EXACT_ALARM permission changes from Denied to Granted.
+ * This BroadcastReceiver is only relevant on, and will only be called on APIs < 33. This is because:
+ *   1) Devices running APIs < 33 will request SCHEDULE_EXACT_ALARM, while Devices running APIs >= 33 will be
+ *   auto-granted USE_EXACT_ALARM instead. USE_EXACT_ALARM, which didn't exist before API 33, cannot be revoked
+ *   and replaces the need for SCHEDULE_EXACT_ALARM.
+ *   2) This BroadcastReceiver only listens for AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED
+ *   which is only relevant on devices requiring SCHEDULE_EXACT_ALARM for scheduling exact Alarms
+ *
+ * Because of this, it is not necessary to check the API level in any of the functions in this class since we know
+ * that this BroadcastReceiver will never be invoked on APIs >= 33.
+ */
+class ScheduleExactAlarmPermissionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context != null && intent != null) {
+            when(intent.action) {
+                // In spite of what the name may suggest, this action is only sent
+                // by the system when the permission changes from denied to granted
+                AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED ->
+                    cleanAndRescheduleAlarms(context)
+            }
+        }
+    }
+
+    /**
+     * Clean and reschedule Alarms as long as the Device has the SCHEDULE_EXACT_ALARM permission granted
+     *
+     * @param context Context used to perform various functions related to the System
+     */
+    private fun cleanAndRescheduleAlarms(context: Context) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        if (alarmManager.canScheduleExactAlarms()) {
+            val alarmRepository = AlarmRepository(
+                AlarmDatabase
+                    .getDatabase(context.createDeviceProtectedStorageContext())
+                    .alarmDao()
+            )
+
+            doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
+                AlarmScheduler.cleanAndRescheduleAlarms(context, alarmRepository)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/alarmexecution/ScheduleExactAlarmPermissionReceiver.kt
@@ -26,7 +26,7 @@ class ScheduleExactAlarmPermissionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
-            when(intent.action) {
+            when (intent.action) {
                 // In spite of what the name may suggest, this action is only sent
                 // by the system when the permission changes from denied to granted
                 AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED ->

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmcreate/AlarmCreationScreen.kt
@@ -116,7 +116,10 @@ fun AlarmCreationScreen(
 
     // TODO: This permission gate is a stopgap. In the future I want to pop a Dialog when the save button
     //  is pressed if a permission is missing, rather than replacing the entire screen like below.
-    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    // POST_NOTIFICATIONS permission was introduced in API 33 (TIRAMISU).
+    // SCHEDULE_EXACT_ALARM permission is only required for APIs < 33 because
+    // alarm apps can instead use USE_EXACT_ALARM on API 33+ which cannot be revoked.
+    // Therefore, we only need to ask for one or the other, never both.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         // Configure Status Bar
         StatusBarUtil.setDarkStatusBar()
@@ -131,7 +134,18 @@ fun AlarmCreationScreen(
             )
         }
     } else {
-        notificationGatedAlarmCreation()
+        // Configure Status Bar
+        StatusBarUtil.setDarkStatusBar()
+
+        Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+            PermissionGateScreen(
+                permission = Permission.ScheduleExactAlarm,
+                gatedScreen = notificationGatedAlarmCreation,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.systemBars)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -116,7 +116,10 @@ fun AlarmEditScreen(
 
     // TODO: This permission gate is a stopgap. In the future I want to pop a Dialog when the save button
     //  is pressed if a permission is missing, rather than replacing the entire screen like below.
-    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    // POST_NOTIFICATIONS permission was introduced in API 33 (TIRAMISU).
+    // SCHEDULE_EXACT_ALARM permission is only required for APIs < 33 because
+    // alarm apps can instead use USE_EXACT_ALARM on API 33+ which cannot be revoked.
+    // Therefore, we only need to ask for one or the other, never both.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         // Configure Status Bar
         StatusBarUtil.setDarkStatusBar()
@@ -131,7 +134,18 @@ fun AlarmEditScreen(
             )
         }
     } else {
-        notificationGatedAlarmEdit()
+        // Configure Status Bar
+        StatusBarUtil.setDarkStatusBar()
+
+        Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+            PermissionGateScreen(
+                permission = Permission.ScheduleExactAlarm,
+                gatedScreen = notificationGatedAlarmEdit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.systemBars)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -59,7 +59,10 @@ fun AlarmListScreen(
         )
     }
 
-    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    // POST_NOTIFICATIONS permission was introduced in API 33 (TIRAMISU).
+    // SCHEDULE_EXACT_ALARM permission is only required for APIs < 33 because
+    // alarm apps can instead use USE_EXACT_ALARM on API 33+ which cannot be revoked.
+    // Therefore, we only need to ask for one or the other, never both.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         PermissionGateScreen(
             permission = Permission.PostNotifications,
@@ -67,7 +70,11 @@ fun AlarmListScreen(
             modifier = Modifier.fillMaxWidth()
         )
     } else {
-        notificationGatedAlarmList()
+        PermissionGateScreen(
+            permission = Permission.ScheduleExactAlarm,
+            gatedScreen = notificationGatedAlarmList,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 

--- a/app/src/main/java/com/example/alarmscratch/alarm/util/AlarmUtil.kt
+++ b/app/src/main/java/com/example/alarmscratch/alarm/util/AlarmUtil.kt
@@ -1,12 +1,8 @@
 package com.example.alarmscratch.alarm.util
 
-import com.example.alarmscratch.alarm.data.model.Alarm
 import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
-import com.example.alarmscratch.alarm.data.repository.AlarmRepository
 import com.example.alarmscratch.core.extension.LocalDateTimeUtil
 import com.example.alarmscratch.core.extension.dayNumber
-import com.example.alarmscratch.core.extension.isDirty
-import com.example.alarmscratch.core.extension.isRepeating
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
@@ -102,39 +98,4 @@ object AlarmUtil {
         repeatingDays
             .filter { it.dayNumber() >= today.dayNumber() }
             .plus(repeatingDays.filter { it.dayNumber() < today.dayNumber() })
-
-    /*
-     * Maintenance
-     */
-
-    /**
-     * Cleans dirty Alarms as determined by Alarm.isDirty().
-     * Alarms that are already clean are a no-op.
-     *
-     * To clean an Alarm is to:
-     * - Reset snooze
-     * - If Alarm is repeating -> set to next repeating date/time
-     * - If Alarm is not repeating -> disable Alarm
-     *
-     * @param alarm Alarm candidate for cleaning
-     * @param alarmRepository repository in which cleaned Alarms are updated
-     */
-    suspend fun cleanAlarm(alarm: Alarm, alarmRepository: AlarmRepository) {
-        if (alarm.isDirty()) {
-            // Clean Alarm
-            val cleanAlarm = alarm.run {
-                if (isRepeating()) {
-                    copy(
-                        dateTime = nextRepeatingDateTime(alarm.dateTime, alarm.weeklyRepeater),
-                        snoozeDateTime = null
-                    )
-                } else {
-                    copy(enabled = false, snoozeDateTime = null)
-                }
-            }
-
-            // Update database
-            alarmRepository.updateAlarm(cleanAlarm)
-        }
-    }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/core/component/LavaFloatingActionButton.kt
@@ -77,7 +77,7 @@ fun LavaFloatingActionButton(
         MutableTransitionState(initialState = initialState).apply { targetState = onScreenWithFab }
     }
 
-    val floatingActionButtonContent: @Composable () -> Unit = {
+    val lavaFloatingActionButton: @Composable () -> Unit = {
         AnimatedVisibility(
             visibleState = visibleState,
             enter = slideInVertically(
@@ -100,18 +100,24 @@ fun LavaFloatingActionButton(
     val notificationGatedFab: @Composable () -> Unit = {
         SimpleNotificationGate(
             appNotificationChannel = AppNotificationChannel.Alarm,
-            gatedComposable = floatingActionButtonContent
+            gatedComposable = lavaFloatingActionButton
         )
     }
 
-    // POST_NOTIFICATIONS permission requires API 33 (TIRAMISU)
+    // POST_NOTIFICATIONS permission was introduced in API 33 (TIRAMISU).
+    // SCHEDULE_EXACT_ALARM permission is only required for APIs < 33 because
+    // alarm apps can instead use USE_EXACT_ALARM on API 33+ which cannot be revoked.
+    // Therefore, we only need to ask for one or the other, never both.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         SimplePermissionGate(
             permission = Permission.PostNotifications,
             gatedComposable = notificationGatedFab
         )
     } else {
-        notificationGatedFab()
+        SimplePermissionGate(
+            permission = Permission.ScheduleExactAlarm,
+            gatedComposable = notificationGatedFab
+        )
     }
 }
 

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
@@ -2,6 +2,7 @@ package com.example.alarmscratch.core.ui.permission
 
 import android.Manifest
 import android.os.Build
+import android.provider.Settings
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import com.example.alarmscratch.R
@@ -9,12 +10,21 @@ import com.example.alarmscratch.R
 sealed class Permission(
     val permissionString: String,
     @StringRes val systemDialogBodyRes: Int,
-    @StringRes val systemSettingsBodyRes: Int
+    @StringRes val systemSettingsBodyRes: Int,
+    val systemSettingsAction: String
 ) {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     data object PostNotifications : Permission(
         permissionString = Manifest.permission.POST_NOTIFICATIONS,
         systemDialogBodyRes = R.string.permission_missing_notifications_system_dialog,
-        systemSettingsBodyRes = R.string.permission_missing_notifications_system_settings
+        systemSettingsBodyRes = R.string.permission_missing_notifications_system_settings,
+        systemSettingsAction = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+    )
+
+    data object ScheduleExactAlarm : Permission(
+        permissionString = Manifest.permission.SCHEDULE_EXACT_ALARM,
+        systemDialogBodyRes = R.string.permission_missing_alarm_system_settings,
+        systemSettingsBodyRes = R.string.permission_missing_alarm_system_settings,
+        systemSettingsAction = Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
     )
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/Permission.kt
@@ -9,20 +9,37 @@ import com.example.alarmscratch.R
 
 sealed class Permission(
     val permissionString: String,
+    val permissionType: PermissionType,
     @StringRes val systemDialogBodyRes: Int,
     @StringRes val systemSettingsBodyRes: Int,
     val systemSettingsAction: String
 ) {
+
+    enum class PermissionType {
+        STANDARD_RUNTIME,
+        SPECIAL
+    }
+
+    /*
+     * Standard Runtime Permissions
+     */
+
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     data object PostNotifications : Permission(
         permissionString = Manifest.permission.POST_NOTIFICATIONS,
+        permissionType = PermissionType.STANDARD_RUNTIME,
         systemDialogBodyRes = R.string.permission_missing_notifications_system_dialog,
         systemSettingsBodyRes = R.string.permission_missing_notifications_system_settings,
         systemSettingsAction = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
     )
 
+    /*
+     * Special Permissions
+     */
+
     data object ScheduleExactAlarm : Permission(
         permissionString = Manifest.permission.SCHEDULE_EXACT_ALARM,
+        permissionType = PermissionType.SPECIAL,
         systemDialogBodyRes = R.string.permission_missing_alarm_system_settings,
         systemSettingsBodyRes = R.string.permission_missing_alarm_system_settings,
         systemSettingsAction = Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateScreen.kt
@@ -3,7 +3,6 @@ package com.example.alarmscratch.core.ui.permission
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -39,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.alarmscratch.R
 import com.example.alarmscratch.core.ui.theme.AlarmScratchTheme
+import com.example.alarmscratch.core.util.PermissionUtil
 
 @Composable
 fun PermissionGateScreen(
@@ -53,31 +53,49 @@ fun PermissionGateScreen(
 
     // Permission logic
     val context = LocalContext.current
+    // This is always false for Special Permissions, such as Permission.ScheduleExactAlarm
     val shouldShowRequestPermissionRationale = (context as? Activity)
         ?.shouldShowRequestPermissionRationale(permission.permissionString)
         ?: false
+    // The Permission Request System Dialog will never display for Special Permissions,
+    // such as Permission.ScheduleExactAlarm. Always launch the System Settings for
+    // Special Permissions instead.
     val permissionRequestLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
-        permissionGateViewModel.onPermissionResult(permission.permissionString, isGranted)
+        permissionGateViewModel.onPermissionResult(permission, isGranted)
     }
     val systemSettingsLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) {
-        permissionGateViewModel.onReturnFromSystemSettings(context, permission.permissionString)
+        permissionGateViewModel.onReturnFromSystemSettings(context, permission)
     }
 
-    // Must auto-call because of the nature of permissions on Android
+    // Initial query. Must auto-call because of the nature of permissions on Android.
     LaunchedEffect(key1 = attemptedToAskForPermission) {
         if (!attemptedToAskForPermission) {
-            permissionRequestLauncher.launch(permission.permissionString)
+            if (permission is Permission.ScheduleExactAlarm) {
+                // The Permission Request System Dialog will never display for Special Permissions,
+                // therefore just query the permission status and invoke the ViewModel's onPermissionResult()
+                // function to progress the permission check logic.
+                permissionGateViewModel.onPermissionResult(
+                    permission,
+                    PermissionUtil.isPermissionGranted(context, permission)
+                )
+            } else {
+                // If the permission is already granted, then "launching" the permissionRequestLauncher
+                // will not cause the Permission Request System Dialog to show. Instead, the permissionRequestLauncher's
+                // onResult() function will immediately return true, changing attemptedToAskForPermission to true
+                // without ever showing the Dialog. To the User, it will look as if the app just launched normally.
+                permissionRequestLauncher.launch(permission.permissionString)
+            }
         }
     }
 
     // Don't show anything until we know we've asked the User for the required permissions at least one time
     if (attemptedToAskForPermission) {
         // Permission denied
-        if (deniedPermissionList.contains(permission.permissionString)) {
+        if (deniedPermissionList.contains(permission)) {
             // TODO: The below 2 properties are a work around for an Android Studio bug where fromHtml() does not work with previews.
             //  The bug mentions TextDefaults.fromHtml() instead of AnnotatedString.fromHtml(), but for reasons I'm not going to get
             //  into for brevity, I believe it's the same thing. This will hopefully go away after updating Android Studio to Koala
@@ -88,7 +106,8 @@ fun PermissionGateScreen(
             val systemSettingsBodyText = AnnotatedString.fromHtml(stringResource(id = permission.systemSettingsBodyRes))
 
             // The User denied the permission only once, therefore we can still display
-            // the Permission Request System Dialog
+            // the Permission Request System Dialog. Note: Activity.shouldShowRequestPermissionRationale()
+            // will always return false for Special Permissions, such as Permission.ScheduleExactAlarm.
             if (shouldShowRequestPermissionRationale) {
                 PermissionGateScreenContent(
                     bodyText = systemDialogBodyText,
@@ -97,19 +116,28 @@ fun PermissionGateScreen(
                     modifier = modifier
                 )
             } else {
+                // Two scenarios:
+                // 1 - Normal Runtime Permission
                 // The User denied the permission twice. Therefore the System will never show
                 // the Permission Request System Dialog again. Therefore we must give the User an option
                 // to manually grant the permission, since at this point the System will never show the
                 // Permission Request System Dialog ever again. Explain why the permission is needed, inform
                 // the User that they can manually accept the permission in the System Settings, and display
                 // a Button that leads to the System Settings, which they can decide if they want to press.
+                //
+                // 2 - Special Permission
+                // Special Permissions will always follow this route since Activity.shouldShowRequestPermissionRationale()
+                // will always return false for Special Permissions. Furthermore, the Permission Request System Dialog
+                // will never display when requested for a Special Permission. Special Permissions each have their
+                // own unique permission status check functions, and furthermore, will always require interaction
+                // with the System Settings for the User to manually grant.
                 PermissionGateScreenContent(
                     bodyText = systemSettingsBodyText,
                     requestButtonTextRes = R.string.permission_open_system_settings,
                     onRequest = {
                         systemSettingsLauncher.launch(
                             Intent(
-                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                permission.systemSettingsAction,
                                 Uri.fromParts(UriScheme.PACKAGE, context.packageName, null)
                             )
                         )
@@ -181,7 +209,7 @@ fun PermissionGateScreenContent(
 
 @Preview
 @Composable
-private fun PermissionGateScreenContentSystemDialogPreview() {
+private fun PermissionGateScreenNotificationSystemDialogPreview() {
     AlarmScratchTheme {
         PermissionGateScreenContent(
             bodyText = buildAnnotatedString {
@@ -196,11 +224,26 @@ private fun PermissionGateScreenContentSystemDialogPreview() {
 
 @Preview
 @Composable
-private fun PermissionGateScreenContentSystemSettingsPreview() {
+private fun PermissionGateScreenNotificationSystemSettingsPreview() {
     AlarmScratchTheme {
         PermissionGateScreenContent(
             bodyText = buildAnnotatedString {
                 append(stringResource(id = R.string.permission_missing_notifications_system_settings))
+            },
+            requestButtonTextRes = R.string.permission_open_system_settings,
+            onRequest = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PermissionGateScreenAlarmSystemSettingsPreview() {
+    AlarmScratchTheme {
+        PermissionGateScreenContent(
+            bodyText = buildAnnotatedString {
+                append(stringResource(id = R.string.permission_missing_alarm_system_settings))
             },
             requestButtonTextRes = R.string.permission_open_system_settings,
             onRequest = {},

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/PermissionGateViewModel.kt
@@ -1,13 +1,12 @@
 package com.example.alarmscratch.core.ui.permission
 
 import android.content.Context
-import android.content.pm.PackageManager
 import androidx.compose.runtime.mutableStateListOf
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.alarmscratch.core.util.PermissionUtil
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +16,7 @@ class PermissionGateViewModel : ViewModel() {
     // Permissions
     private val _attemptedToAskForPermission: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val attemptedToAskForPermission: StateFlow<Boolean> = _attemptedToAskForPermission.asStateFlow()
-    val deniedPermissionList = mutableStateListOf<String>()
+    val deniedPermissionList = mutableStateListOf<Permission>()
 
     companion object {
 
@@ -32,22 +31,24 @@ class PermissionGateViewModel : ViewModel() {
      * Callback
      */
 
-    fun onPermissionResult(permission: String, isGranted: Boolean) {
+    fun onPermissionResult(permission: Permission, isGranted: Boolean) {
         _attemptedToAskForPermission.value = true
 
         if (!isGranted) {
             deniedPermissionList.add(permission)
         } else if (deniedPermissionList.isNotEmpty()) {
             // List can contain duplicates, remove all instances
-            deniedPermissionList.removeAll { it == permission }
+            deniedPermissionList.removeAll { it.permissionString == permission.permissionString }
         }
     }
 
-    fun onReturnFromSystemSettings(context: Context, permission: String) {
-        val isGranted = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    fun onReturnFromSystemSettings(context: Context, permission: Permission) {
+        _attemptedToAskForPermission.value = true
+
+        val isGranted = PermissionUtil.isPermissionGranted(context, permission)
         if (isGranted && deniedPermissionList.isNotEmpty()) {
             // List can contain duplicates, remove all instances
-            deniedPermissionList.removeAll { it == permission }
+            deniedPermissionList.removeAll { it.permissionString == permission.permissionString }
         }
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGate.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGate.kt
@@ -25,7 +25,7 @@ fun SimplePermissionGate(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val checkForPermission: () -> Unit = {
-        simplePermissionGateViewModel.checkForPermission(context, permission.permissionString)
+        simplePermissionGateViewModel.checkForPermission(context, permission)
     }
 
     // Manually refresh the state every time the LifecycleOwner enters the RESUMED state to ensure

--- a/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGateViewModel.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/ui/permission/SimplePermissionGateViewModel.kt
@@ -1,12 +1,11 @@
 package com.example.alarmscratch.core.ui.permission
 
 import android.content.Context
-import android.content.pm.PackageManager
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.alarmscratch.core.util.PermissionUtil
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,8 +29,7 @@ class SimplePermissionGateViewModel : ViewModel() {
      * Check
      */
 
-    fun checkForPermission(context: Context, permission: String) {
-        _isPermissionGranted.value =
-            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    fun checkForPermission(context: Context, permission: Permission) {
+        _isPermissionGranted.value = PermissionUtil.isPermissionGranted(context, permission)
     }
 }

--- a/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
@@ -9,11 +9,15 @@ import com.example.alarmscratch.core.ui.permission.Permission
 object PermissionUtil {
 
     fun isPermissionGranted(context: Context, permission: Permission): Boolean =
-        if (permission is Permission.ScheduleExactAlarm) {
-            // SCHEDULE_EXACT_ALARM is a Special Permission and therefore requires usage
-            // of its own unique permission check function. If you call ContextCompat.checkSelPermission()
-            // with SCHEDULE_EXACT_ALARM it will always return true.
-            context.getSystemService(AlarmManager::class.java).canScheduleExactAlarms()
+        if (permission.permissionType == Permission.PermissionType.SPECIAL) {
+            // Special Permissions require usage of their own unique permission check functions.
+            // Calling ContextCompat.checkSelPermission() on a Special Permission will always return true.
+            when (permission) {
+                is Permission.ScheduleExactAlarm ->
+                    context.getSystemService(AlarmManager::class.java).canScheduleExactAlarms()
+                else ->
+                    false
+            }
         } else {
             ContextCompat.checkSelfPermission(
                 context,

--- a/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
+++ b/app/src/main/java/com/example/alarmscratch/core/util/PermissionUtil.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.core.util
 
+import android.app.AlarmManager
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
@@ -8,8 +9,15 @@ import com.example.alarmscratch.core.ui.permission.Permission
 object PermissionUtil {
 
     fun isPermissionGranted(context: Context, permission: Permission): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            permission.permissionString
-        ) == PackageManager.PERMISSION_GRANTED
+        if (permission is Permission.ScheduleExactAlarm) {
+            // SCHEDULE_EXACT_ALARM is a Special Permission and therefore requires usage
+            // of its own unique permission check function. If you call ContextCompat.checkSelPermission()
+            // with SCHEDULE_EXACT_ALARM it will always return true.
+            context.getSystemService(AlarmManager::class.java).canScheduleExactAlarms()
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                permission.permissionString
+            ) == PackageManager.PERMISSION_GRANTED
+        }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,13 @@
         To do so, press the \"System Settings\" button below, then navigate to \"Permissions\"
         &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
         ensure that the \"Alarm\" Notification is also enabled.</string>
+    <string name="permission_missing_alarm_system_settings">The Alarms &amp; Reminders Permission is
+        required to use Alarms. Without it you will not be able to create or edit Alarms,
+        &lt;i&gt;&lt;u&gt;and any Alarms that you previously created will not go off&lt;/u&gt;&lt;/i&gt;.
+        &lt;br&gt;&lt;br&gt;
+        To use Alarms, you must manually accept the Permission in the System Settings.
+        To do so, press the \"System Settings\" button below, then enable the Permission on the
+        following screen.</string>
 
     <!--
         ***************************

--- a/app/src/test/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerTest.kt
+++ b/app/src/test/java/com/example/alarmscratch/alarm/alarmexecution/AlarmSchedulerTest.kt
@@ -1,0 +1,170 @@
+package com.example.alarmscratch.alarm.alarmexecution
+
+import com.example.alarmscratch.alarm.data.model.Alarm
+import com.example.alarmscratch.alarm.data.model.WeeklyRepeater
+import com.example.alarmscratch.alarm.data.repository.AlarmRepository
+import com.example.alarmscratch.alarm.util.AlarmUtil
+import com.example.alarmscratch.core.extension.isDirty
+import com.example.alarmscratch.core.extension.isRepeating
+import com.example.alarmscratch.testutil.callPrivateSuspendFunction
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.temporal.TemporalAdjusters
+
+class AlarmSchedulerTest {
+
+    // Alarm
+    private val ringtoneUri = "ringtoneUri"
+    private val snoozeDuration = 10
+
+    companion object {
+        // File names
+        private const val ALARM_EXTENSION_FUNCTION_FILE = "com.example.alarmscratch.core.extension._AlarmKt"
+        // Function names
+        private const val CLEAN_ALARM_FUNCTION = "cleanAlarm"
+    }
+
+    /*
+     * cleanAlarm
+     */
+
+    @Test
+    fun cleanAlarm_Cleans_RepeatingAlarm() = runTest {
+        val dateTime = nextWeekOnDayAtNoon(DayOfWeek.WEDNESDAY)
+        val expectedDateTime = dateTime.plusDays(7)
+        val alarm = Alarm(
+            enabled = true,
+            dateTime = dateTime,
+            weeklyRepeater = WeeklyRepeater().withDay(WeeklyRepeater.Day.WEDNESDAY),
+            ringtoneUri = ringtoneUri,
+            snoozeDateTime = dateTime.plusMinutes(snoozeDuration.toLong()),
+            snoozeDuration = snoozeDuration
+        )
+        val expectedAlarm = alarm.copy(
+            dateTime = expectedDateTime,
+            snoozeDateTime = null
+        )
+
+        val alarmRepository = mockk<AlarmRepository> { coEvery { updateAlarm(any()) } returns Unit }
+        mockkStatic(ALARM_EXTENSION_FUNCTION_FILE) {
+            every { (Alarm::isDirty)(any()) } returns true
+            every { (Alarm::isRepeating)(any()) } returns true
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns expectedDateTime
+                AlarmScheduler.callPrivateSuspendFunction(CLEAN_ALARM_FUNCTION, alarm, alarmRepository)
+            }
+        }
+
+        coVerify {
+            alarmRepository.updateAlarm(expectedAlarm)
+        }
+    }
+
+    @Test
+    fun cleanAlarm_Cleans_NonRepeatingAlarm() = runTest {
+        val dateTime = nextWeekOnDayAtNoon(DayOfWeek.WEDNESDAY)
+        val alarm = Alarm(
+            enabled = true,
+            dateTime = dateTime,
+            weeklyRepeater = WeeklyRepeater(),
+            ringtoneUri = ringtoneUri,
+            snoozeDateTime = dateTime.plusMinutes(snoozeDuration.toLong()),
+            snoozeDuration = snoozeDuration
+        )
+        val expectedAlarm = alarm.copy(
+            enabled = false,
+            snoozeDateTime = null
+        )
+
+        val alarmRepository = mockk<AlarmRepository> { coEvery { updateAlarm(any()) } returns Unit }
+        mockkStatic(ALARM_EXTENSION_FUNCTION_FILE) {
+            every { (Alarm::isDirty)(any()) } returns true
+            every { (Alarm::isRepeating)(any()) } returns false
+            AlarmScheduler.callPrivateSuspendFunction(CLEAN_ALARM_FUNCTION, alarm, alarmRepository)
+        }
+
+        coVerify {
+            alarmRepository.updateAlarm(expectedAlarm)
+        }
+    }
+
+    @Test
+    fun cleanAlarm_DoesNothing_IfAlarmIsAlreadyClean() = runTest {
+        val dateTime = nextWeekOnDayAtNoon(DayOfWeek.WEDNESDAY)
+        val alarm = Alarm(
+            enabled = true,
+            dateTime = dateTime,
+            weeklyRepeater = WeeklyRepeater(),
+            ringtoneUri = ringtoneUri,
+            snoozeDateTime = dateTime.plusMinutes(snoozeDuration.toLong()),
+            snoozeDuration = snoozeDuration
+        )
+
+        val alarmRepository = mockk<AlarmRepository>()
+        mockkStatic(ALARM_EXTENSION_FUNCTION_FILE) {
+            every { (Alarm::isDirty)(any()) } returns false
+            AlarmScheduler.callPrivateSuspendFunction(CLEAN_ALARM_FUNCTION, alarm, alarmRepository)
+        }
+
+        coVerify {
+            alarmRepository wasNot Called
+        }
+    }
+
+    /*
+     * Helper Functions
+     */
+
+    // Tests in this class require LocalDateTimes that are set on a specific DayOfWeek.
+    // The only way to do this is via a TemporalAdjuster and finding the next occurrence
+    // of the target DayOfWeek. Since the TemporalAdjuster could return days that are either in this week
+    // or next week, for consistency we are ensuring that the returned LocalDateTime is always in next week.
+    @Suppress("SameParameterValue")
+    private fun nextWeekOnDayAtNoon(targetDayOfWeek: DayOfWeek): LocalDateTime {
+        val now = LocalDateTime.now()
+        val todayDayOfWeek = now.dayOfWeek
+        val nextWeekOnTargetDay = now
+            .withHour(12)
+            .withSecond(0)
+            .withNano(0)
+            .with(TemporalAdjusters.next(targetDayOfWeek))
+
+        // We want to ensure that nextWeekOnTargetDay is set for next week.
+        // TemporalAdjusters.next(targetDayOfWeek) returns the next occurrence of targetDayOfWeek AFTER today.
+        // This means that any targetDayOfWeek ON OR BEFORE today will ALREADY have one week added to it.
+        //
+        // However, any targetDayOfWeek AFTER today will not ALREADY have one week added to it,
+        // which would mean that nextWeekOnTargetDay would CURRENTLY be set for this week in this case.
+        // Therefore, we must add 7 days to the returned value if targetDayOfWeek is greater than today.
+        //
+        // Special case:
+        // java.time.DayOfWeek starts the week on Monday. Therefore, if targetDayOfWeek is after today,
+        // AND targetDayOfWeek is Sunday, then nextWeekOnTargetDay will ALREADY be set for next week.
+        // Therefore, we do not have to add 7 days to it.
+        return if (targetDayOfWeek > todayDayOfWeek) {
+            // targetDayOfWeek is after todayDayOfWeek, therefore nextWeekOnTargetDay MAY currently be set in this week.
+            // Add a week if necessary to ensure that we're returning a day in next week.
+            if (targetDayOfWeek != DayOfWeek.SUNDAY) {
+                // nextWeekOnTargetDay is CURRENTLY set for this week, add 7 days
+                nextWeekOnTargetDay.plusDays(7)
+            } else {
+                // targetDayOfWeek > todayDayOfWeek AND targetDayOfWeek == DayOfWeek.SUNDAY,
+                // therefore nextWeekOnTargetDay is ALREADY set in next week.
+                nextWeekOnTargetDay
+            }
+        } else {
+            // targetDayOfWeek is before or the same as todayDayOfWeek,
+            // therefore nextWeekOnTargetDay is ALREADY set in next week.
+            nextWeekOnTargetDay
+        }
+    }
+}

--- a/app/src/test/java/com/example/alarmscratch/core/util/PermissionUtilTest.kt
+++ b/app/src/test/java/com/example/alarmscratch/core/util/PermissionUtilTest.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.core.util
 
+import android.app.AlarmManager
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
@@ -18,7 +19,7 @@ class PermissionUtilTest {
      */
 
     @Test
-    fun isPermissionGranted_ReturnsTrue_WhenPermissionIsGranted() {
+    fun isPermissionGranted_ReturnsTrue_WhenStandardRuntimePermission_IsGranted() {
         mockkStatic(ContextCompat::class) {
             every { ContextCompat.checkSelfPermission(any(), any()) } returns PackageManager.PERMISSION_GRANTED
             assertTrue(PermissionUtil.isPermissionGranted(mockk<Context>(), Permission.PostNotifications))
@@ -26,10 +27,34 @@ class PermissionUtilTest {
     }
 
     @Test
-    fun isPermissionGranted_ReturnsFalse_WhenPermissionIsDenied() {
+    fun isPermissionGranted_ReturnsFalse_WhenStandardRuntimePermission_IsDenied() {
         mockkStatic(ContextCompat::class) {
             every { ContextCompat.checkSelfPermission(any(), any()) } returns PackageManager.PERMISSION_DENIED
             assertFalse(PermissionUtil.isPermissionGranted(mockk<Context>(), Permission.PostNotifications))
         }
+    }
+
+    @Test
+    fun isPermissionGranted_ReturnsTrue_WhenSpecialPermission_ScheduleExactAlarm_IsGranted() {
+        val alarmManager = mockk<AlarmManager> {
+            every { canScheduleExactAlarms() } returns true
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+        }
+
+        assertTrue(PermissionUtil.isPermissionGranted(context, Permission.ScheduleExactAlarm))
+    }
+
+    @Test
+    fun isPermissionGranted_ReturnsFalse_WhenSpecialPermission_ScheduleExactAlarm_IsDenied() {
+        val alarmManager = mockk<AlarmManager> {
+            every { canScheduleExactAlarms() } returns false
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+        }
+
+        assertFalse(PermissionUtil.isPermissionGranted(context, Permission.ScheduleExactAlarm))
     }
 }

--- a/app/src/test/java/com/example/alarmscratch/testutil/ReflectionUtil.kt
+++ b/app/src/test/java/com/example/alarmscratch/testutil/ReflectionUtil.kt
@@ -1,5 +1,6 @@
 package com.example.alarmscratch.testutil
 
+import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.kotlinFunction
@@ -8,6 +9,15 @@ inline fun <reified T : Any> T.callPrivateFunction(name: String, vararg args: An
     val function = T::class.declaredMemberFunctions.firstOrNull { it.name == name }
     function?.isAccessible = true
     val ret = function?.call(this, *args)
+    function?.isAccessible = false
+
+    return ret
+}
+
+suspend inline fun <reified T : Any> T.callPrivateSuspendFunction(name: String, vararg args: Any): Any? {
+    val function = T::class.declaredMemberFunctions.firstOrNull { it.name == name }
+    function?.isAccessible = true
+    val ret = function?.callSuspend(this, *args)
     function?.isAccessible = false
 
     return ret


### PR DESCRIPTION
### Description
- Add `SHCEDULE_EXACT_ALARM` permission to Manifest with `maxSdkVersion="32"`
- Check for `SHCEDULE_EXACT_ALARM` everywhere that Alarm permissions are required, and are possible to reach with this permission revoked
  - Some of the code inside `AlarmNotificationService.displayAlarmNotification()` requires `SHCEDULE_EXACT_ALARM` in order to function properly. However, we do not check for the `SHCEDULE_EXACT_ALARM` permission here because this method is only called in response to an Alarm triggering, and the `AlarmManager` auto-cancels all "exact" alarms, including those scheduled with `AlarmManager.setAlarmClock()`, when the `SHCEDULE_EXACT_ALARM` permission is revoked. Therefore, `AlarmNotificationService.displayAlarmNotification()` can never be called when `SHCEDULE_EXACT_ALARM` is not granted since in this scenario there will be no Alarms scheduled with the `AlarmManager` to even do anything. Furthermore, if `SHCEDULE_EXACT_ALARM` is revoked during Alarm execution, then we do not have to worry about the User snoozing the Alarm and crashing the app since the Operating System will automatically terminate the app's process when the permission is revoked.
- Bump `minSdk` from `27 to 31` to deal with some issues
  - `API 31+` has a high enough market share to warrant discluding lower APIs in order to avoid sullying code with too many version checks, or accounting for API specific quirks
- Add an API level-determined permission check to `BootCompletedReceiver` to ensure that Devices running `APIs < 33` have the `SHCEDULE_EXACT_ALARM` permission before cleaning and rescheduling Alarms
- Create `ScheduleExactAlarmPermissionReceiver` to clean and reschedule Alarms when the state of the `SHCEDULE_EXACT_ALARM` permission changes from Denied to Granted
- Move code related to rescheduling Alarms from `AlarmActionReceiver`, `AlarmNotificationService`, and `BootCompletedReceiver` to `AlarmScheduler`
  - Previously, `AlarmScheduler` simply had `scheduleAlarm()`, `cancelAlarm()`, and `refreshAlarms()`. After this change it also has `snoozeAndRescheduleAlarm()` and `disableOrRescheduleAlarm()`.