### PR TITLE
Feature | Force Stop Recovery

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.androidxRoom)
     alias(libs.plugins.jetbrainsKotlinAndroid)
+    alias(libs.plugins.kotlinParcelize)
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.composeCompiler)

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmRefreshReceiver.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmRefreshReceiver.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
+import com.octrobi.lavalarm.core.constant.actionPackageName
 import com.octrobi.lavalarm.core.extension.alarmApplication
 import com.octrobi.lavalarm.core.extension.doAsync
 import kotlinx.coroutines.Dispatchers
@@ -18,9 +19,17 @@ import kotlinx.coroutines.Dispatchers
  */
 class AlarmRefreshReceiver : BroadcastReceiver() {
 
+    companion object {
+        // Actions
+        // This should only be used on APIs < 35
+        const val ACTION_FORCE_STOP_RECOVERY_PRE_API_35 = "${actionPackageName}FORCE_STOP_RECOVERY_PRE_API_35"
+    }
+
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
             when (intent.action) {
+                ACTION_FORCE_STOP_RECOVERY_PRE_API_35,
+                // Handles both device boot (all APIs), and Force Stop Recovery (APIs >= 35)
                 Intent.ACTION_LOCKED_BOOT_COMPLETED,
                 Intent.ACTION_TIME_CHANGED,
                 Intent.ACTION_DATE_CHANGED,

--- a/app/src/main/java/com/octrobi/lavalarm/core/MainActivity.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/MainActivity.kt
@@ -1,23 +1,42 @@
 package com.octrobi.lavalarm.core
 
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.octrobi.lavalarm.core.navigation.TopLevelNavHost
+import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryState
 import com.octrobi.lavalarm.core.ui.theme.AndroidDefaultDarkScrim
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+
+    private val viewModel by viewModels<MainActivityViewModel> {
+        MainActivityViewModel.provideFactory()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         // Create and display Splash Screen and auto switch from
         // Splash Screen theme to general app theme afterwards
         installSplashScreen()
         super.onCreate(savedInstanceState)
+
+        // Handle any potential Force Stop Recovery on APIs < 35.
+        // APIs >= 35 have different behavior when recovering from a Forced Stop state
+        // and are handled in AlarmRefreshReceiver, reacting to Intent.ACTION_LOCKED_BOOT_COMPLETED.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            handleForceStopRecoveryPreApi35()
+        }
 
         // Enable edge to edge for dynamic Status Bar coloring
         enableEdgeToEdge(
@@ -30,5 +49,22 @@ class MainActivity : ComponentActivity() {
                 TopLevelNavHost()
             }
         }
+    }
+
+    fun handleForceStopRecoveryPreApi35() {
+        // Listen for and react to MainActivityViewModel's determination
+        // as to whether or not Force Stop Recovery is needed.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                viewModel.shouldPerformForceStopRecovery.collect { forceStopRecoveryState ->
+                    if (forceStopRecoveryState is ForceStopRecoveryState.ShouldPerformRecovery) {
+                        viewModel.performForceStopRecoveryPreApi35(this@MainActivity)
+                    }
+                }
+            }
+        }
+
+        // Determine whether Force Stop Recovery is needed
+        viewModel.checkForceStopPreApi35(this)
     }
 }

--- a/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
+import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryHandler
 import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryState
 import kotlinx.coroutines.flow.StateFlow
@@ -37,14 +39,21 @@ class MainActivityViewModel(private val savedStateHandle: SavedStateHandle) : Vi
     fun checkForceStopPreApi35(context: Context) {
         if (shouldPerformForceStopRecovery.value is ForceStopRecoveryState.Unchecked) {
             viewModelScope.launch {
+                val alarmRepository = AlarmRepository(
+                    AlarmDatabase
+                        .getDatabase(context.createDeviceProtectedStorageContext())
+                        .alarmDao()
+                )
+
                 val shouldPerformRecovery =
-                    if (ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context)) {
+                    ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+
+                savedStateHandle[KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY] =
+                    if (shouldPerformRecovery) {
                         ForceStopRecoveryState.ShouldPerformRecovery
                     } else {
                         ForceStopRecoveryState.ShouldNotPerformRecovery
                     }
-
-                savedStateHandle[KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY] = shouldPerformRecovery
             }
         }
     }

