### PR TITLE
Feature | Bump Dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.composeCompiler)
 }
 
 android {
@@ -40,9 +41,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.10"
     }
     room {
         schemaDirectory("$projectDir/schemas")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.kotlinxSerialization) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.composeCompiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-agp = "8.3.2"
-kotlin = "1.9.22"
-coreKtx = "1.13.0"
-ksp = "1.9.22-1.0.17"
-room = "2.6.1"
-junitVersion = "1.1.5"
-preferencesDataStore = "1.1.1"
-espressoCore = "3.5.1"
-androidxLifecycle = "2.8.0"
-activityCompose = "1.9.0"
-composeBom = "2024.09.02"
-materialIcons = "1.6.6"
-navigationCompose = "2.8.8"
+agp = "8.9.1"
+kotlin = "2.1.20"
+coreKtx = "1.16.0"
+ksp = "2.1.20-2.0.0"
+room = "2.7.0"
+junitVersion = "1.2.1"
+preferencesDataStore = "1.1.4"
+espressoCore = "3.6.1"
+androidxLifecycle = "2.8.7"
+activityCompose = "1.10.1"
+composeBom = "2025.04.00"
+materialIcons = "1.7.8"
+navigationCompose = "2.8.9"
 splashscreen = "1.0.1"
-kotlinReflect = "1.9.22"
+kotlinReflect = "2.0.20"
 serialization = "1.6.3"
 # Unit Tests
 junit = "4.13.2"
-kotlinxCoroutinesTest = "1.9.0"
+kotlinxCoroutinesTest = "1.10.1"
 mockk = "1.13.17"
 # Instrumented Tests
 orchestrator = "1.5.1"
@@ -65,3 +65,4 @@ androidxRoom = { id = "androidx.room", version.ref = "room" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 23 21:14:49 EDT 2024
+#Tue Apr 15 15:55:52 EDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description
- Update:
  - `Android Gradle plugin`: `8.3.2` -> `8.9.1`
  - `Gradle`: `8.4` -> `8.11.1`
  - `Kotlin`: `1.9.22` -> `2.1.20`
- Update all other outdated dependencies in `libs.versions.toml`
- Add `Compose Compiler Gradle plugin`
  - `kotlinCompilerExtensionVersion` inside the `composeOptions` block is no longer required, and has been removed