### PR TITLE
Feature | Hilt Repository Cleanup

### DIFF
--- a/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmActionReceiver.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmActionReceiver.kt
@@ -3,7 +3,6 @@ package com.octrobi.lavalarm.alarm.alarmexecution
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.alarm.ui.fullscreenalert.FullScreenAlarmButton
 import com.octrobi.lavalarm.core.constant.actionPackageName
@@ -13,10 +12,16 @@ import com.octrobi.lavalarm.core.extension.alarmApplication
 import com.octrobi.lavalarm.core.extension.doAsync
 import com.octrobi.lavalarm.core.extension.getSerializableExtraSafe
 import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsRepository
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import java.time.LocalDateTime
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class AlarmActionReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var alarmRepository: AlarmRepository
 
     companion object {
         // Actions
@@ -110,9 +115,11 @@ class AlarmActionReceiver : BroadcastReceiver() {
         // Update Alarm Database and reschedule Alarm
         doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
             // Update Alarm
-            val alarmRepo = AlarmRepository(AlarmDatabase.getDatabase(context).alarmDao())
-            val alarm = alarmRepo.getAlarm(id)
-            AlarmScheduler.snoozeAndRescheduleAlarm(context.applicationContext, alarmRepo, alarm)
+            AlarmScheduler.snoozeAndRescheduleAlarm(
+                context.applicationContext,
+                alarmRepository,
+                alarmRepository.getAlarm(id)
+            )
         }
     }
 
@@ -135,9 +142,11 @@ class AlarmActionReceiver : BroadcastReceiver() {
                 // passed in the Intent just represents when the Alarm was supposed to execute,
                 // which may be a snoozed time that was modified from the original.
                 // Here we need the original, unmodified LocalDateTime for rescheduling.
-                val alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(context).alarmDao())
-                val alarm = alarmRepository.getAlarm(id)
-                AlarmScheduler.disableOrRescheduleAlarm(context.applicationContext, alarmRepository, alarm)
+                AlarmScheduler.disableOrRescheduleAlarm(
+                    context.applicationContext,
+                    alarmRepository,
+                    alarmRepository.getAlarm(id)
+                )
             }
         }
     }

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmNotificationService.kt
@@ -8,7 +8,6 @@ import android.os.IBinder
 import com.octrobi.lavalarm.R
 import com.octrobi.lavalarm.alarm.data.model.Alarm
 import com.octrobi.lavalarm.alarm.data.model.AlarmExecutionData
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.alarm.ui.fullscreenalert.FullScreenAlarmActivity
 import com.octrobi.lavalarm.alarm.ui.fullscreenalert.FullScreenAlarmButton