--- a/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
@@ -1,0 +1,59 @@
+package com.octrobi.lavalarm.core
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryHandler
+import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryState
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class MainActivityViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    val shouldPerformForceStopRecovery: StateFlow<ForceStopRecoveryState> =
+        savedStateHandle.getStateFlow(
+            KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY,
+            ForceStopRecoveryState.Unchecked
+        )
+
+    companion object {
+
+        // SavedStateHandle Keys
+        private const val KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY = "should_perform_force_stop_recovery"
+
+        fun provideFactory(): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    MainActivityViewModel(savedStateHandle = createSavedStateHandle())
+                }
+            }
+    }
+
+    fun checkForceStopPreApi35(context: Context) {
+        if (shouldPerformForceStopRecovery.value is ForceStopRecoveryState.Unchecked) {
+            viewModelScope.launch {
+                val shouldPerformRecovery =
+                    if (ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context)) {
+                        ForceStopRecoveryState.ShouldPerformRecovery
+                    } else {
+                        ForceStopRecoveryState.ShouldNotPerformRecovery
+                    }
+
+                savedStateHandle[KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY] = shouldPerformRecovery
+            }
+        }
+    }
+
+    fun performForceStopRecoveryPreApi35(context: Context) {
+        // Perform Force Stop Recovery
+        ForceStopRecoveryHandler.performForceStopRecoveryPreApi35(context)
+
+        // Prevent multiple recoveries
+        savedStateHandle[KEY_SHOULD_PERFORM_FORCE_STOP_RECOVERY] = ForceStopRecoveryState.RecoveryPerformed
+    }
+}

