### PR TITLE
Feature | Bump compileSdk and targetSdk to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.joebsource.lavalarm"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.joebsource.lavalarm"
         minSdk = 31
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/java/com/joebsource/lavalarm/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -207,7 +208,12 @@ fun AlarmCreateEditScreen(
         },
         containerColor = MaterialTheme.colorScheme.surface,
         modifier = modifier
-            .background(color = MediumVolcanicRock)
+            .background(
+                brush = Brush.verticalGradient(
+                    0.07f to MediumVolcanicRock,
+                    0.08f to DarkVolcanicRock
+                )
+            )
             .windowInsetsPadding(WindowInsets.systemBars)
             .clickable(interactionSource = null, indication = null) { scaffoldFocusRequester.requestFocus() }
             .focusRequester(scaffoldFocusRequester)

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
@@ -67,6 +67,7 @@ import com.joebsource.lavalarm.core.ui.snackbar.SnackbarEvent
 import com.joebsource.lavalarm.core.ui.snackbar.global.GlobalSnackbarController
 import com.joebsource.lavalarm.core.ui.theme.BoatSails
 import com.joebsource.lavalarm.core.ui.theme.BottomOceanBlue
+import com.joebsource.lavalarm.core.ui.theme.DarkVolcanicRock
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
 import com.joebsource.lavalarm.core.ui.theme.SkyBlue
 import com.joebsource.lavalarm.core.ui.theme.TopOceanBlue
@@ -223,14 +224,17 @@ fun CoreScreenContent(
                 brush = Brush.verticalGradient(
                     0.07f to SkyBlue,
                     0.08f to TopOceanBlue,
-                    1.0f to BottomOceanBlue
+                    0.93f to BottomOceanBlue,
+                    0.94f to DarkVolcanicRock
                 )
             )
             .windowInsetsPadding(WindowInsets.systemBars)
     ) { innerPadding ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(innerPadding)
         ) {
             // Internal Screen
             Box(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
@@ -206,6 +206,7 @@ fun CoreScreenContent(
     }
 
     Scaffold(
+        topBar = header,
         bottomBar = navigationBar,
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) { snackbarData ->
@@ -231,9 +232,6 @@ fun CoreScreenContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(innerPadding)
         ) {
-            // Header
-            header()
-
             // Internal Screen
             Box(modifier = Modifier.weight(1f)) {
                 internalScreen()

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/ringtonepicker/RingtonePickerScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/ringtonepicker/RingtonePickerScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -111,7 +112,12 @@ fun RingtonePickerScreenContent(
 
     Surface(
         modifier = modifier
-            .background(color = MediumVolcanicRock)
+            .background(
+                brush = Brush.verticalGradient(
+                    0.07f to MediumVolcanicRock,
+                    0.08f to DarkVolcanicRock
+                )
+            )
             .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column {

--- a/app/src/main/java/com/joebsource/lavalarm/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/settings/ui/alarmdefaults/AlarmDefaultsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -162,7 +163,12 @@ fun AlarmDefaultsScreenContent(
         },
         containerColor = MaterialTheme.colorScheme.surface,
         modifier = modifier
-            .background(color = MediumVolcanicRock)
+            .background(
+                brush = Brush.verticalGradient(
+                    0.07f to MediumVolcanicRock,
+                    0.08f to DarkVolcanicRock
+                )
+            )
             .windowInsetsPadding(WindowInsets.systemBars)
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/joebsource/lavalarm/settings/ui/generalsettings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/settings/ui/generalsettings/GeneralSettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,6 +42,7 @@ import com.joebsource.lavalarm.R
 import com.joebsource.lavalarm.core.ui.shared.CustomTopAppBar
 import com.joebsource.lavalarm.core.ui.shared.RowSelectionItem
 import com.joebsource.lavalarm.core.ui.shared.UnsavedChangesDialog
+import com.joebsource.lavalarm.core.ui.theme.DarkVolcanicRock
 import com.joebsource.lavalarm.core.ui.theme.DarkerBoatSails
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
 import com.joebsource.lavalarm.core.ui.theme.MediumVolcanicRock
@@ -126,7 +128,12 @@ fun GeneralSettingsScreenContent(
         },
         containerColor = MaterialTheme.colorScheme.surface,
         modifier = modifier
-            .background(color = MediumVolcanicRock)
+            .background(
+                brush = Brush.verticalGradient(
+                    0.07f to MediumVolcanicRock,
+                    0.08f to DarkVolcanicRock
+                )
+            )
             .windowInsetsPadding(WindowInsets.systemBars)
     ) { innerPadding ->
         Column(modifier = Modifier


### PR DESCRIPTION
### Description
- Bump both `compileSdk` and `targetSdk` to `35`
- Fix issue on all screens specific to `egde-to-edge` on `API 35`
  - `AlarmCreateEditScreen`, `CoreScreen`, `RingtonePickerScreen`, `AlarmDefaultsScreen`, `GeneralSettingsScreen`
  - These issues were not apparent when utilizing `edge-to-edge` on lower APIs, as I was using `ComponentActivity.enableEdgeToEdge()` and passing a `SystemBarStyle` with a non-transparent color to the `navigationBarStyle` parameter, which provided color to the OS navigation bar. However, the `navigationBarStyle` parameter has no effect on `API 35`, which left the bottom of the screen's color exposed behind the navigation bar. This color was what I was setting to the `Scaffolds'` background color via a `Modifier` in order to color the Status Bar (while the "content" of the screen had it's own background color, making the Scaffold's background color essential JUST the Status Bar color). I was doing it like this so the color of the Status Bar would transition between screens synchronously with the `NavHost's` screen transitions (rather than hard changing with typical Status Bar coloring functions). This color was not what I wanted at the bottom of the screen, so I had to apply vertical gradients to these brushes in order to have a background with a different color at the top, than at the bottom.
- Fix an issue specific to `API 35` where the `LavaFloatingActionButton` and `Volcano` were being visually displayed on the screen before being centered. This had a visual affect of them showing up on the left side of the screen, then immediately popping over to the center.
  - This was fixed by adding `Modifier.fillMaxWidth()` to the main Column inside the `CoreScreen's` `Scaffold`. I believe this was some sort of issue with `API 35` having a different order of operations in regards to applying `Modifiers` and displaying composables on the screen.
- Fix an issue in `API 35` where the bottom text in the Status Bar was being cut off by the `SkylineHeader`. Fixed by moving the `SkylineHeader` from the body of the `CoreScreen's` `Scaffold`, to the `Scaffold's` `topBar` parameter.
  - This was pretty strange, and I have a feeling it may have just been an issue with the Pixel 8 emulator I was using, but making this change didn't negatively impact anything so I'm going with it.