### PR TITLE
Feature | Fix AlarmCreateEditScreen Focus

### DIFF
--- a/app/src/main/java/com/joebsource/lavalarm/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
+++ b/app/src/main/java/com/joebsource/lavalarm/alarm/ui/alarmcreateedit/AlarmCreateEditScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
@@ -143,8 +144,8 @@ fun AlarmCreateEditScreen(
     // State
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val focusManager = LocalFocusManager.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val scaffoldFocusRequester = remember { FocusRequester() }
     val upNavigationFocusRequester = remember { FocusRequester() }
     val saveFocusRequester = remember { FocusRequester() }
 
@@ -215,9 +216,7 @@ fun AlarmCreateEditScreen(
                 )
             )
             .windowInsetsPadding(WindowInsets.systemBars)
-            .clickable(interactionSource = null, indication = null) { scaffoldFocusRequester.requestFocus() }
-            .focusRequester(scaffoldFocusRequester)
-            .focusable()
+            .clickable(interactionSource = null, indication = null) { focusManager.clearFocus() }
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -539,9 +538,9 @@ fun AlertSettings(
     toggleVibration: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val focusManager = LocalFocusManager.current
     val ringtoneFocusRequester = remember { FocusRequester() }
     val vibrationRowFocusRequester = remember { FocusRequester() }
-    val vibrationSwitchFocusRequester = remember { FocusRequester() }
 
     Column(modifier = modifier) {
         // Alert Icon and Text
@@ -584,16 +583,13 @@ fun AlertSettings(
                 Switch(
                     checked = isVibrationEnabled,
                     onCheckedChange = {
-                        vibrationSwitchFocusRequester.requestFocus()
+                        focusManager.clearFocus()
                         toggleVibration()
                     },
                     colors = SwitchDefaults.colors(
                         checkedTrackColor = WayDarkerBoatSails,
                         uncheckedTrackColor = DarkVolcanicRock
-                    ),
-                    modifier = Modifier
-                        .focusRequester(vibrationSwitchFocusRequester)
-                        .focusable()
+                    )
                 )
             },
             modifier = Modifier


### PR DESCRIPTION
### Description
- Fix focus-related issue on `AlarmCreateEditScreen` where after clicking on certain UI elements, the User needed to press the system back button twice instead of once in order to navigate back to `CoreScreen`.
  - This was due to some focus-related changes implemented in https://github.com/Joe-Beaulieu-Dev/maritime-alarm/pull/87. All "clickable" UI elements on `AlarmCreateEditScreen` were made to request focus when clicked, including the screen's `Scaffold`. This was done to remove focus from the Alarm name `OutlinedTextField` whenever the User clicks outside of it (without this it just never loses focus, which is an undesirable default behavior). While this worked, it caused the "double back press" issue.
    - The fix was to remove the `Scaffold's` `focusRequestor()` and `focusable()` `Modifiers`, and replace its `onClick` call to `FocusRequester.requestFocus()` with `FocusManager.clearFocus()`. This also needed to be done with the Vibration `Switch` in the `AlertSettings` composable.