### PR TITLE
Feature | Edge to Edge FullScreenAlarmScreen

### DIFF
--- a/app/src/main/java/com/joebsource/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -59,6 +60,7 @@ import com.joebsource.lavalarm.core.extension.getDayFull
 import com.joebsource.lavalarm.core.ui.shared.LongPressButton
 import com.joebsource.lavalarm.core.ui.theme.BoatHull
 import com.joebsource.lavalarm.core.ui.theme.DarkGrey
+import com.joebsource.lavalarm.core.ui.theme.DrySand
 import com.joebsource.lavalarm.core.ui.theme.Grey
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
 import com.joebsource.lavalarm.core.ui.theme.MediumGrey
@@ -93,7 +95,12 @@ fun FullScreenAlarmScreenContent(
     Surface(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = SkyBlue)
+            .background(
+                brush = Brush.verticalGradient(
+                    0.07f to SkyBlue,
+                    0.08f to DrySand
+                )
+            )
             .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         // Screen background


### PR DESCRIPTION
### Description
- Fix OS 3 button `Navigation Bar` "color" for edge-to-edge on `FullScreenAlarmScreen`, specifically on `API 35`
  - Edge-to-edge worked fine on `APIs <= 34` because I was only using it to color the `Status Bar`, and lock the `Navigation Bar` to dark mode, and I did not make the `Navigation Bar` background transparent. However, on `API 35` you can no longer color the `Navigation Bar`, nor can you lock it to dark mode. Instead, it's just the 3 buttons on an automatically transparent background, which you cannot change. This exposed the UI behind the `Navigation Bar` which was not previously exposed, and was not the color I wanted. Because of this, I had to manually set the color behind the `Navigation Bar` on `FullScreenAlarmScreen` to `DrySand`.