### PR TITLE
Feature | Bump targetSdk compileSdk to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 
 android {
     namespace = "com.octrobi.lavalarm"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.octrobi.lavalarm"
         minSdk = 31
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 2
         versionName = "1.0.1"
 


### PR DESCRIPTION
### Description
- Bump `targetSdk` and `compileSdk` from 35 to 36