### PR TITLE
Feature | Migrate Full Screen Alarm Flow to Hilt

### DIFF
--- a/app/src/main/java/com/octrobi/lavalarm/alarm/data/model/AlarmExecutionData.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/data/model/AlarmExecutionData.kt
@@ -1,10 +1,13 @@
 package com.octrobi.lavalarm.alarm.data.model
 
+import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 
+@Serializable
 data class AlarmExecutionData(
     val id: Int,
     val name: String,
+    @Serializable(with = LocalDateTimeSerializer::class)
     val executionDateTime: LocalDateTime,
     val encodedRepeatingDays: Int,
     val ringtoneUri: String,

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/data/model/LocalDateTimeSerializer.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/data/model/LocalDateTimeSerializer.kt
@@ -1,0 +1,22 @@
+package com.octrobi.lavalarm.alarm.data.model
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDateTime
+
+object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("java.time.LocalDateTime", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: LocalDateTime) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDateTime =
+        LocalDateTime.parse(decoder.decodeString())
+}

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmActivity.kt
@@ -11,7 +11,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -28,8 +27,10 @@ import com.octrobi.lavalarm.core.navigation.Destination
 import com.octrobi.lavalarm.core.ui.theme.AndroidDefaultDarkScrim
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
 import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsRepository
+import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 
+@AndroidEntryPoint
 class FullScreenAlarmActivity : ComponentActivity() {
 
     // Navigation State
@@ -117,17 +118,13 @@ class FullScreenAlarmActivity : ComponentActivity() {
             )
         )
 
