### PR TITLE
Feature | Time Change Reschedule

### DIFF
--- a/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
@@ -58,14 +58,12 @@ fun Alarm.isSnoozed(): Boolean =
 
 /**
  * Returns whether or not the Alarm is dirty. Dirty Alarms are those that have invalid configurations.
- * This can happen if the phone is off during a time in which an Alarm is scheduled to execute, or
- * after the device's time changes.
+ * This can happen, for example, if the phone is off during a time in which an Alarm is scheduled to execute.
  *
  * For repeating Alarms - Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled
- * 2) Alarm is not configured to go off in the future, OR Alarm is not configured to go off at the
- * next possible repeating LocalDateTime
- *    - Both of the above conditions take snooze into account
+ * 2) Alarm is not configured to go off in the future, taking snooze into account, OR Alarm is not
+ * configured to go off at the next possible repeating LocalDateTime
  *
  * For non-repeating Alarms - Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled
@@ -82,14 +80,12 @@ fun Alarm.isDirty(): Boolean =
 
 /**
  * Returns whether or not a repeating Alarm is dirty. Dirty repeating Alarms are those that have invalid configurations.
- * This can happen if the phone is off during a time in which an Alarm is scheduled to execute, or
- * after the device's time changes.
+ * This can happen, for example, if the phone is off during a time in which an Alarm is scheduled to execute.
  *
  * Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled
- * 2) Alarm is not configured to go off in the future, OR Alarm is not configured to go off at the
- * next possible repeating LocalDateTime
- *    - Both of the above conditions take snooze into account
+ * 2) Alarm is not configured to go off in the future, taking snooze into account, OR Alarm is not
+ * configured to go off at the next possible repeating LocalDateTime
  *
  * @return true if the Alarm is dirty, false otherwise
  */