@@ -25,18 +24,25 @@ import com.octrobi.lavalarm.settings.data.model.GeneralSettings
 import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsRepository
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
 import com.octrobi.lavalarm.settings.data.repository.generalSettingsDataStore
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class AlarmNotificationService : Service() {
 
     // Coroutine
     private val job = SupervisorJob()
     private val coroutineScope = CoroutineScope(job)
+
+    // Repository
+    @Inject
+    lateinit var alarmRepository: AlarmRepository
 
     companion object {
         // Actions
@@ -123,9 +129,11 @@ class AlarmNotificationService : Service() {
         if (gateLogic()) {
             launchNotification(alarmExecutionData)
         } else {
-            val alarmRepository = AlarmRepository(AlarmDatabase.getDatabase(this).alarmDao())
-            val alarm = alarmRepository.getAlarm(alarmExecutionData.id)
-            AlarmScheduler.disableOrRescheduleAlarm(applicationContext, alarmRepository, alarm)
+            AlarmScheduler.disableOrRescheduleAlarm(
+                applicationContext,
+                alarmRepository,
+                alarmRepository.getAlarm(alarmExecutionData.id)
+            )
         }
     }
 
@@ -163,8 +171,7 @@ class AlarmNotificationService : Service() {
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         val allNotifications = notificationManager.activeNotifications
         // Get all Alarms
-        val alarmRepo = AlarmRepository(AlarmDatabase.getDatabase(this).alarmDao())
-        val allAlarms = alarmRepo.getAllAlarms()
+        val allAlarms = alarmRepository.getAllAlarms()
 
         // Get Alarm that currently has a Notification
         val notificationAlarm: Alarm? = allAlarms.firstOrNull { alarm ->
@@ -176,7 +183,7 @@ class AlarmNotificationService : Service() {
             // Dismiss Full Screen Notification
             finishFullScreenAlarmFlow()
             // Disable/reschedule Alarm
-            AlarmScheduler.disableOrRescheduleAlarm(applicationContext, alarmRepo, notificationAlarm)
+            AlarmScheduler.disableOrRescheduleAlarm(applicationContext, alarmRepository, notificationAlarm)
         }
     }
 

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmNotificationService.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmNotificationService.kt
@@ -23,7 +23,6 @@ import com.octrobi.lavalarm.core.util.PermissionUtil
 import com.octrobi.lavalarm.settings.data.model.GeneralSettings
 import com.octrobi.lavalarm.settings.data.repository.AlarmDefaultsRepository
 import com.octrobi.lavalarm.settings.data.repository.GeneralSettingsRepository
-import com.octrobi.lavalarm.settings.data.repository.generalSettingsDataStore
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +42,8 @@ class AlarmNotificationService : Service() {
     // Repository
     @Inject
     lateinit var alarmRepository: AlarmRepository
+    @Inject
+    lateinit var generalSettingsRepository: GeneralSettingsRepository
 
     companion object {
         // Actions
@@ -139,7 +140,6 @@ class AlarmNotificationService : Service() {
 
     private suspend fun launchNotification(alarmExecutionData: AlarmExecutionData) {
         // Get General Settings
-        val generalSettingsRepository = GeneralSettingsRepository(applicationContext.generalSettingsDataStore)
         val generalSettings = try {
             generalSettingsRepository.generalSettingsFlow.first()
         } catch (e: NoSuchElementException) {

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmRefreshReceiver.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/alarmexecution/AlarmRefreshReceiver.kt
@@ -5,19 +5,24 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.core.constant.actionPackageName
 import com.octrobi.lavalarm.core.extension.alarmApplication
 import com.octrobi.lavalarm.core.extension.doAsync
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
 
 /**
  * Clean and reschedule Alarms in various scenarios in reaction to system Intent actions.
  *
  * Scenarios include, but are not limited to: device boot, device date/time change, etc.
  */
+@AndroidEntryPoint
 class AlarmRefreshReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var alarmRepository: AlarmRepository
 
     companion object {
         // Actions
@@ -64,12 +69,6 @@ class AlarmRefreshReceiver : BroadcastReceiver() {
             }
 
         if (canRescheduleAlarms) {
-            val alarmRepository = AlarmRepository(
-                AlarmDatabase
-                    .getDatabase(context.createDeviceProtectedStorageContext())
-                    .alarmDao()
-            )
-
             doAsync(context.alarmApplication.applicationScope, Dispatchers.IO) {
                 AlarmScheduler.cleanAndRescheduleAlarms(context, alarmRepository)
             }

--- a/app/src/main/java/com/octrobi/lavalarm/alarm/data/repository/AlarmDatabase.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/alarm/data/repository/AlarmDatabase.kt
@@ -1,8 +1,6 @@
 package com.octrobi.lavalarm.alarm.data.repository
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.octrobi.lavalarm.alarm.data.model.Alarm
@@ -15,22 +13,4 @@ import com.octrobi.lavalarm.alarm.data.model.WeeklyRepeaterConverter
 abstract class AlarmDatabase : RoomDatabase() {
 
     abstract fun alarmDao(): AlarmDao
-
-    companion object {
-
-        @Volatile
-        private var Instance: AlarmDatabase? = null
-
-        fun getDatabase(context: Context): AlarmDatabase =
-            Instance ?: synchronized(this) {
-                Room.databaseBuilder(
-                    context.createDeviceProtectedStorageContext(),
-                    AlarmDatabase::class.java,
-                    "alarm_database"
-                )
-                    .fallbackToDestructiveMigration()
-                    .build()
-                    .also { databaseInstance -> Instance = databaseInstance }
-            }
-    }
 }

--- a/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/core/MainActivityViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.octrobi.lavalarm.alarm.data.repository.AlarmDatabase
 import com.octrobi.lavalarm.alarm.data.repository.AlarmRepository
 import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryHandler
 import com.octrobi.lavalarm.core.recovery.ForceStopRecoveryState
@@ -15,7 +14,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val alarmRepository: AlarmRepository
 ) : ViewModel() {
 
     val shouldPerformForceStopRecovery: StateFlow<ForceStopRecoveryState> =
@@ -32,12 +32,6 @@ class MainActivityViewModel @Inject constructor(
     fun checkForceStopPreApi35(context: Context) {
         if (shouldPerformForceStopRecovery.value is ForceStopRecoveryState.Unchecked) {
             viewModelScope.launch {
-                val alarmRepository = AlarmRepository(
-                    AlarmDatabase
-                        .getDatabase(context.createDeviceProtectedStorageContext())
-                        .alarmDao()
-                )
-
                 val shouldPerformRecovery =
                     ForceStopRecoveryHandler.shouldPerformForceStopRecoveryPreApi35(context, alarmRepository)
 

--- a/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/GeneralSettingsRepository.kt
+++ b/app/src/main/java/com/octrobi/lavalarm/settings/data/repository/GeneralSettingsRepository.kt
@@ -1,13 +1,10 @@
 package com.octrobi.lavalarm.settings.data.repository
 
-import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.octrobi.lavalarm.settings.data.model.GeneralSettings
 import com.octrobi.lavalarm.settings.data.model.TimeDisplay
 import com.octrobi.lavalarm.settings.di.GeneralSettingsDataStore
@@ -16,11 +13,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
-
-val Context.generalSettingsDataStore by preferencesDataStore(
-    name = GeneralSettingsRepository.GENERAL_SETTINGS_PREFERENCES_NAME,
-    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
-)
 
 @Singleton
 class GeneralSettingsRepository @Inject constructor(


### PR DESCRIPTION
### Description
- Perform field injection for `AlarmRepository` and `GeneralSettingsRepository` in Android classes
  - `AlarmActionReceiver`
  - `AlarmNotificationService`
  - `AlarmRefreshReceiver`
- In accordance with the above mentioned field injection, remove newly unused instance creation functions in `AlarmDatabase` and `GeneralSettingsRepository`
- Inject `AlarmRepository` into the `MainActivityViewModel` constructor