### PR TITLE
Feature | Migrate Gate Screens to Hilt

### DIFF
--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/NotificationChannelGateScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/NotificationChannelGateScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.octrobi.lavalarm.R
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
 import kotlinx.coroutines.Dispatchers
@@ -41,7 +41,7 @@ fun NotificationChannelGateScreen(
     notificationPermission: NotificationPermission,
     gatedScreen: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    notificationChannelGateViewModel: NotificationChannelGateViewModel = viewModel(factory = NotificationChannelGateViewModel.Factory)
+    notificationChannelGateViewModel: NotificationChannelGateViewModel = hiltViewModel()
 ) {
     // State
     val disabledChannelList = notificationChannelGateViewModel.disabledChannelList

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/NotificationChannelGateViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/NotificationChannelGateViewModel.kt
@@ -1,39 +1,27 @@
 package com.octrobi.lavalarm.core.ui.notificationcheck
 
 import android.app.Activity
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
+import com.octrobi.lavalarm.core.util.NotificationChannelUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class NotificationChannelGateViewModel : ViewModel() {
+@HiltViewModel
+class NotificationChannelGateViewModel @Inject constructor() : ViewModel() {
 
     // Notification
     val disabledChannelList = mutableStateListOf<AppNotificationChannel>()
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                NotificationChannelGateViewModel()
-            }
-        }
-    }
 
     /*
      * Check
      */
 
     fun checkNotificationChannelStatus(context: Context, appNotificationChannel: AppNotificationChannel) {
-        val notificationManager = context.getSystemService(NotificationManager::class.java)
-        val channel = notificationManager.getNotificationChannel(appNotificationChannel.id)
-        val isChannelEnabled =
-            notificationManager.areNotificationsEnabled() && channel.importance != NotificationManager.IMPORTANCE_NONE
+        val isChannelEnabled = NotificationChannelUtil.isNotificationChannelEnabled(context, appNotificationChannel)
 
         if (!isChannelEnabled) {
             disabledChannelList.add(appNotificationChannel)

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/SimpleNotificationGate.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/SimpleNotificationGate.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 fun SimpleNotificationGate(
     appNotificationChannel: AppNotificationChannel,
     gatedComposable: @Composable () -> Unit,
-    simpleNotificationGateViewModel: SimpleNotificationGateViewModel = viewModel(factory = SimpleNotificationGateViewModel.Factory)
+    simpleNotificationGateViewModel: SimpleNotificationGateViewModel = hiltViewModel()
 ) {
     // State
     val isNotificationChannelEnabled by simpleNotificationGateViewModel.isNotificationChannelEnabled.collectAsState()

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/SimpleNotificationGateViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/notificationcheck/SimpleNotificationGateViewModel.kt
@@ -1,39 +1,26 @@
 package com.octrobi.lavalarm.core.ui.notificationcheck
 
-import android.app.NotificationManager
 import android.content.Context
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
+import com.octrobi.lavalarm.core.util.NotificationChannelUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
-class SimpleNotificationGateViewModel : ViewModel() {
+@HiltViewModel
+class SimpleNotificationGateViewModel @Inject constructor() : ViewModel() {
 
     // Notification Channel
     private val _isNotificationChannelEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isNotificationChannelEnabled: StateFlow<Boolean> = _isNotificationChannelEnabled.asStateFlow()
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                SimpleNotificationGateViewModel()
-            }
-        }
-    }
 
     /*
      * Check
      */
 
     fun checkNotificationChannelStatus(context: Context, appNotificationChannel: AppNotificationChannel) {
-        val notificationManager = context.getSystemService(NotificationManager::class.java)
-        val channel = notificationManager.getNotificationChannel(appNotificationChannel.id)
-
-        _isNotificationChannelEnabled.value =
-            notificationManager.areNotificationsEnabled() && channel.importance != NotificationManager.IMPORTANCE_NONE
+        _isNotificationChannelEnabled.value = NotificationChannelUtil.isNotificationChannelEnabled(context, appNotificationChannel)
     }
 }

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/PermissionGateScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/PermissionGateScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.octrobi.lavalarm.R
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
 import com.octrobi.lavalarm.core.util.PermissionUtil
@@ -45,7 +45,7 @@ fun PermissionGateScreen(
     permission: Permission,
     gatedScreen: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    permissionGateViewModel: PermissionGateViewModel = viewModel(factory = PermissionGateViewModel.Factory)
+    permissionGateViewModel: PermissionGateViewModel = hiltViewModel()
 ) {
     // State
     val attemptedToAskForPermission by permissionGateViewModel.attemptedToAskForPermission.collectAsState()

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/PermissionGateViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/PermissionGateViewModel.kt
@@ -3,29 +3,20 @@ package com.octrobi.lavalarm.core.ui.permission
 import android.content.Context
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import com.octrobi.lavalarm.core.util.PermissionUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
-class PermissionGateViewModel : ViewModel() {
+@HiltViewModel
+class PermissionGateViewModel @Inject constructor() : ViewModel() {
 
     // Permissions
     private val _attemptedToAskForPermission: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val attemptedToAskForPermission: StateFlow<Boolean> = _attemptedToAskForPermission.asStateFlow()
     val deniedPermissionList = mutableStateListOf<Permission>()
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                PermissionGateViewModel()
-            }
-        }
-    }
 
     /*
      * Callback

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/SimplePermissionGate.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/SimplePermissionGate.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 fun SimplePermissionGate(
     permission: Permission,
     gatedComposable: @Composable () -> Unit,
-    simplePermissionGateViewModel: SimplePermissionGateViewModel = viewModel(factory = SimplePermissionGateViewModel.Factory)
+    simplePermissionGateViewModel: SimplePermissionGateViewModel = hiltViewModel()
 ) {
     // State
     val isPermissionGranted by simplePermissionGateViewModel.isPermissionGranted.collectAsState()

--- a/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/SimplePermissionGateViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/ui/permission/SimplePermissionGateViewModel.kt
@@ -2,28 +2,19 @@ package com.octrobi.lavalarm.core.ui.permission
 
 import android.content.Context
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import com.octrobi.lavalarm.core.util.PermissionUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
-class SimplePermissionGateViewModel : ViewModel() {
+@HiltViewModel
+class SimplePermissionGateViewModel @Inject constructor() : ViewModel() {
 
     // Permissions
     private val _isPermissionGranted: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isPermissionGranted: StateFlow<Boolean> = _isPermissionGranted.asStateFlow()
-
-    companion object {
-
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                SimplePermissionGateViewModel()
-            }
-        }
-    }
 
     /*
      * Check


### PR DESCRIPTION
### Description
- Migrate all gate screens, and simple gates to `Hilt`
  - `NotificationChannelGateScreen`, `SimpleNotificationGate`, `PermissionGateScreen`, `SimplePermissionGate`
- Make use of `NotificationChannelUtil` in `NotificationChannelGateViewModel` and `SimpleNotificationGateViewModel`