### PR TITLE
Feature | Fix Notification String

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,7 +171,7 @@
         &lt;br&gt;&lt;br&gt;
         To use Alarms, you must manually accept the Permission in the System Settings.
         To do so, press the \"System Settings\" button below, then navigate to \"Permissions\"
-        &gt; \"Notifications\" and enable \"All AlarmApp Notifications\". Then on the same screen,
+        &gt; \"Notifications\" and enable \"All Lavalarm notifications\". Then on the same screen,
         ensure that the \"Alarm\" Notification is also enabled.</string>
     <string name="permission_missing_alarm_system_settings">The Alarms &amp; Reminders Permission is
         required to use Alarms. Without it you will not be able to create or edit Alarms,


### PR DESCRIPTION
### Description
- Replace placeholder text for the app name in the `permission_missing_notifications_system_settings` string in `strings.xml`
  - Changed from `AlarmApp` -> `Lavalarm`
  - Also make the word "notifications" in the quoted text lowercase to match what's in the System Settings