### PR TITLE
Feature | Fix Flashing UI Elements

### DIFF
--- a/app/src/androidTest/java/com/joebsource/lavalarm/core/ui/core/CoreScreenTest.kt
+++ b/app/src/androidTest/java/com/joebsource/lavalarm/core/ui/core/CoreScreenTest.kt
@@ -14,7 +14,7 @@ import com.joebsource.lavalarm.alarm.data.model.WeeklyRepeater
 import com.joebsource.lavalarm.alarm.data.repository.AlarmRepository
 import com.joebsource.lavalarm.core.extension.LocalDateTimeUtil
 import com.joebsource.lavalarm.core.extension.toCountdownString
-import com.joebsource.lavalarm.core.navigation.AlarmApp
+import com.joebsource.lavalarm.core.navigation.TopLevelNavHost
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
 import io.mockk.every
 import io.mockk.mockkConstructor
@@ -78,7 +78,7 @@ class CoreScreenTest {
 
         composeTestRule.setContent {
             LavalarmTheme {
-                AlarmApp()
+                TopLevelNavHost()
             }
         }
 
@@ -101,7 +101,7 @@ class CoreScreenTest {
             every { anyConstructed<AlarmRepository>().getAllAlarmsFlow() } returns flowOf(alarmList)
             composeTestRule.setContent {
                 LavalarmTheme {
-                    AlarmApp()
+                    TopLevelNavHost()
                 }
             }
         }
@@ -130,7 +130,7 @@ class CoreScreenTest {
 
         composeTestRule.setContent {
             LavalarmTheme {
-                AlarmApp()
+                TopLevelNavHost()
             }
         }
 
@@ -165,7 +165,7 @@ class CoreScreenTest {
 
         composeTestRule.setContent {
             LavalarmTheme {
-                AlarmApp()
+                TopLevelNavHost()
             }
         }
 
@@ -210,7 +210,7 @@ class CoreScreenTest {
 
         composeTestRule.setContent {
             LavalarmTheme {
-                AlarmApp()
+                TopLevelNavHost()
             }
         }
 
@@ -242,7 +242,7 @@ class CoreScreenTest {
             every { anyConstructed<AlarmRepository>().getAlarmFlow(baseAlarmNonRepeating.id) } returns flowOf(baseAlarmNonRepeating)
             composeTestRule.setContent {
                 LavalarmTheme {
-                    AlarmApp()
+                    TopLevelNavHost()
                 }
             }
 

--- a/app/src/main/java/com/joebsource/lavalarm/core/MainActivity.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.joebsource.lavalarm.core.navigation.AlarmApp
+import com.joebsource.lavalarm.core.navigation.TopLevelNavHost
 import com.joebsource.lavalarm.core.ui.theme.AndroidDefaultDarkScrim
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
 
@@ -27,7 +27,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             LavalarmTheme {
-                AlarmApp()
+                TopLevelNavHost()
             }
         }
     }

--- a/app/src/main/java/com/joebsource/lavalarm/core/navigation/CoreScreenNavComponent.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/navigation/CoreScreenNavComponent.kt
@@ -9,7 +9,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
 import com.joebsource.lavalarm.R
 
-enum class NavComponent(
+enum class CoreScreenNavComponent(
     @StringRes val navNameRes: Int,
     val navIcon: ImageVector,
     val destination: Destination,

--- a/app/src/main/java/com/joebsource/lavalarm/core/navigation/CoreScreenNavHost.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/navigation/CoreScreenNavHost.kt
@@ -13,7 +13,7 @@ import com.joebsource.lavalarm.core.extension.navigateSingleTop
 import com.joebsource.lavalarm.settings.SettingsScreen
 
 @Composable
-fun CoreNavHost(
+fun CoreScreenNavHost(
     coreNavHostController: NavHostController,
     secondaryNavHostController: NavHostController,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/joebsource/lavalarm/core/navigation/TopLevelNavHost.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/navigation/TopLevelNavHost.kt
@@ -18,7 +18,7 @@ import com.joebsource.lavalarm.settings.ui.alarmdefaults.AlarmDefaultsScreen
 import com.joebsource.lavalarm.settings.ui.generalsettings.GeneralSettingsScreen
 
 @Composable
-fun AlarmApp() {
+fun TopLevelNavHost() {
     val navHostController = rememberNavController()
     NavHost(
         navController = navHostController,

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreen.kt
@@ -51,9 +51,9 @@ import com.joebsource.lavalarm.alarm.ui.alarmlist.AlarmListScreenContent
 import com.joebsource.lavalarm.core.extension.getAndRemoveStringFromBackStack
 import com.joebsource.lavalarm.core.extension.navigateSingleTop
 import com.joebsource.lavalarm.core.extension.toCountdownString
-import com.joebsource.lavalarm.core.navigation.CoreNavHost
+import com.joebsource.lavalarm.core.navigation.CoreScreenNavComponent
+import com.joebsource.lavalarm.core.navigation.CoreScreenNavHost
 import com.joebsource.lavalarm.core.navigation.Destination
-import com.joebsource.lavalarm.core.navigation.NavComponent
 import com.joebsource.lavalarm.core.runtime.ObserveAsEvent
 import com.joebsource.lavalarm.core.ui.core.component.AlarmCountdownState
 import com.joebsource.lavalarm.core.ui.core.component.LavaFloatingActionButton
@@ -90,34 +90,18 @@ fun CoreScreen(
     StatusBarUtil.setLightStatusBar()
 
     // Navigation
-    // Current and previous destinations must be tracked in order to prevent LavaFloatingActionButton
-    // and NextAlarmCloud from unnecessarily reanimating on orientation change, etc. Part of achieving
-    // this requires tracking the previous Destination during CoreScreen (coreNavHostController)
+    // Current and previous Destinations must be tracked in order to prevent LavaFloatingActionButton,
+    // NextAlarmCloud, and VolcanoNavigationBar from unnecessarily reanimating on orientation change, etc.
+    // Part of achieving this requires tracking the previous Destination during CoreScreen (coreNavHostController)
     // navigation. Simply observing coreNavHostController.previousBackStackEntry is not sufficient
     // because once the User pops the entire back stack (is back at the original Destination),
     // there will be no "previous Destination" in the back stack, even though there actually was
     // a previous Destination in practice. Because of this, the previous Destination must be tracked manually.
     val coreNavHostController = rememberNavController()
-    val currentCoreBackStackEntry by coreNavHostController.currentBackStackEntryAsState()
     val currentCoreDestination by coreScreenViewModel.currentCoreDestination.collectAsState()
-    val setCurrentCoreDestination: (Destination) -> Unit = coreScreenViewModel::setCurrentCoreDestination
     val previousCoreDestination by coreScreenViewModel.previousCoreDestination.collectAsState()
+    val setCurrentCoreDestination: (Destination) -> Unit = coreScreenViewModel::setCurrentCoreDestination
     val setPreviousCoreDestination: (Destination) -> Unit = coreScreenViewModel::setPreviousCoreDestination
-
-    // NavController.currentBackStackEntryAsState() emits null after performing navigation away from and back to CoreScreen.
-    //   Ex: SettingsScreen -> AlarmDefaultsScreen -> (Back Nav) SettingsScreen
-    //
-    // Normally, emitting a null value implies that there is no backstack. However, there IS a backstack in this scenario.
-    // Shortly after initially emitting null, it subsequently emits the proper NavBackStackEntry. It's as if it's emitting values
-    // while in some sort of "in-between" state of re-initialization. This causes errors, and I believe this to be a bug.
-    // In order to account for this, do not call CoreScreenViewModel.setCurrentCoreDestination() if the backstack is null.
-    //
-    // Note: There are legitimate reasons why the backstack would be null, for example, if you haven't navigated anywhere yet.
-    // However, the above described bug example is not a legitimate reason. Because of the above mentioned bug, we unfortunately
-    // need to filter out ALL instances of a null backstack, even though we only want to filter out the bugged one.
-    if (currentCoreBackStackEntry != null) {
-        setCurrentCoreDestination(NavComponent.fromNavBackStackEntry(currentCoreBackStackEntry))
-    }
 
     // Back press
     val activity: Activity? = (LocalContext.current as? Activity)
@@ -136,11 +120,23 @@ fun CoreScreen(
         }
     }
 
-    // Track that the User is leaving the Core Screen by
-    // setting previousCoreDestination to currentCoreDestination
-    val currentSecondaryBackStackEntry by secondaryNavHostController.currentBackStackEntryAsState()
-    LaunchedEffect(key1 = currentSecondaryBackStackEntry) {
-        if (currentSecondaryBackStackEntry != null) {
+    // Track changes in coreNavHostController's back stack
+    // Don't use delegation, and also grab the value from the back stack state. This is in order
+    // to avoid smart casting issues with delegated properties and open/custom getters.
+    val currentCoreBackStackEntry = coreNavHostController.currentBackStackEntryAsState().value
+    if (currentCoreBackStackEntry != null) {
+        LaunchedEffect(key1 = currentCoreBackStackEntry.destination) {
+            setCurrentCoreDestination(CoreScreenNavComponent.fromNavBackStackEntry(currentCoreBackStackEntry))
+        }
+    }
+
+    // Track that the User is leaving the CoreScreen by setting previousCoreDestination to
+    // currentCoreDestination when the secondaryNavHostController's NavBackStackEntry changes.
+    // Don't use delegation, and also grab the value from the back stack state. This is in order
+    // to avoid smart casting issues with delegated properties and open/custom getters.
+    val currentSecondaryBackStackEntry = secondaryNavHostController.currentBackStackEntryAsState().value
+    if (currentSecondaryBackStackEntry != null) {
+        LaunchedEffect(key1 = currentSecondaryBackStackEntry.destination) {
             setPreviousCoreDestination(currentCoreDestination)
         }
     }
@@ -176,7 +172,7 @@ fun CoreScreen(
         }
     ) {
         // Nested Internal Screen
-        CoreNavHost(
+        CoreScreenNavHost(
             coreNavHostController = coreNavHostController,
             secondaryNavHostController = secondaryNavHostController,
             modifier = Modifier.padding(20.dp)

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreenViewModel.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/core/CoreScreenViewModel.kt
@@ -5,13 +5,23 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.joebsource.lavalarm.core.navigation.Destination
 import com.joebsource.lavalarm.core.ui.snackbar.SnackbarEvent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 class CoreScreenViewModel : ViewModel() {
+
+    // Navigation Tracking
+    private val _currentCoreDestination: MutableStateFlow<Destination> = MutableStateFlow(Destination.AlarmListScreen)
+    val currentCoreDestination: StateFlow<Destination> = _currentCoreDestination.asStateFlow()
+    private val _previousCoreDestination: MutableStateFlow<Destination> = MutableStateFlow(Destination.AlarmListScreen)
+    val previousCoreDestination: StateFlow<Destination> = _previousCoreDestination.asStateFlow()
 
     // Snackbar
     private val localSnackbarChannel = Channel<SnackbarEvent>()
@@ -25,6 +35,26 @@ class CoreScreenViewModel : ViewModel() {
             }
         }
     }
+
+    /*
+     * Navigation Tracking
+     */
+
+    fun setCurrentCoreDestination(destination: Destination) {
+        if (_currentCoreDestination.value != destination) {
+            _currentCoreDestination.value = destination
+        }
+    }
+
+    fun setPreviousCoreDestination(destination: Destination) {
+        if (_previousCoreDestination.value != destination) {
+            _previousCoreDestination.value = destination
+        }
+    }
+
+    /*
+     * Snackbar
+     */
 
     fun retrieveSnackbarFromPrevious(message: String?) {
         if (message != null) {

--- a/app/src/main/java/com/joebsource/lavalarm/core/ui/core/component/VolcanoNavigationBar.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ui/core/component/VolcanoNavigationBar.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.joebsource.lavalarm.core.navigation.CoreScreenNavComponent
 import com.joebsource.lavalarm.core.navigation.Destination
-import com.joebsource.lavalarm.core.navigation.NavComponent
 import com.joebsource.lavalarm.core.ui.theme.BrightLavaRed
 import com.joebsource.lavalarm.core.ui.theme.DarkVolcanicRock
 import com.joebsource.lavalarm.core.ui.theme.LavalarmTheme
@@ -59,7 +59,7 @@ fun VolcanoNavigationBar(
         containerColor = DarkVolcanicRock,
         modifier = modifier
     ) {
-        NavComponent.entries.forEach { navComponent ->
+        CoreScreenNavComponent.entries.forEach { navComponent ->
             NavigationBarItem(
                 selected = currentCoreDestination == navComponent.destination,
                 onClick = { onDestinationChange(navComponent.destination) },


### PR DESCRIPTION
### Description
- Fix an issue where UI elements on the `CoreScreen` that are visibility-gated by navigation logic would quickly flash on and off the screen under certain conditions.
  - The fix was to move the `currentCoreDestination` and `previousCoreDestination` `State` to `CoreScreenViewModel`, and prevent them from being updated when either `coreNavHostController.currentBackStackEntry.destination` or `secondaryNavHostController.currentBackStackEntry.destination` were `null`. This was done by putting them inside `null` check-gated `LaunchedEffects`. These `LaunchedEffects` also take their respective `NavDestinations` as a key in order to prevent redundant method calls to update the `State`.
  - Bug Example: If you're on the `SettingsScreen` (`CoreScreen`), then navigate away from `CoreScreen` -> `AlarmDefaultsScreen`, when you press back to go back to the `SettingsScreen`, the `LavaFloatingActionButton` and `NextAlarmCloud`, which are supposed to not be shown on the `SettingsScreen`, would very quickly flash on the screen before disappearing to their intended "invisible" state. Furthermore, the `VolcanoNavigationBar` would incorrectly flash "Alarm" as the current screen, before switching to "Settings."
  - This was happening due to the fact that the `NavHostController.currentBackStackEntry` returns `null` when a screen is recreated, such as when navigating from `CoreScreen` -> `AlarmDefaultsScreen` -> `CoreScreen`. Upon going back to `CoreScreen`, its `NavHostController` returns `null` from `NavHostController.currentBackStackEntry` as if it didn't have a back stack. Immediately afterwards it automatically returns the actual `non-null` `NavBackStackEntry` that it should have emitted in the first place, which I was observing as `State`. This `NavBackStackEntry` is converted to a `Destination` via `CoreScreenNavComponent.fromNavBackStackEntry()`, which defaults to `Destination.AlarmListScreen` if the `NavBackStackEntry` is `null`. Without getting into the visibility-gating logic of the aforementioned `CoreScreen` UI elements, this default of `Destination.AlarmListScreen`, which quickly switches to the "real" `Destination` once `NavHostController` catches up with itself and returns the true `non-null` value, was causing these UI elements to flash on the screen before going away, when they should have instead just not been there at all.
- Rename `AlarmApp` -> `TopLevelNavHost`, `NavComponent` -> `CoreScreenNavComponent`, and `CoreNavHost` -> `CoreScreenNavHost`