-        // Create/Get ViewModel
-        val fullScreenAlarmViewModel by viewModels<FullScreenAlarmViewModel> {
-            FullScreenAlarmViewModel.provideFactory(alarmExecutionData, is24Hour)
-        }
-
         setContent {
             LavalarmTheme {
                 navHostController = rememberNavController()
                 FullScreenAlarmNavHost(
                     navHostController = navHostController,
-                    fullScreenAlarmViewModel = fullScreenAlarmViewModel
+                    alarmExecutionData = alarmExecutionData,
+                    is24Hour = is24Hour
                 )
             }
         }

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
@@ -8,16 +8,22 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
+import com.octrobi.lavalarm.core.navigation.AlarmExecutionDataNavType
 import com.octrobi.lavalarm.core.navigation.Destination
 
 @Composable
 fun FullScreenAlarmNavHost(
     navHostController: NavHostController,
-    fullScreenAlarmViewModel: FullScreenAlarmViewModel
+    alarmExecutionData: AlarmExecutionData,
+    is24Hour: Boolean
 ) {
     NavHost(
         navController = navHostController,
-        startDestination = Destination.FullScreenAlarmScreen,
+        startDestination = Destination.FullScreenAlarmScreen(
+            alarmExecutionData = alarmExecutionData,
+            is24Hour = is24Hour
+        ),
         enterTransition = {
             fadeIn(animationSpec = tween(durationMillis = 300))
         },
@@ -26,8 +32,10 @@ fun FullScreenAlarmNavHost(
         }
     ) {
         // Full Screen Alarm Screen
-        composable<Destination.FullScreenAlarmScreen> {
-            FullScreenAlarmScreen(fullScreenAlarmViewModel = fullScreenAlarmViewModel)
+        composable<Destination.FullScreenAlarmScreen>(
+            typeMap = AlarmExecutionDataNavType.typeMap
+        ) {
+            FullScreenAlarmScreen()
         }
 
         // Post Alarm Confirmation Screen

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmNavHost.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
 import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
 import com.octrobi.lavalarm.core.navigation.AlarmExecutionDataNavType
 import com.octrobi.lavalarm.core.navigation.Destination
@@ -40,14 +39,7 @@ fun FullScreenAlarmNavHost(
 
         // Post Alarm Confirmation Screen
         composable<Destination.PostAlarmConfirmationScreen> {
-            val route = it.toRoute<Destination.PostAlarmConfirmationScreen>()
-            val fullScreenAlarmButton = route.fullScreenAlarmButton
-            val snoozeDuration = route.snoozeDuration
-
-            PostAlarmConfirmationScreen(
-                fullScreenAlarmButton = fullScreenAlarmButton,
-                snoozeDuration = snoozeDuration
-            )
+            PostAlarmConfirmationScreen()
         }
     }
 }

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.octrobi.lavalarm.R
 import com.octrobi.lavalarm.alarm.data.preview.consistentFutureAlarm
 import com.octrobi.lavalarm.alarm.ui.fullscreenalert.component.BeachBackdrop
@@ -71,7 +72,9 @@ import com.octrobi.lavalarm.core.util.StatusBarUtil
 import java.time.LocalDateTime
 
 @Composable
-fun FullScreenAlarmScreen(fullScreenAlarmViewModel: FullScreenAlarmViewModel) {
+fun FullScreenAlarmScreen(
+    fullScreenAlarmViewModel: FullScreenAlarmViewModel = hiltViewModel()
+) {
     // Configure Status Bar
     StatusBarUtil.setLightStatusBar()
 

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/FullScreenAlarmViewModel.kt
@@ -1,30 +1,30 @@
 package com.octrobi.lavalarm.alarm.ui.fullscreenalert
 
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.toRoute
 import com.octrobi.lavalarm.alarm.alarmexecution.AlarmIntentBuilder
-import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
+import com.octrobi.lavalarm.core.navigation.AlarmExecutionDataNavType
+import com.octrobi.lavalarm.core.navigation.Destination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class FullScreenAlarmViewModel(
-    val alarmExecutionData: AlarmExecutionData,
-    val is24Hour: Boolean
+@HiltViewModel
+class FullScreenAlarmViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    companion object {
+    // Alarm and Display data
+    private val navigationRoute = savedStateHandle.toRoute<Destination.FullScreenAlarmScreen>(
+        typeMap = AlarmExecutionDataNavType.typeMap
+    )
+    val alarmExecutionData = navigationRoute.alarmExecutionData
+    val is24Hour = navigationRoute.is24Hour
 
-        fun provideFactory(
-            alarmExecutionData: AlarmExecutionData,
-            is24Hour: Boolean
-        ): ViewModelProvider.Factory =
-            viewModelFactory {
-                initializer {
-                    FullScreenAlarmViewModel(alarmExecutionData, is24Hour)
-                }
-            }
-    }
+    /*
+     * Action
+     */
 
     fun snoozeAlarm(context: Context) {
         context.sendBroadcast(

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/PostAlarmConfirmationScreen.kt
@@ -1,5 +1,6 @@
 package com.octrobi.lavalarm.alarm.ui.fullscreenalert
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,10 +27,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.octrobi.lavalarm.R
 import com.octrobi.lavalarm.core.ui.theme.DarkVolcanicRock
 import com.octrobi.lavalarm.core.ui.theme.LavalarmTheme
@@ -38,18 +39,31 @@ import kotlinx.coroutines.delay
 
 @Composable
 fun PostAlarmConfirmationScreen(
-    fullScreenAlarmButton: FullScreenAlarmButton,
-    snoozeDuration: Int,
     modifier: Modifier = Modifier,
-    postAlarmConfirmationViewModel: PostAlarmConfirmationViewModel = viewModel(factory = PostAlarmConfirmationViewModel.Factory)
+    postAlarmConfirmationViewModel: PostAlarmConfirmationViewModel = hiltViewModel()
 ) {
     // Configure Status Bar
     StatusBarUtil.setDarkStatusBar()
 
+    PostAlarmConfirmationScreenContent(
+        fullScreenAlarmButton = postAlarmConfirmationViewModel.fullScreenAlarmButton,
+        snoozeDuration = postAlarmConfirmationViewModel.snoozeDuration,
+        finishFullScreenAlarmFlow = postAlarmConfirmationViewModel::finishFullScreenAlarmFlow,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun PostAlarmConfirmationScreenContent(
+    fullScreenAlarmButton: FullScreenAlarmButton,
+    snoozeDuration: Int,
+    finishFullScreenAlarmFlow: (Context) -> Unit,
+    modifier: Modifier = Modifier
+) {
     // Countdown timer to finish the Alarm execution flow
     val context = LocalContext.current
     BasicCountdown(timeSeconds = 2) {
-        postAlarmConfirmationViewModel.finishFullScreenAlarmFlow(context)
+        finishFullScreenAlarmFlow(context)
     }
 
     Surface(
@@ -126,9 +140,10 @@ fun BasicCountdown(
 @Composable
 private fun PostAlarmConfirmationScreenSnoozePreview() {
     LavalarmTheme {
-        PostAlarmConfirmationScreen(
+        PostAlarmConfirmationScreenContent(
             fullScreenAlarmButton = FullScreenAlarmButton.SNOOZE,
-            snoozeDuration = 10
+            snoozeDuration = 10,
+            finishFullScreenAlarmFlow = {}
         )
     }
 }
@@ -137,9 +152,10 @@ private fun PostAlarmConfirmationScreenSnoozePreview() {
 @Composable
 private fun PostAlarmConfirmationScreenDismissPreview() {
     LavalarmTheme {
-        PostAlarmConfirmationScreen(
+        PostAlarmConfirmationScreenContent(
             fullScreenAlarmButton = FullScreenAlarmButton.DISMISS,
-            snoozeDuration = 10
+            snoozeDuration = 10,
+            finishFullScreenAlarmFlow = {}
         )
     }
 }

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/ui/fullscreenalert/PostAlarmConfirmationViewModel.kt
@@ -2,21 +2,26 @@ package com.octrobi.lavalarm.alarm.ui.fullscreenalert
 
 import android.content.Context
 import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.toRoute
+import com.octrobi.lavalarm.core.navigation.Destination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class PostAlarmConfirmationViewModel : ViewModel() {
+@HiltViewModel
+class PostAlarmConfirmationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
 
-    companion object {
+    // Alarm and Display data
+    private val navigationRoute = savedStateHandle.toRoute<Destination.PostAlarmConfirmationScreen>()
+    val fullScreenAlarmButton = navigationRoute.fullScreenAlarmButton
+    val snoozeDuration = navigationRoute.snoozeDuration
 
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                PostAlarmConfirmationViewModel()
-            }
-        }
-    }
+    /*
+     * Action
+     */
 
     fun finishFullScreenAlarmFlow(context: Context) {
         context.sendBroadcast(

--- a/app/src/main/java/com/octrobi/lavalarm/core/navigation/AlarmExecutionDataNavType.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/navigation/AlarmExecutionDataNavType.kt
@@ -1,0 +1,30 @@
+package com.octrobi.lavalarm.core.navigation
+
+import android.net.Uri
+import androidx.navigation.NavType
+import androidx.savedstate.SavedState
+import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.reflect.typeOf
+
+object AlarmExecutionDataNavType : NavType<AlarmExecutionData>(isNullableAllowed = false) {
+
+    val typeMap = mapOf(typeOf<AlarmExecutionData>() to AlarmExecutionDataNavType)
+
+    override fun put(bundle: SavedState, key: String, value: AlarmExecutionData) {
+        bundle.putString(key, Json.encodeToString(value))
+    }
+
+    override fun get(bundle: SavedState, key: String): AlarmExecutionData? {
+        return Json.decodeFromString(bundle.getString(key) ?: return null)
+    }
+
+    override fun serializeAsValue(value: AlarmExecutionData): String {
+        return Uri.encode(Json.encodeToString(value))
+    }
+
+    override fun parseValue(value: String): AlarmExecutionData {
+        return Json.decodeFromString(Uri.decode(value))
+    }
+}

--- a/app/src/main/java/com/octrobi/lavalarm/core/navigation/Destination.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/navigation/Destination.kt
@@ -1,5 +1,6 @@
 package com.octrobi.lavalarm.core.navigation
 
+import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
 import com.octrobi.lavalarm.alarm.ui.fullscreenalert.FullScreenAlarmButton
 import kotlinx.serialization.Serializable
 
@@ -42,7 +43,10 @@ sealed interface Destination {
      */
 
     @Serializable
-    data object FullScreenAlarmScreen : Destination
+    data class FullScreenAlarmScreen(
+        val alarmExecutionData: AlarmExecutionData,
+        val is24Hour: Boolean
+    ) : Destination
 
     @Serializable
     data class PostAlarmConfirmationScreen(


### PR DESCRIPTION
### Description
- Migrate `FullScreenAlarmScreen` and `PostAlarmConfirmationScreen` to `Hilt`
  - `FullScreenAlarmViewModel` is no longer managed by `FullScreenAlarmActivity`, and is therefore no longer passed into `FullScreenAlarmNavHost` when setting the content in `FullScreenAlarmActivity`. Furthermore, `alarmExecutionData` and `is24Hour` are no longer passed as parameters when constructing `FullScreenAlarmViewModel`. Now, those values are passed into `FullScreenAlarmNavHost` and then into the `Destination.FullScreenAlarmScreen` `startDestination`. Because of this it was necessary to make `AlarmExecutionData` and `LocalDateTime` `Serializable`, which involved creating a custom `LocalDateTimeSerializer` for `LocalDateTime`.