@@ -109,7 +105,7 @@ private fun Alarm.isRepeatingDirty(): Boolean {
 
 /**
  * Returns whether or not a non-repeating Alarm is dirty. Dirty non-repeating Alarms are those that have invalid configurations.
- * This can happen if the phone is off during a time in which an Alarm is scheduled to execute.
+ * This can happen, for example, if the phone is off during a time in which an Alarm is scheduled to execute.
  *
  * Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled

--- a/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
@@ -63,7 +63,7 @@ fun Alarm.isSnoozed(): Boolean =
  *
  * For repeating Alarms - Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled
- * 2) Alarm is not configured to go off in the future, OR Alarm is configured to go off after the
+ * 2) Alarm is not configured to go off in the future, OR Alarm is not configured to go off at the
  * next possible repeating LocalDateTime
  *    - Both of the above conditions take snooze into account
  *
@@ -87,7 +87,7 @@ fun Alarm.isDirty(): Boolean =
  *
  * Returns true if, and only if, both of the following conditions are met:
  * 1) Alarm is enabled
- * 2) Alarm is not configured to go off in the future, OR Alarm is configured to go off after the
+ * 2) Alarm is not configured to go off in the future, OR Alarm is not configured to go off at the
  * next possible repeating LocalDateTime
  *    - Both of the above conditions take snooze into account
  *
@@ -101,9 +101,9 @@ private fun Alarm.isRepeatingDirty(): Boolean {
             // If it IS set in the future, is it set so far into
             // the future that it's beyond the next possible Alarm?
             if (isSnoozed()) {
-                snoozeDateTime?.isAfter(now) == false || snoozeDateTime?.isAfter(nextRepeatingDateTime) == true
+                snoozeDateTime?.isAfter(now) == false || dateTime != nextRepeatingDateTime
             } else {
-                !dateTime.isAfter(now) || dateTime.isAfter(nextRepeatingDateTime)
+                !dateTime.isAfter(now) || dateTime != nextRepeatingDateTime
             }
 }
 

--- a/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/extension/_Alarm.kt
@@ -58,6 +58,57 @@ fun Alarm.isSnoozed(): Boolean =
 
 /**
  * Returns whether or not the Alarm is dirty. Dirty Alarms are those that have invalid configurations.
+ * This can happen if the phone is off during a time in which an Alarm is scheduled to execute, or
+ * after the device's time changes.
+ *
+ * For repeating Alarms - Returns true if, and only if, both of the following conditions are met:
+ * 1) Alarm is enabled
+ * 2) Alarm is not configured to go off in the future, OR Alarm is configured to go off after the
+ * next possible repeating LocalDateTime
+ *    - Both of the above conditions take snooze into account
+ *
+ * For non-repeating Alarms - Returns true if, and only if, both of the following conditions are met:
+ * 1) Alarm is enabled
+ * 2) Alarm is not configured to go off in the future, taking snooze into account
+ *
+ * @return true if the Alarm is dirty, false otherwise
+ */
+fun Alarm.isDirty(): Boolean =
+    if (isRepeating()) {
+        isRepeatingDirty()
+    } else {
+        isNonRepeatingDirty()
+    }
+
+/**
+ * Returns whether or not a repeating Alarm is dirty. Dirty repeating Alarms are those that have invalid configurations.
+ * This can happen if the phone is off during a time in which an Alarm is scheduled to execute, or
+ * after the device's time changes.
+ *
+ * Returns true if, and only if, both of the following conditions are met:
+ * 1) Alarm is enabled
+ * 2) Alarm is not configured to go off in the future, OR Alarm is configured to go off after the
+ * next possible repeating LocalDateTime
+ *    - Both of the above conditions take snooze into account
+ *
+ * @return true if the Alarm is dirty, false otherwise
+ */
+private fun Alarm.isRepeatingDirty(): Boolean {
+    val now = LocalDateTimeUtil.nowTruncated()
+    val nextRepeatingDateTime = AlarmUtil.nextRepeatingDateTime(dateTime, weeklyRepeater)
+    return enabled &&
+            // Is the Alarm NOT set in the future?
+            // If it IS set in the future, is it set so far into
+            // the future that it's beyond the next possible Alarm?
+            if (isSnoozed()) {
+                snoozeDateTime?.isAfter(now) == false || snoozeDateTime?.isAfter(nextRepeatingDateTime) == true
+            } else {
+                !dateTime.isAfter(now) || dateTime.isAfter(nextRepeatingDateTime)
+            }
+}
+
+/**
+ * Returns whether or not a non-repeating Alarm is dirty. Dirty non-repeating Alarms are those that have invalid configurations.
  * This can happen if the phone is off during a time in which an Alarm is scheduled to execute.
  *
  * Returns true if, and only if, both of the following conditions are met:
@@ -66,7 +117,7 @@ fun Alarm.isSnoozed(): Boolean =
  *
  * @return true if the Alarm is dirty, false otherwise
  */
-fun Alarm.isDirty(): Boolean {
+private fun Alarm.isNonRepeatingDirty(): Boolean {
     val now = LocalDateTimeUtil.nowTruncated()
     return enabled &&
             if (isSnoozed()) {

--- a/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
+++ b/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
@@ -199,88 +199,6 @@ class _AlarmTest {
     }
 
     /*
-     * isDirty - Non-repeating Alarm
-     */
-
-    // Snoozed
-    @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndInPast() {
-        val alarm = snoozedBaseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.plusHours(1)
-            assertTrue(alarm.isDirty())
-        }
-    }
-
-    @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndIsNow() {
-        val alarm = snoozedBaseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!
-            assertTrue(alarm.isDirty())
-        }
-    }
-
-    @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndSnoozed_AndInFuture() {
-        val alarm = snoozedBaseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.minusHours(1)
-            assertFalse(alarm.isDirty())
-        }
-    }
-
-    // Not Snoozed
-    @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndInPast() {
-        val alarm = baseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.plusHours(1)
-            assertTrue(alarm.isDirty())
-        }
-    }
-
-    @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndIsNow() {
-        val alarm = baseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime
-            assertTrue(alarm.isDirty())
-        }
-    }
-
-    @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndNotSnoozed_AndInFuture() {
-        val alarm = baseAlarmNonRepeating
-
-        mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
-            assertFalse(alarm.isDirty())
-        }
-    }
-
-    @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsDisabled_AndSnoozedOrNotSnoozed_AndInFuture() {
-        val snoozedAlarm = snoozedBaseAlarmNonRepeating.copy(enabled = false)
-        val alarm = baseAlarmNonRepeating.copy(enabled = false)
-
-        mockkObject(LocalDateTimeUtil) {
-            // Snoozed
-            every { LocalDateTimeUtil.nowTruncated() } returns snoozedAlarm.snoozeDateTime!!.minusHours(1)
-            assertFalse(snoozedAlarm.isDirty())
-
-            // Not snoozed
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
-            assertFalse(alarm.isDirty())
-        }
-    }
-
-    /*
      * isDirty - Repeating Alarm
      */
 
