### PR TITLE
Feature | Migrate AlarmListScreen to Hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.androidxRoom)
+    alias(libs.plugins.hilt)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.kotlinParcelize)
     alias(libs.plugins.kotlinxSerialization)
@@ -87,6 +88,11 @@ dependencies {
     // Navigation
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
+
+    // Hilt
+    implementation(libs.hilt)
+    implementation(libs.androidx.hilt.navigation.compose)
+    ksp(libs.hilt.compiler)
 
     // Room
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/data/repository/AlarmRepository.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/data/repository/AlarmRepository.kt
@@ -4,8 +4,13 @@ import com.octrobi.lavalarm.alarm.data.model.Alarm
 import com.octrobi.lavalarm.alarm.data.model.AlarmDao
 import kotlinx.coroutines.flow.Flow
 import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class AlarmRepository(private val alarmDao: AlarmDao) {
+@Singleton
+class AlarmRepository @Inject constructor(
+    private val alarmDao: AlarmDao
+) {
 
     /*
      *******************************

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/di/AlarmDatabaseModule.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/di/AlarmDatabaseModule.kt
@@ -1,0 +1,32 @@
+package com.octrobi.lavalarm.alarm.di
+
+import android.content.Context
+import androidx.room.Room
+import com.octrobi.lavalarm.alarm.data.model.AlarmDao
+import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AlarmDatabaseModule {
+
+    @Provides
+    fun provideAlarmDao(alarmDatabase: AlarmDatabase): AlarmDao =
+        alarmDatabase.alarmDao()
+
+    @Provides
+    @Singleton
+    fun provideAlarmDatabase(@ApplicationContext applicationContext: Context): AlarmDatabase =
+        Room.databaseBuilder(
+            applicationContext.createDeviceProtectedStorageContext(),
+            AlarmDatabase::class.java,
+            "alarm_database"
+        )
+            .fallbackToDestructiveMigration()
+            .build()
+}

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmlist/AlarmListScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmlist/AlarmListScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.octrobi.lavalarm.alarm.data.model.Alarm
 import com.octrobi.lavalarm.alarm.data.preview.alarmSampleDataHardCodedIds
 import com.octrobi.lavalarm.alarm.data.repository.AlarmListState
@@ -31,7 +31,7 @@ import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsState
 fun AlarmListScreen(
     navigateToAlarmEditScreen: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    alarmListViewModel: AlarmListViewModel = viewModel(factory = AlarmListViewModel.Factory)
+    alarmListViewModel: AlarmListViewModel = hiltViewModel()
 ) {
     // State
     val alarmListState by alarmListViewModel.alarmList.collectAsState()

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmlist/AlarmListViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmlist/AlarmListViewModel.kt
@@ -1,15 +1,10 @@
 package com.octrobi.lavalarm.alarm.ui.alarmlist
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import com.octrobi.lavalarm.alarm.alarmexecution.AlarmScheduler
 import com.octrobi.lavalarm.alarm.data.model.Alarm
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmListState
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.core.extension.toAlarmExecutionData
@@ -20,17 +15,19 @@ import com.octrobi.lavalarm.core.ui.snackbar.global.GlobalSnackbarController
 import com.octrobi.lavalarm.settings.data.model.GeneralSettings
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsState
-import com.octrobi.lavalarm.settings.data.repository.generalSettingsDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class AlarmListViewModel(
+@HiltViewModel
+class AlarmListViewModel @Inject constructor(
     private val alarmRepository: AlarmRepository,
-    private val generalSettingsRepository: GeneralSettingsRepository
+    generalSettingsRepository: GeneralSettingsRepository
 ) : ViewModel() {
 
     // Alarm List
@@ -54,20 +51,6 @@ class AlarmListViewModel(
                 SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
                 GeneralSettingsState.Loading
             )
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                val application = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application)
-
-                AlarmListViewModel(
-                    alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao()),
-                    generalSettingsRepository = GeneralSettingsRepository(application.generalSettingsDataStore)
-                )
-            }
-        }
-    }
 
     /*
      * Modify

--- a/app/src/main/java/com/octrobi/lavalarm/core/AlarmApplication.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/AlarmApplication.kt
@@ -3,9 +3,11 @@ package com.octrobi.lavalarm.core
 import android.app.Application
 import com.octrobi.lavalarm.core.ui.notificationcheck.AppNotificationChannel
 import com.octrobi.lavalarm.core.util.NotificationChannelUtil
+import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
+@HiltAndroidApp
 class AlarmApplication : Application() {
 
     val applicationScope = CoroutineScope(SupervisorJob())

--- a/app/src/main/java/com/octrobi/lavalarm/core/MainActivity.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/MainActivity.kt
@@ -17,8 +17,10 @@ import com.octrobi.lavalarm.core.navigation.TopLevelNavHost
 import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryState
 import com.octrobi.lavalarm.core.ui.theme.AndroidDefaultDarkScrim
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val viewModel by viewModels<MainActivityViewModel> {

--- a/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/GeneralSettingsRepository.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/GeneralSettingsRepository.kt
@@ -13,13 +13,18 @@ import com.octrobi.lavalarm.settings.data.model.TimeDisplay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
 
 val Context.generalSettingsDataStore by preferencesDataStore(
     name = GeneralSettingsRepository.GENERAL_SETTINGS_PREFERENCES_NAME,
     corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
 )
 
-class GeneralSettingsRepository(private val dataStore: DataStore<Preferences>) {
+@Singleton
+class GeneralSettingsRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
 
     companion object {
         // Preferences name

--- a/app/src/main/java/com/octrobi/lavalarm/settings/di/GeneralSettingsDataStoreModule.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/settings/di/GeneralSettingsDataStoreModule.kt
@@ -1,0 +1,30 @@
+package com.octrobi.lavalarm.settings.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object GeneralSettingsDataStoreModule {
+
+    @Provides
+    @Singleton
+    fun provideGeneralSettingsDataStore(@ApplicationContext applicationContext: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
+        ) {
+            applicationContext.preferencesDataStoreFile(GeneralSettingsRepository.GENERAL_SETTINGS_PREFERENCES_NAME)
+        }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidxRoom) apply false
+    alias(libs.plugins.hilt) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.kotlinParcelize) apply false
     alias(libs.plugins.kotlinxSerialization) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ navigationCompose = "2.8.9"
 splashscreen = "1.0.1"
 kotlinReflect = "2.0.20"
 serialization = "1.6.3"
+hilt = "2.57.2"
+androidxHilt = "1.3.0"
 # Unit Tests
 junit = "4.13.2"
 kotlinxCoroutinesTest = "1.10.1"
@@ -38,6 +40,7 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIcons" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHilt" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
@@ -48,6 +51,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlinReflect" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 # Unit Tests
@@ -62,6 +67,7 @@ mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "moc
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidxRoom = { id = "androidx.room", version.ref = "room" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }


### PR DESCRIPTION
### Description
- Add `Hilt` to project
- Migrate `AlarmListScreen` to `Hilt`. Involves modifying the following files to use `Hilt`:
  - `AlarmListScreen`, `AlarmListViewModel`, `AlarmRepository`, `GeneralSettingsRepository`, `AlarmApplication`, `MainActivity`

Note: Since `AlarmRepository` and `GeneralSettingsRespository` are now injected into `AlarmListViewModel` via `Hilt`, but not injected via `Hilt` anywhere else, `AlarmListScreen` is out of sync with other parts of the application that display data from `AlarmRepository` and `GeneralSettingsRespository`. This is because other areas of the code are still accessing the singletons provided in `AlarmDatabase` and the Context extension property in `GeneralSettingsRepository`, while `AlarmListViewModel` is using the different singletons provided by `Hilt`. This will no longer be an issue after the rest of the app is migrated to `Hilt`, and no longer uses `AlarmDatabase.getDatabase()` and `Context.generalSettingsDataStore` in `GeneralSettingsRepository`.