### PR TITLE
Feature | Migrate AlarmEditScreen to Hilt

### DIFF
--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmcreate/AlarmCreationViewModel.kt
@@ -1,17 +1,12 @@
 package com.octrobi.lavalarm.alarm.ui.alarmcreate
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavHostController
 import com.octrobi.lavalarm.alarm.alarmexecution.AlarmScheduler
 import com.octrobi.lavalarm.alarm.data.model.Alarm
 import com.octrobi.lavalarm.alarm.data.model.WeeklyRepeater
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.alarm.data.repository.AlarmState
 import com.octrobi.lavalarm.alarm.util.AlarmUtil
@@ -31,8 +26,6 @@ import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsRepository
 import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsState
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsState
-import com.octrobi.lavalarm.settings.data.repository.alarmDefaultsDataStore
-import com.octrobi.lavalarm.settings.data.repository.generalSettingsDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
@@ -52,8 +45,8 @@ import javax.inject.Inject
 @HiltViewModel
 class AlarmCreationViewModel @Inject constructor(
     private val alarmRepository: AlarmRepository,
-    private val alarmDefaultsRepository: AlarmDefaultsRepository,
-    private val generalSettingsRepository: GeneralSettingsRepository,
+    alarmDefaultsRepository: AlarmDefaultsRepository,
+    generalSettingsRepository: GeneralSettingsRepository,
     private val alarmValidator: AlarmValidator
 ) : ViewModel() {
 
@@ -116,22 +109,6 @@ class AlarmCreationViewModel @Inject constructor(
                         _newAlarm.value = alarmState
                     }
                 }
-        }
-    }
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                val application = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application)
-
-                AlarmCreationViewModel(
-                    alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao()),
-                    alarmDefaultsRepository = AlarmDefaultsRepository(application, application.alarmDefaultsDataStore),
-                    generalSettingsRepository = GeneralSettingsRepository(application.generalSettingsDataStore),
-                    alarmValidator = AlarmValidator()
-                )
-            }
         }
     }
 

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmedit/AlarmEditScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmedit/AlarmEditScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.octrobi.lavalarm.R
@@ -46,7 +46,7 @@ fun AlarmEditScreen(
     navHostController: NavHostController,
     navigateToRingtonePickerScreen: (String) -> Unit,
     modifier: Modifier = Modifier,
-    alarmEditViewModel: AlarmEditViewModel = viewModel(factory = AlarmEditViewModel.Factory)
+    alarmEditViewModel: AlarmEditViewModel = hiltViewModel()
 ) {
     // State
     val alarmState by alarmEditViewModel.modifiedAlarm.collectAsState()

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmedit/AlarmEditViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/alarmedit/AlarmEditViewModel.kt
@@ -1,20 +1,14 @@
 package com.octrobi.lavalarm.alarm.ui.alarmedit
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
 import com.octrobi.lavalarm.alarm.alarmexecution.AlarmScheduler
 import com.octrobi.lavalarm.alarm.data.model.Alarm
 import com.octrobi.lavalarm.alarm.data.model.WeeklyRepeater
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.alarm.data.repository.AlarmState
 import com.octrobi.lavalarm.alarm.util.AlarmUtil
@@ -31,7 +25,7 @@ import com.octrobi.lavalarm.core.ui.snackbar.SnackbarEvent
 import com.octrobi.lavalarm.settings.data.model.GeneralSettings
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsState
-import com.octrobi.lavalarm.settings.data.repository.generalSettingsDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,11 +38,13 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import javax.inject.Inject
 
-class AlarmEditViewModel(
+@HiltViewModel
+class AlarmEditViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val alarmRepository: AlarmRepository,
-    private val generalSettingsRepository: GeneralSettingsRepository,
+    generalSettingsRepository: GeneralSettingsRepository,
     private val alarmValidator: AlarmValidator
 ) : ViewModel() {
 
@@ -97,22 +93,6 @@ class AlarmEditViewModel(
                     referenceAlarm.value = alarmState
                     _modifiedAlarm.value = alarmState
                 }
-        }
-    }
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                val application = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application)
-
-                AlarmEditViewModel(
-                    savedStateHandle = createSavedStateHandle(),
-                    alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(application).alarmDao()),
-                    generalSettingsRepository = GeneralSettingsRepository(application.generalSettingsDataStore),
-                    alarmValidator = AlarmValidator()
-                )
-            }
         }
     }
 

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/ringtonepicker/RingtonePickerViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/ringtonepicker/RingtonePickerViewModel.kt
@@ -1,16 +1,11 @@
 package com.octrobi.lavalarm.core.ui.ringtonepicker
 
-import android.app.Application
 import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.createSavedStateHandle
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
 import com.octrobi.lavalarm.core.data.model.RingtoneData
@@ -57,20 +52,6 @@ class RingtonePickerViewModel @Inject constructor(
         // This is because onStop() won't be called when the ViewModel is destroyed via back-navigation; however, ViewModel.onCleared()
         // will be called in this situation. Therefore, both onStop() and onCleared() are required for proper Ringtone playback management.
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
-    }
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                val application = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application)
-
-                RingtonePickerViewModel(
-                    savedStateHandle = createSavedStateHandle(),
-                    ringtoneRepository = RingtoneRepository(application)
-                )
-            }
-        }
     }
 
     /*

--- a/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/AlarmDefaultsRepository.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/AlarmDefaultsRepository.kt
@@ -3,14 +3,12 @@ package com.octrobi.lavalarm.settings.data.repository
 import android.content.Context
 import android.media.RingtoneManager
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.octrobi.lavalarm.core.data.model.RingtoneData
 import com.octrobi.lavalarm.core.data.repository.RingtoneRepository
 import com.octrobi.lavalarm.core.extension.alarmApplication
@@ -24,11 +22,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
-
-val Context.alarmDefaultsDataStore by preferencesDataStore(
-    name = AlarmDefaultsRepository.ALARM_DEFAULTS_PREFERENCES_NAME,
-    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
-)
 
 @Singleton
 class AlarmDefaultsRepository @Inject constructor(


### PR DESCRIPTION
### Description
- Migrate `AlarmEditScreen` to `Hilt`
- Remove unused code obsoleted by `Hilt` migration
  - `AlarmCreationViewModel` factory
  - `RingtonePickerViewModel` factory
  - `Context.alarmDefaultsDataStore` extension property in `AlarmDefaultsRepository`