@@ -501,6 +419,88 @@ class _AlarmTest {
                 every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
                 assertFalse(alarm.isDirty())
             }
+        }
+    }
+
+    /*
+     * isDirty - Non-repeating Alarm
+     */
+
+    // Snoozed
+    @Test
+    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndInPast() {
+        val alarm = snoozedBaseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.plusHours(1)
+            assertTrue(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndIsNow() {
+        val alarm = snoozedBaseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!
+            assertTrue(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndSnoozed_AndInFuture() {
+        val alarm = snoozedBaseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.minusHours(1)
+            assertFalse(alarm.isDirty())
+        }
+    }
+
+    // Not Snoozed
+    @Test
+    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndInPast() {
+        val alarm = baseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.plusHours(1)
+            assertTrue(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndIsNow() {
+        val alarm = baseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime
+            assertTrue(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndNotSnoozed_AndInFuture() {
+        val alarm = baseAlarmNonRepeating
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
+            assertFalse(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_WhenAlarmIsDisabled_AndSnoozedOrNotSnoozed_AndInFuture() {
+        val snoozedAlarm = snoozedBaseAlarmNonRepeating.copy(enabled = false)
+        val alarm = baseAlarmNonRepeating.copy(enabled = false)
+
+        mockkObject(LocalDateTimeUtil) {
+            // Snoozed
+            every { LocalDateTimeUtil.nowTruncated() } returns snoozedAlarm.snoozeDateTime!!.minusHours(1)
+            assertFalse(snoozedAlarm.isDirty())
+
+            // Not snoozed
+            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
+            assertFalse(alarm.isDirty())
         }
     }
 

--- a/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
+++ b/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
@@ -36,6 +36,9 @@ class _AlarmTest {
     private val snoozedBaseAlarmNonRepeating = baseAlarmNonRepeating.copy(
         snoozeDateTime = baseAlarmNonRepeating.dateTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
     )
+    private val arbitraryWeeklyRepeater = WeeklyRepeater()
+        .withDay(WeeklyRepeater.Day.WEDNESDAY)
+        .withDay(WeeklyRepeater.Day.THURSDAY)
 
     /*
      * toAlarmExecutionData
@@ -196,9 +199,10 @@ class _AlarmTest {
     }
 
     /*
-     * isDirty
+     * isDirty - Non-repeating Alarm
      */
 
+    // Snoozed
     @Test
     fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndInPast() {
         val alarm = snoozedBaseAlarmNonRepeating
@@ -229,6 +233,7 @@ class _AlarmTest {
         }
     }
 
+    // Not Snoozed
     @Test
     fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndInPast() {
         val alarm = baseAlarmNonRepeating
@@ -272,6 +277,230 @@ class _AlarmTest {
             // Not snoozed
             every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
             assertFalse(alarm.isDirty())
+        }
+    }
+
+    /*
+     * isDirty - Repeating Alarm
+     */
+
+    // Snoozed
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInPast() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.minusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndIsNow() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.minusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndIsBeforeNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime.plusDays(1)
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndAfterNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.plusDays(1).plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime.minusDays(1)
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_RepeatingAlarm_IsDisabled_AndSnoozed() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            enabled = false,
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertFalse(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndEqualsNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarmTime = now.plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong()),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertFalse(alarm.isDirty())
+            }
+        }
+    }
+
+    // Not Snoozed
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInPast() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = now.minusHours(1),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndIsNow() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = now,
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndIsBeforeNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = now.plusHours(1),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime.plusDays(1)
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndAfterNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = now.plusDays(1).plusHours(1),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime.minusDays(1)
+                assertTrue(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_RepeatingAlarm_IsDisabled_AndNotSnoozed() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            enabled = false,
+            dateTime = now.plusHours(1),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertFalse(alarm.isDirty())
+            }
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndEqualsNextRepeating() {
+        val now = LocalDateTimeUtil.nowTruncated()
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = now.plusHours(1),
+            weeklyRepeater = arbitraryWeeklyRepeater
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            mockkObject(AlarmUtil) {
+                every { AlarmUtil.nextRepeatingDateTime(any(), any()) } returns alarm.dateTime
+                assertFalse(alarm.isDirty())
+            }
         }
     }
 

--- a/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
+++ b/app/src/test/java/com/octrobi/lavalarm/core/extension/_AlarmTest.kt
@@ -21,20 +21,20 @@ import java.time.LocalDateTime
 @Suppress("ClassName")
 class _AlarmTest {
 
+    // General
+    private val now = LocalDateTimeUtil.nowTruncated()
+
     // Alarm
     private val baseAlarmNonRepeating = Alarm(
         id = 1,
         name = "name",
         enabled = true,
-        dateTime = LocalDateTime.now(),
+        dateTime = now,
         weeklyRepeater = WeeklyRepeater(),
         ringtoneUri = "ringtoneUri",
         isVibrationEnabled = false,
         snoozeDateTime = null,
         snoozeDuration = 10
-    )
-    private val snoozedBaseAlarmNonRepeating = baseAlarmNonRepeating.copy(
-        snoozeDateTime = baseAlarmNonRepeating.dateTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
     )
     private val arbitraryWeeklyRepeater = WeeklyRepeater()
         .withDay(WeeklyRepeater.Day.WEDNESDAY)
@@ -64,7 +64,9 @@ class _AlarmTest {
 
     @Test
     fun toAlarmExecutionData_ProperlyCreates_AlarmExecutionData_WhenAlarmIsSnoozed() {
-        val alarm = snoozedBaseAlarmNonRepeating
+        val alarm = baseAlarmNonRepeating.copy(
+            snoozeDateTime = baseAlarmNonRepeating.dateTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
         val expectedAlarmExecutionData = AlarmExecutionData(
             id = alarm.id,
             name = alarm.name,
@@ -190,7 +192,10 @@ class _AlarmTest {
 
     @Test
     fun isSnoozed_ReturnsTrue_WhenAlarmIsSnoozed() {
-        assertTrue(snoozedBaseAlarmNonRepeating.isSnoozed())
+        val alarm = baseAlarmNonRepeating.copy(
+            snoozeDateTime = baseAlarmNonRepeating.dateTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
+        assertTrue(alarm.isSnoozed())
     }
 
     @Test
@@ -205,7 +210,6 @@ class _AlarmTest {
     // Snoozed
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInPast() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.minusHours(1)
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = alarmTime,
@@ -224,7 +228,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndIsNow() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.minusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = alarmTime,
@@ -243,7 +246,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndIsBeforeNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.plusHours(1)
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = alarmTime,
@@ -262,7 +264,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndAfterNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.plusDays(1).plusHours(1)
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = alarmTime,
@@ -281,7 +282,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsFalse_RepeatingAlarm_IsDisabled_AndSnoozed() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.plusHours(1)
         val alarm = baseAlarmNonRepeating.copy(
             enabled = false,
@@ -301,7 +301,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsFalse_RepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture_AndEqualsNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarmTime = now.plusHours(1)
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = alarmTime,
@@ -321,7 +320,6 @@ class _AlarmTest {
     // Not Snoozed
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInPast() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = now.minusHours(1),
             weeklyRepeater = arbitraryWeeklyRepeater
@@ -338,7 +336,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndIsNow() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = now,
             weeklyRepeater = arbitraryWeeklyRepeater
@@ -355,7 +352,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndIsBeforeNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = now.plusHours(1),
             weeklyRepeater = arbitraryWeeklyRepeater
@@ -372,7 +368,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsTrue_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndAfterNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = now.plusDays(1).plusHours(1),
             weeklyRepeater = arbitraryWeeklyRepeater
@@ -389,7 +384,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsFalse_RepeatingAlarm_IsDisabled_AndNotSnoozed() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             enabled = false,
             dateTime = now.plusHours(1),
@@ -407,7 +401,6 @@ class _AlarmTest {
 
     @Test
     fun isDirty_ReturnsFalse_RepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture_AndEqualsNextRepeating() {
-        val now = LocalDateTimeUtil.nowTruncated()
         val alarm = baseAlarmNonRepeating.copy(
             dateTime = now.plusHours(1),
             weeklyRepeater = arbitraryWeeklyRepeater
@@ -428,78 +421,102 @@ class _AlarmTest {
 
     // Snoozed
     @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndInPast() {
-        val alarm = snoozedBaseAlarmNonRepeating
+    fun isDirty_ReturnsTrue_NonRepeatingAlarm_IsEnabled_AndSnoozed_AndInPast() {
+        val alarmTime = now.minusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.plusHours(1)
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertTrue(alarm.isDirty())
         }
     }
 
     @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndSnoozed_AndIsNow() {
-        val alarm = snoozedBaseAlarmNonRepeating
+    fun isDirty_ReturnsTrue_NonRepeatingAlarm_IsEnabled_AndSnoozed_AndIsNow() {
+        val alarmTime = now.minusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertTrue(alarm.isDirty())
         }
     }
 
     @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndSnoozed_AndInFuture() {
-        val alarm = snoozedBaseAlarmNonRepeating
+    fun isDirty_ReturnsFalse_NonRepeatingAlarm_IsDisabled_AndSnoozed() {
+        val alarmTime = now.plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            enabled = false,
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.snoozeDateTime!!.minusHours(1)
+            every { LocalDateTimeUtil.nowTruncated() } returns now
+            assertFalse(alarm.isDirty())
+        }
+    }
+
+    @Test
+    fun isDirty_ReturnsFalse_NonRepeatingAlarm_IsEnabled_AndSnoozed_AndInFuture() {
+        val alarmTime = now.plusHours(1)
+        val alarm = baseAlarmNonRepeating.copy(
+            dateTime = alarmTime,
+            snoozeDateTime = alarmTime.plusMinutes(baseAlarmNonRepeating.snoozeDuration.toLong())
+        )
+
+        mockkObject(LocalDateTimeUtil) {
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertFalse(alarm.isDirty())
         }
     }
 
     // Not Snoozed
     @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndInPast() {
-        val alarm = baseAlarmNonRepeating
+    fun isDirty_ReturnsTrue_NonRepeatingAlarm_IsEnabled_AndNotSnoozed_AndInPast() {
+        val alarm = baseAlarmNonRepeating.copy(dateTime = now.minusHours(1))
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.plusHours(1)
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertTrue(alarm.isDirty())
         }
     }
 
     @Test
-    fun isDirty_ReturnsTrue_WhenAlarmIsEnabled_AndNotSnoozed_AndIsNow() {
-        val alarm = baseAlarmNonRepeating
+    fun isDirty_ReturnsTrue_NonRepeatingAlarm_IsEnabled_AndNotSnoozed_AndIsNow() {
+        val alarm = baseAlarmNonRepeating.copy(dateTime = now)
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertTrue(alarm.isDirty())
         }
     }
 
     @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsEnabled_AndNotSnoozed_AndInFuture() {
-        val alarm = baseAlarmNonRepeating
+    fun isDirty_ReturnsFalse_NonRepeatingAlarm_IsDisabled_AndNotSnoozed() {
+        val alarm = baseAlarmNonRepeating.copy(
+            enabled = false,
+            dateTime = now.plusHours(1)
+        )
 
         mockkObject(LocalDateTimeUtil) {
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertFalse(alarm.isDirty())
         }
     }
 
     @Test
-    fun isDirty_ReturnsFalse_WhenAlarmIsDisabled_AndSnoozedOrNotSnoozed_AndInFuture() {
-        val snoozedAlarm = snoozedBaseAlarmNonRepeating.copy(enabled = false)
-        val alarm = baseAlarmNonRepeating.copy(enabled = false)
+    fun isDirty_ReturnsFalse_NonRepeatingAlarm_IsEnabled_AndNotSnoozed_AndInFuture() {
+        val alarm = baseAlarmNonRepeating.copy(dateTime = now.plusHours(1))
 
         mockkObject(LocalDateTimeUtil) {
-            // Snoozed
-            every { LocalDateTimeUtil.nowTruncated() } returns snoozedAlarm.snoozeDateTime!!.minusHours(1)
-            assertFalse(snoozedAlarm.isDirty())
-
-            // Not snoozed
-            every { LocalDateTimeUtil.nowTruncated() } returns alarm.dateTime.minusHours(1)
+            every { LocalDateTimeUtil.nowTruncated() } returns now
             assertFalse(alarm.isDirty())
         }
     }


### PR DESCRIPTION
### Description
- Modify underlying functionality of `_Alarm.isDirty()` to consider repeating Alarms dirty if their current execution time is not equal to the next possible execution time.
  - Ex: A repeating Alarm that's set to repeat every day is scheduled to go off in 2 days, however, the next valid time for it to go off would actually be tomorrow.
    - In this scenario, based on how other functions use `_Alarm.isDirty()`, for example in `TimeChangeReceiver.onTimeChanged()`, the Alarm would be rescheduled for tomorrow. This is because repeating Alarms should always be scheduled to go off at the very next time it's valid for them to execute.
    - This can happen with edge case time zone changes, etc.