--- a/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandler.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandler.kt
@@ -1,0 +1,116 @@
+package com.octrobi.lavalarm.core.recovery
+
+import android.app.AlarmManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.octrobi.lavalarm.alarm.alarmexecution.AlarmRefreshReceiver
+import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
+import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
+
+object ForceStopRecoveryHandler {
+
+    /**
+     * Do not call with APIs >= 35. Indirectly determine if it was possible that the app was in a
+     * Package Stopped state (Force Stopped) prior to the current run, and return whether or not
+     * we should perform recovery operations.
+     *
+     * This function is only needed on APIs < 35 since direct methods of detecting a Force Stop were
+     * not added until API 35. Unfortunately on APIs < 35 since there is no direct way to tell, it must be inferred.
+     * This function gives a best guess, and defaults to true in scenarios where it is impossible to tell if
+     * the app may have been Force Stopped. Therefore, although it detects indirectly, it is still reliable
+     * since there will be no false negatives because it defaults to true in any scenario where a false
+     * negative may occur.
+     *
+     * Detection is performed by taking advantage of the fact that this app schedules Alarms with
+     * AlarmManger.setAlarmClock(), and you can see the very next Alarm scheduled this way via
+     * AlarmManager.getNextAlarmClock(). Furthermore, you can see which app scheduled the Alarm that's
+     * returned by calling AlarmManager.getNextAlarmClock()?.getShowIntent()?.getCreatorPackage(). This is
+     * necessary since AlarmManager.getNextAlarmClock() will return AlarmClockInfo for the next Alarm even
+     * if it's not from your app. If the function returns null, then there's no Alarms scheduled with
+     * AlarmManger.setAlarmClock(). After checking the AlarmClockInfo we check if there's any enabled Alarms
+     * in the database to make a determination as to whether or not a Force Stop may have occurred and if
+     * recovery is necessary. Below is a breakdown of scenarios to illustrate the logic behind this function:
+     *
+     * Device is running an API < 35
+     *   1) AlarmClockInfo is from a different app
+     *     - There is no way to tell if the app was Force Stopped. Check the database for any enabled Alarms.
+     *       - If there are enabled Alarms in the database, return true. The app MAY have been Force Stopped,
+     *         and since the database has enabled Alarms we should refresh them to ensure reliability.
+     *       - If there are no enabled Alarms in the database, return false. The app MAY have been Force
+     *         Stopped, but since the database has no enabled Alarms we have nothing to refresh.
+     *   2) AlarmClockInfo is from this app
+     *     - The app was definitely not Force Stopped, return false. Force Stopping an app clears all of its
+     *       Alarm data with AlarmManager, so the fact that we have an Alarm scheduled shows that no Force Stop
+     *       occurred. Because of this, checking the database for enabled Alarms is unnecessary.
+     *   3) AlarmClockInfo is null
+     *     - There is no way to tell if the app was Force Stopped. Treat this the same as Scenario 1 where
+     *       the AlarmClockInfo is from another app.
+     *
+     * Device is running an API >= 35
+     *  1) This function is not needed and returns true by default to err on the side of caution. Force Stop Recovery
+     *     is handled directly in AlarmRefreshReceiver on APIs >= 35. This is because starting with API 35, the system
+     *     will send Intent.ACTION_LOCKED_BOOT_COMPLETED and Intent.ACTION_BOOT_COMPLETED (although the documentation
+     *     only mentions Intent.ACTION_BOOT_COMPLETED). This is somewhat unfortunate as these Intent actions are both
+     *     already used in other scenarios, so reusing them makes them ambiguous. However, since this app performs the
+     *     same action (Alarm refresh) on both device boot and Force Stop Recovery, this is fine. Furthermore, API 35
+     *     also introduced ApplicationStartInfo.wasForceStopped() so you can query for Force Stops on demand, rather
+     *     than reacting to an Intent action.
+     *
+     * For details on the new Force Stop Recovery options and behavior introduced in API 35, see:
+     *   - https://developer.android.com/about/versions/15/behavior-changes-all#enhanced-stop-states
+     *
+     * @param context used to perform various functions related to the System
+     *
+     * @return true if the app may have been previously Force Stopped and needs recovery, false if otherwise.
+     *         Defaults to true if called on APIs >= 35 to err on the side of caution. Do not call on APIs >= 35.
+     */
+    suspend fun shouldPerformForceStopRecoveryPreApi35(context: Context): Boolean =
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            val alarmManager = context.getSystemService(AlarmManager::class.java)
+            val nextAlarmCreator = alarmManager.nextAlarmClock?.showIntent?.creatorPackage
+            val myPackageName = context.packageName
+
+            if (nextAlarmCreator != myPackageName) {
+                // Either their are no "Alarm Clock" Alarms scheduled with AlarmManager, or the next "Alarm Clock"
+                // Alarm is from another app. Check to see if there's any enabled Alarms in the database. If so, then
+                // this is an indication that the app MIGHT have been Forced Stopped. Return true to err on the side
+                // of caution in order to ensure reliability. If there's no enabled Alarms in the database, then it's
+                // still possible the app MIGHT have been Force Stopped, but if there's no enabled Alarms in the database
+                // then there's nothing to refresh so just return false. Returning false in this scenario is desired
+                // as this function is utilized to determine whether or not action needs to be taken in the form of an
+                // Alarm refresh.
+                val alarmRepository = AlarmRepository(
+                    AlarmDatabase
+                        .getDatabase(context.createDeviceProtectedStorageContext())
+                        .alarmDao()
+                )
+                alarmRepository.getAllEnabledAlarms().isNotEmpty()
+            } else {
+                // The next upcoming Alarm scheduled with AlarmManager is from this app,
+                // therefore it was not Force Stopped.
+                false
+            }
+        } else {
+            // This function should not be used on APIs >= 35.
+            // On APIs >= 35, Force Stop Recovery is handled directly in AlarmRefreshReceiver
+            // in response to receiving Intent.ACTION_LOCKED_BOOT_COMPLETED.
+            // On APIs < 35 however, this Intent action has nothing to do with Force Stop Recovery.
+            // Since Force Stop Recovery is handled elsewhere on APIs >= 35, return true here because
+            // this function should always default to true in order to ensure reliability.
+            true
+        }
+
+    /**
+     * Perform any recovery operation necessary after a Force Stop.
+     *
+     * @param context used to perform various functions related to the System
+     */
+    fun performForceStopRecoveryPreApi35(context: Context) {
+        context.sendBroadcast(
+            Intent(context, AlarmRefreshReceiver::class.java).apply {
+                action = AlarmRefreshReceiver.ACTION_FORCE_STOP_RECOVERY_PRE_API_35
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandler.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandler.kt
@@ -5,9 +5,24 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import com.octrobi.lavalarm.alarm.alarmexecution.AlarmRefreshReceiver
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
+import com.octrobi.lavalarm.core.util.BuildVersionUtil
 
+/**
+ * Detect and handle Force Stops on APIs < 35.
+ *
+ * Since Force Stops cannot be detected in real time, they are dealt with the first
+ * time the User launches the app following a Force Stop (Force Stop Recovery).
+ * Due to the limitations of Android, Force Stops cannot be directly detected on
+ * APIs < 35, so custom indirect methods must be created.
+ *
+ * On APIs >= 35, Force Stop Recovery is handled directly in AlarmRefreshReceiver
+ * by reacting to Intent.ACTION_LOCKED_BOOT_COMPLETED, which is broadcast on
+ * APIs >= 35 when the User launches an app for the first time after it was Force Stopped.
+ *
+ * For details on the new Force Stop Recovery options and behavior introduced in API 35, see:
+ *   - https://developer.android.com/about/versions/15/behavior-changes-all#enhanced-stop-states
+ */
 object ForceStopRecoveryHandler {
 
     /**
@@ -65,8 +80,11 @@ object ForceStopRecoveryHandler {
      * @return true if the app may have been previously Force Stopped and needs recovery, false if otherwise.
      *         Defaults to true if called on APIs >= 35 to err on the side of caution. Do not call on APIs >= 35.
      */
-    suspend fun shouldPerformForceStopRecoveryPreApi35(context: Context): Boolean =
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+    suspend fun shouldPerformForceStopRecoveryPreApi35(
+        context: Context,
+        alarmRepository: AlarmRepository
+    ): Boolean =
+        if (BuildVersionUtil.getCurrentSkdInt() < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             val alarmManager = context.getSystemService(AlarmManager::class.java)
             val nextAlarmCreator = alarmManager.nextAlarmClock?.showIntent?.creatorPackage
             val myPackageName = context.packageName
@@ -80,11 +98,6 @@ object ForceStopRecoveryHandler {
                 // then there's nothing to refresh so just return false. Returning false in this scenario is desired
                 // as this function is utilized to determine whether or not action needs to be taken in the form of an
                 // Alarm refresh.
-                val alarmRepository = AlarmRepository(
-                    AlarmDatabase
-                        .getDatabase(context.createDeviceProtectedStorageContext())
-                        .alarmDao()
-                )
                 alarmRepository.getAllEnabledAlarms().isNotEmpty()
             } else {
                 // The next upcoming Alarm scheduled with AlarmManager is from this app,

--- a/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryState.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryState.kt
@@ -1,0 +1,12 @@
+package com.octrobi.lavalarm.core.recovery
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed interface ForceStopRecoveryState : Parcelable {
+    data object Unchecked : ForceStopRecoveryState
+    data object ShouldPerformRecovery : ForceStopRecoveryState
+    data object ShouldNotPerformRecovery : ForceStopRecoveryState
+    data object RecoveryPerformed : ForceStopRecoveryState
+}

--- a/app/src/main/java/com/octrobi/lavalarm/core/util/BuildVersionUtil.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/util/BuildVersionUtil.kt
@@ -1,0 +1,9 @@
+package com.octrobi.lavalarm.core.util
+
+import android.os.Build
+
+object BuildVersionUtil {
+
+    fun getCurrentSkdInt() =
+        Build.VERSION.SDK_INT
+}

--- a/app/src/test/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandlerTest.kt
+++ b/app/src/test/java/com/octrobi/lavalarm/core/recovery/ForceStopRecoveryHandlerTest.kt
@@ -1,0 +1,287 @@
+package com.octrobi.lavalarm.core.recovery
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.octrobi.lavalarm.alarm.alarmexecution.AlarmRefreshReceiver
+import com.octrobi.lavalarm.alarm.data.model.Alarm
+import com.octrobi.lavalarm.alarm.data.model.WeeklyRepeater
+import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
+import com.octrobi.lavalarm.core.extension.LocalDateTimeUtil
+import com.octrobi.lavalarm.core.util.BuildVersionUtil
+import io.mockk.EqMatcher
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForceStopRecoveryHandlerTest {
+
+    // Alarm
+    private val enabledAlarm = Alarm(
+        id = 1,
+        name = "name",
+        enabled = true,
+        dateTime = LocalDateTimeUtil.nowTruncated(),
+        weeklyRepeater = WeeklyRepeater(),
+        ringtoneUri = "ringtoneUri",
+        isVibrationEnabled = false,
+        snoozeDateTime = null,
+        snoozeDuration = 10
+    )
+    private val enabledAlarmList: List<Alarm> = listOf(enabledAlarm)
+
+    /*
+     * shouldPerformForceStopRecoveryPreApi35
+     */
+
+    // Next Alarm different app
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsTrue_nextAlarmFromDifferentApp_enabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val otherPackageName = "other.package"
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns otherPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns enabledAlarmList
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertTrue(shouldPerformRecovery)
+        }
+    }
+
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsFalse_nextAlarmFromDifferentApp_noEnabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val otherPackageName = "other.package"
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns otherPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns emptyList()
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertFalse(shouldPerformRecovery)
+        }
+    }
+
+    // Next Alarm null
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsTrue_nextAlarmNull_enabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val otherPackageName = null
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns otherPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns enabledAlarmList
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertTrue(shouldPerformRecovery)
+        }
+    }
+
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsFalse_nextAlarmNull_noEnabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val otherPackageName = null
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns otherPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns emptyList()
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertFalse(shouldPerformRecovery)
+        }
+    }
+
+    // Next Alarm this app
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsFalse_nextAlarmFromThisApp_enabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns myPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns enabledAlarmList
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertFalse(shouldPerformRecovery)
+        }
+    }
+
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsFalse_nextAlarmFromThisApp_noEnabledAlarmsInDb() = runTest {
+        // Arrange
+        val myPackageName = "my.package"
+        val pendingIntent = mockk<PendingIntent> {
+            every { creatorPackage } returns myPackageName
+        }
+        val alarmClockInfo = mockk<AlarmManager.AlarmClockInfo> {
+            every { showIntent } returns pendingIntent
+        }
+        val alarmManager = mockk<AlarmManager> {
+            every { nextAlarmClock } returns alarmClockInfo
+        }
+        val context = mockk<Context> {
+            every { getSystemService(AlarmManager::class.java) } returns alarmManager
+            every { packageName } returns myPackageName
+        }
+        val alarmRepository = mockk<AlarmRepository> {
+            coEvery { getAllEnabledAlarms() } returns emptyList()
+        }
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt() } returns Build.VERSION_CODES.VANILLA_ICE_CREAM - 1
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertFalse(shouldPerformRecovery)
+        }
+    }
+
+    // Device running API >= 35
+    @Test
+    fun shouldPerformForceStopRecoveryPreApi35_returnsTrue_ApiLevelAbove34() = runTest {
+        // Arrange
+        val context = mockk<Context>()
+        val alarmRepository = mockk<AlarmRepository>()
+
+        // Act & Assert
+        mockkObject(BuildVersionUtil) {
+            every { BuildVersionUtil.getCurrentSkdInt()} returns Build.VERSION_CODES.VANILLA_ICE_CREAM
+
+            val shouldPerformRecovery = ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
+            assertTrue(shouldPerformRecovery)
+        }
+    }
+
+    /*
+     * performForceStopRecoveryPreApi35
+     */
+
+    @Test
+    fun performForceStopRecoveryPreApi35_sendsBroadcastWithProperArgs() {
+        // Arrange
+        val actionSlot = slot<String>()
+        val context = mockk<Context> {
+            every { sendBroadcast(any()) } just Runs
+        }
+
+        // Act & Assert
+        mockkConstructor(Intent::class) {
+            // This function is mocked only for Intents constructed with the specific parameters
+            // that we expect in the production code. This is done so we can tell if the Intent
+            // was constructed in the way we expect. If it were not constructed with AlarmRefreshReceiver::class.java
+            // for example, then setAction() would not be mocked, and the test would fail.
+            //
+            // Furthermore, the return value here is just a generic mock.
+            // Normally, this function would return "this", but there's no way to
+            // directly access the mock created by mockkConstructor() here, but we
+            // still have to return something. This is fine for this test because the
+            // production code under test here does not use the return value of setAction().
+            every {
+                constructedWith<Intent>(
+                    EqMatcher(context),
+                    EqMatcher(AlarmRefreshReceiver::class.java)
+                ).setAction(capture(actionSlot))
+            } returns mockk<Intent>()
+
+            ForceStopRecoveryHandler.performForceStopRecoveryPreApi35(context)
+            assertEquals(AlarmRefreshReceiver.ACTION_FORCE_STOP_RECOVERY_PRE_API_35, actionSlot.captured)
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidxRoom) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
+    alias(libs.plugins.kotlinParcelize) apply false
     alias(libs.plugins.kotlinxSerialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.composeCompiler) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,5 +64,6 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidxRoom = { id = "androidx.room", version.ref = "room" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
### Description
- Implement Force Stop Recovery operations for devices running an `API < 35`
  - When the User Force Stops an app, all of its Alarms with `AlarmManager` are cleared (other things happen as well). The app cannot leave this Force Stopped state until the User explicitly launches the app again (ex: pressing the launcher icon). When the app is first launched after being Force Stopped (Force Stop Recovery) it may be in an invalid state with Alarms that are still enabled in the database that are stale because they were never launched due to the Force Stop. Because of this, we need to refresh the Alarms in the database, and potentially reschedule them with the `AlarmManager` if necessary.
  - On `APIs < 35`, it is impossible to determine whether or not the User Force Stopped the application. I've come up with a method to do this that takes advantage of `AlarmManager.getNextAlarmClock()`, and also checks the Alarm database for any enabled Alarms, to determine whether a Force Stop may have happened, and if Force Stop Recovery operations are necessary. This method is implemented in such a way that there will be no false negatives. See the KDocs in `ForceStopRecoveryHandler.kt` below for more details.
  - Starting with `API 35`, the system will broadcast `Intent.ACTION_BOOT_COMPLETED` and `Intent.ACTION_LOCKED_BOOT_COMPLETED` on the first app launch after the app was Force Stopped, allowing you to know that you're leaving the Force Stopped state (although the documentation only mentions `Intent.ACTION_BOOT_COMPLETED`). Furthermore, `ApplicationStartInfo.wasForceStopped()` was also added in `API 35` so you can check if a Force Stop happened without having to rely on a broadcast, however I did not need to utilize this particular method. Because of this, Force Stop Recovery is automatically handled in `AlarmRefreshReceiver` by reacting to `Intent.ACTION_LOCKED_BOOT_COMPLETED` without any modification necessary since `AlarmRefreshReceiver` was already listening for that action to refresh the Alarms. For more details on the new Force Stop Recovery options and behavior introduced in `API 35`, see:
    - https://developer.android.com/about/versions/15/behavior-changes-all#enhanced-stop-states
- Add the Kotlin Parcelize plugin to the project