### PR TITLE
Feature | Direct Boot Aware Components

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
         <!-- Receive Alarm Actions -->
         <receiver
             android:name=".alarm.alarmexecution.AlarmActionReceiver"
+            android:directBootAware="true"
             android:exported="false" />
         <!-- Reschedule Alarms on Device boot -->
         <receiver
@@ -86,6 +87,7 @@
         <!-- Handle Device Time Changes -->
         <receiver
             android:name=".core.receiver.TimeChangeReceiver"
+            android:directBootAware="true"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.TIME_SET" />
@@ -96,6 +98,7 @@
         <!-- SCHEDULE_EXACT_ALARM Permission Granted -->
         <receiver
             android:name=".alarm.alarmexecution.ScheduleExactAlarmPermissionReceiver"
+            android:directBootAware="true"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
@@ -117,6 +120,7 @@
         -->
         <service
             android:name=".alarm.alarmexecution.AlarmNotificationService"
+            android:directBootAware="true"
             android:exported="false"
             android:foregroundServiceType="systemExempted" />
     </application>

--- a/app/src/main/java/com/joebsource/lavalarm/core/receiver/TimeChangeReceiver.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/receiver/TimeChangeReceiver.kt
@@ -25,7 +25,11 @@ class TimeChangeReceiver : BroadcastReceiver() {
 
     private fun onTimeChanged(context: Context) {
         doAsync(context.alarmApplication.applicationScope, Dispatchers.Main) {
-            val alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(context.applicationContext).alarmDao())
+            val alarmRepository = AlarmRepository(
+                AlarmDatabase
+                    .getDatabase(context.createDeviceProtectedStorageContext())
+                    .alarmDao()
+            )
             AlarmScheduler.refreshAlarms(context, alarmRepository)
         }
     }

--- a/app/src/main/java/com/joebsource/lavalarm/core/ringtone/RingtonePlayer.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/core/ringtone/RingtonePlayer.kt
@@ -36,6 +36,22 @@ class RingtonePlayer {
         audioManager?.let { manager ->
             audioFocusRequest?.let { request ->
                 ringtone?.let { ring ->
+                    // Setting looping is only necessary when the RingtoneManager returns a default fallback Ringtone,
+                    // which happens when it can't find a Ringtone for the given URI. This happens when the Alarm goes off
+                    // after a device restart, when the User has a protected lock screen set up, BEFORE they unlock it for the first time.
+                    // I'm guessing this is due to the RingtoneManager not having access to the necessary files while in this state.
+                    // Note: In the above scenario, if the User unlocks their phone at least once, then re-locks it, the RingtoneManager
+                    // will be able to find the Ringtone, and will not need to return the fallback.
+                    //
+                    // The non-fallback Ringtones used by this app, which are of type RingtoneManager.TYPE_ALARM,
+                    // are already set to loop by default and therefore don't need to be set below.
+                    try {
+                        ring.isLooping = true
+                    } catch (_: Exception) {
+                        // Just don't crash, nothing else to do here
+                        // When I've seen Ringtone.setLooping() used, it was called in a try/catch like this.
+                        // Alarm execution is a critical part of the code so I'm not taking any chances.
+                    }
                     manager.requestAudioFocus(request)
 
                     // Ringtone.setStreamType() is deprecated. However, it is the only way to get


### PR DESCRIPTION
### Description
- Set `android:directBootAware="true"` on components in the `Manifest` that were missing it. `BootCompletedReceiver` and `FullScreenAlarmActivity` already had this, but other components didn't which was causing issues such as Alarms not going off in certain scenarios.
  - Ex: User restarts device, has a PIN protected lock screen, never unlocks device, Alarm gets rescheduled but never goes off because `AlarmActionReceiver` isn't direct boot aware.
  - Added to: `AlarmActionReceiver`, `TimeChangeReceiver`, `ScheduleExactAlarmPermissionReceiver`, `AlarmNotificationService`
    - `android:directBootAware="true"` seems like it might not be needed on `ScheduleExactAlarmPermissionReceiver`, but during testing I found that after disabling `android.permission.SCHEDULE_EXACT_ALARM` and restarting the emulator, `android.permission.SCHEDULE_EXACT_ALARM` was auto-regranted for some reason. I feel like this could be some weird emulator issue since emulators do weird stuff sometimes, and it just doesn't make sense to auto-regrant the permission. However, to err on the side of caution I decided to just go ahead and make `ScheduleExactAlarmPermissionReceiver` direct boot aware as well.
- Fix an issue specific to Alarms not going off in the scenario where `android:directBootAware="true"` is required. The issue was that the `RingtoneManager` is not able to return any of the device's "normal" `Ringtones` when in this specific state. Instead, `RingtoneManager` returns a default fallback `Ringtone`. Unlike the other `Ringtones`, the fallback isn't set to loop by default. Set looping to true for all `Ringtones` so that the fallback loops as well. Setting looping to true on the non-fallbacks is redundant, but it's just a single line of code, doesn't hurt anything, and is safer than trying to determine (if even possible) if a fallback was used.